### PR TITLE
Fix PLAYWRIGHT_MICROSERVICE_URL endpoint

### DIFF
--- a/contributing/self-host.mdx
+++ b/contributing/self-host.mdx
@@ -59,7 +59,7 @@ REDIS_URL=redis://redis:6379
 
 #for self-hosting using docker, use redis://redis:6379. For running locally, use redis://localhost:6379
 REDIS_RATE_LIMIT_URL=redis://redis:6379 
-PLAYWRIGHT_MICROSERVICE_URL=http://playwright-service:3000/html
+PLAYWRIGHT_MICROSERVICE_URL=http://playwright-service:3000/scrape
 
 ## To turn on DB authentication, you need to set up supabase.
 USE_DB_AUTHENTICATION=false


### PR DESCRIPTION
The endpoint must've changed at some point, and the `/html` endpoint doesn't work anymore. Updating it to `/scrape`, as per the instructions here: https://github.com/mendableai/firecrawl/blob/main/SELF_HOST.md