### PR TITLE
More intuitive Bull Queue Manager UI access URL

### DIFF
--- a/contributing/self-host.mdx
+++ b/contributing/self-host.mdx
@@ -159,7 +159,7 @@ BULL_AUTH_KEY=CHANGEME
 
 This will run a local instance of Firecrawl which can be accessed at `http://localhost:3002`.
 
-You should be able to see the Bull Queue Manager UI on `http://localhost:3002/admin/@/queues`.
+You should be able to see the Bull Queue Manager UI on `http://localhost:3002/admin/{BULL_AUTH_KEY}/queues`.
 
 5. *(Optional)* Test the API
 


### PR DESCRIPTION
Updated the URL for accessing the Bull Queue Manager UI.

the  @ threw me off for a couple minute.