### PR TITLE
Add Quickstarts section with 28 language and framework guides

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -57,7 +57,6 @@
                     "pages": [
                       {
                         "group": "Node.js",
-                        "icon": "node",
                         "pages": [
                           "quickstarts/nodejs",
                           "quickstarts/nextjs",
@@ -74,7 +73,6 @@
                       },
                       {
                         "group": "Serverless",
-                        "icon": "cloud",
                         "pages": [
                           "quickstarts/cloudflare-workers",
                           "quickstarts/vercel-functions",
@@ -85,7 +83,6 @@
                       },
                       {
                         "group": "PHP",
-                        "icon": "php",
                         "pages": [
                           "quickstarts/php",
                           "quickstarts/laravel"
@@ -93,7 +90,6 @@
                       },
                       {
                         "group": "Ruby",
-                        "icon": "gem",
                         "pages": [
                           "quickstarts/ruby",
                           "quickstarts/rails"
@@ -101,7 +97,6 @@
                       },
                       {
                         "group": "Python",
-                        "icon": "python",
                         "pages": [
                           "quickstarts/python",
                           "quickstarts/fastapi",
@@ -114,7 +109,6 @@
                       "quickstarts/elixir",
                       {
                         "group": "Java",
-                        "icon": "java",
                         "pages": [
                           "quickstarts/java",
                           "quickstarts/spring-boot"
@@ -122,7 +116,6 @@
                       },
                       {
                         "group": ".NET",
-                        "icon": "microsoft",
                         "pages": [
                           "quickstarts/dotnet",
                           "quickstarts/aspnet-core"

--- a/docs.json
+++ b/docs.json
@@ -56,22 +56,10 @@
                     "group": "Quickstarts",
                     "pages": [
                       {
-                        "group": "Languages",
-                        "icon": "code",
+                        "group": "Node.js",
+                        "icon": "node",
                         "pages": [
                           "quickstarts/nodejs",
-                          "quickstarts/python",
-                          "quickstarts/go",
-                          "quickstarts/rust",
-                          "quickstarts/php",
-                          "quickstarts/java",
-                          "quickstarts/dotnet"
-                        ]
-                      },
-                      {
-                        "group": "Frameworks",
-                        "icon": "layer-group",
-                        "pages": [
                           "quickstarts/nextjs",
                           "quickstarts/express",
                           "quickstarts/nestjs",
@@ -81,18 +69,62 @@
                           "quickstarts/remix",
                           "quickstarts/nuxt",
                           "quickstarts/sveltekit",
-                          "quickstarts/astro",
+                          "quickstarts/astro"
+                        ]
+                      },
+                      {
+                        "group": "Serverless",
+                        "icon": "cloud",
+                        "pages": [
                           "quickstarts/cloudflare-workers",
                           "quickstarts/vercel-functions",
                           "quickstarts/aws-lambda",
                           "quickstarts/supabase-edge-functions",
-                          "quickstarts/deno-deploy",
+                          "quickstarts/deno-deploy"
+                        ]
+                      },
+                      {
+                        "group": "PHP",
+                        "icon": "php",
+                        "pages": [
+                          "quickstarts/php",
+                          "quickstarts/laravel"
+                        ]
+                      },
+                      {
+                        "group": "Ruby",
+                        "icon": "gem",
+                        "pages": [
+                          "quickstarts/ruby",
+                          "quickstarts/rails"
+                        ]
+                      },
+                      {
+                        "group": "Python",
+                        "icon": "python",
+                        "pages": [
+                          "quickstarts/python",
                           "quickstarts/fastapi",
                           "quickstarts/django",
-                          "quickstarts/flask",
-                          "quickstarts/laravel",
-                          "quickstarts/rails",
-                          "quickstarts/spring-boot",
+                          "quickstarts/flask"
+                        ]
+                      },
+                      "quickstarts/go",
+                      "quickstarts/rust",
+                      "quickstarts/elixir",
+                      {
+                        "group": "Java",
+                        "icon": "java",
+                        "pages": [
+                          "quickstarts/java",
+                          "quickstarts/spring-boot"
+                        ]
+                      },
+                      {
+                        "group": ".NET",
+                        "icon": "microsoft",
+                        "pages": [
+                          "quickstarts/dotnet",
                           "quickstarts/aspnet-core"
                         ]
                       }

--- a/docs.json
+++ b/docs.json
@@ -53,6 +53,52 @@
                     ]
                   },
                   {
+                    "group": "Quickstarts",
+                    "pages": [
+                      {
+                        "group": "Languages",
+                        "icon": "code",
+                        "pages": [
+                          "quickstarts/nodejs",
+                          "quickstarts/python",
+                          "quickstarts/go",
+                          "quickstarts/rust",
+                          "quickstarts/php",
+                          "quickstarts/java",
+                          "quickstarts/dotnet"
+                        ]
+                      },
+                      {
+                        "group": "Frameworks",
+                        "icon": "layer-group",
+                        "pages": [
+                          "quickstarts/nextjs",
+                          "quickstarts/express",
+                          "quickstarts/nestjs",
+                          "quickstarts/fastify",
+                          "quickstarts/hono",
+                          "quickstarts/bun",
+                          "quickstarts/remix",
+                          "quickstarts/nuxt",
+                          "quickstarts/sveltekit",
+                          "quickstarts/astro",
+                          "quickstarts/cloudflare-workers",
+                          "quickstarts/vercel-functions",
+                          "quickstarts/aws-lambda",
+                          "quickstarts/supabase-edge-functions",
+                          "quickstarts/deno-deploy",
+                          "quickstarts/fastapi",
+                          "quickstarts/django",
+                          "quickstarts/flask",
+                          "quickstarts/laravel",
+                          "quickstarts/rails",
+                          "quickstarts/spring-boot",
+                          "quickstarts/aspnet-core"
+                        ]
+                      }
+                    ]
+                  },
+                  {
                     "group": "Core Endpoints",
                     "pages": [
                       "features/search",

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,7 +1,7 @@
 ---
-title: Quickstart
+title: Introduction
 description: "Search the web, scrape any page, and interact with it — all through one API."
-og:title: "Quickstart | Firecrawl"
+og:title: "Introduction | Firecrawl"
 og:description: "Search the web, scrape any page, and interact with it — all through one API."
 ---
 

--- a/quickstarts/aspnet-core.mdx
+++ b/quickstarts/aspnet-core.mdx
@@ -1,8 +1,8 @@
 ---
 title: "ASP.NET Core"
-description: "Use Firecrawl with ASP.NET Core to scrape, search, and interact with web data using the REST API."
+description: "Use Firecrawl with ASP.NET Core to search, scrape, and interact with web data using the REST API."
 og:title: "ASP.NET Core Quickstart | Firecrawl"
-og:description: "Use Firecrawl with ASP.NET Core to scrape, search, and interact with web data using the REST API."
+og:description: "Use Firecrawl with ASP.NET Core to search, scrape, and interact with web data using the REST API."
 ---
 
 ## Prerequisites
@@ -51,6 +51,17 @@ public class FirecrawlService
             new AuthenticationHeaderValue("Bearer", config["Firecrawl:ApiKey"]);
     }
 
+    public async Task<JsonDocument> SearchAsync(string query, int limit = 5)
+    {
+        var content = new StringContent(
+            JsonSerializer.Serialize(new { query, limit }),
+            Encoding.UTF8, "application/json");
+
+        var response = await _http.PostAsync($"{_baseUrl}/search", content);
+        response.EnsureSuccessStatusCode();
+        return JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+    }
+
     public async Task<JsonDocument> ScrapeAsync(string url)
     {
         var content = new StringContent(
@@ -62,15 +73,42 @@ public class FirecrawlService
         return JsonDocument.Parse(await response.Content.ReadAsStringAsync());
     }
 
-    public async Task<JsonDocument> SearchAsync(string query, int limit = 5)
+    public async Task<JsonDocument> InteractAsync(string url, string prompt, string? followUp = null)
     {
-        var content = new StringContent(
-            JsonSerializer.Serialize(new { query, limit }),
+        // 1. Scrape to open a browser session
+        var scrapeContent = new StringContent(
+            JsonSerializer.Serialize(new { url, formats = new[] { "markdown" } }),
             Encoding.UTF8, "application/json");
 
-        var response = await _http.PostAsync($"{_baseUrl}/search", content);
-        response.EnsureSuccessStatusCode();
-        return JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var scrapeRes = await _http.PostAsync($"{_baseUrl}/scrape", scrapeContent);
+        scrapeRes.EnsureSuccessStatusCode();
+        var scrapeDoc = JsonDocument.Parse(await scrapeRes.Content.ReadAsStringAsync());
+        var scrapeId = scrapeDoc.RootElement
+            .GetProperty("data").GetProperty("metadata").GetProperty("scrapeId").GetString();
+
+        // 2. Send first prompt
+        var firstPrompt = new StringContent(
+            JsonSerializer.Serialize(new { prompt }),
+            Encoding.UTF8, "application/json");
+        await _http.PostAsync($"{_baseUrl}/scrape/{scrapeId}/interact", firstPrompt);
+
+        // 3. Send follow-up prompt
+        JsonDocument? result = null;
+        if (followUp != null)
+        {
+            var followUpContent = new StringContent(
+                JsonSerializer.Serialize(new { prompt = followUp }),
+                Encoding.UTF8, "application/json");
+            var followUpRes = await _http.PostAsync(
+                $"{_baseUrl}/scrape/{scrapeId}/interact", followUpContent);
+            followUpRes.EnsureSuccessStatusCode();
+            result = JsonDocument.Parse(await followUpRes.Content.ReadAsStringAsync());
+        }
+
+        // 4. Close the session
+        await _http.DeleteAsync($"{_baseUrl}/scrape/{scrapeId}/interact");
+
+        return result ?? scrapeDoc;
     }
 }
 ```
@@ -85,22 +123,29 @@ builder.Services.AddSingleton<FirecrawlService>();
 
 var app = builder.Build();
 
-app.MapPost("/api/scrape", async (FirecrawlService firecrawl, ScrapeRequest req) =>
-{
-    var result = await firecrawl.ScrapeAsync(req.Url);
-    return Results.Ok(result.RootElement);
-});
-
 app.MapPost("/api/search", async (FirecrawlService firecrawl, SearchRequest req) =>
 {
     var result = await firecrawl.SearchAsync(req.Query, req.Limit);
     return Results.Ok(result.RootElement);
 });
 
+app.MapPost("/api/scrape", async (FirecrawlService firecrawl, ScrapeRequest req) =>
+{
+    var result = await firecrawl.ScrapeAsync(req.Url);
+    return Results.Ok(result.RootElement);
+});
+
+app.MapPost("/api/interact", async (FirecrawlService firecrawl, InteractRequest req) =>
+{
+    var result = await firecrawl.InteractAsync(req.Url, req.Prompt, req.FollowUp);
+    return Results.Ok(result.RootElement);
+});
+
 app.Run();
 
-record ScrapeRequest(string Url);
 record SearchRequest(string Query, int Limit = 5);
+record ScrapeRequest(string Url);
+record InteractRequest(string Url, string Prompt, string? FollowUp = null);
 ```
 
 ## Run it
@@ -112,24 +157,35 @@ dotnet run
 ## Test it
 
 ```bash
+# Search the web
+curl -X POST http://localhost:5000/api/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "firecrawl web scraping"}'
+
+# Scrape a page
 curl -X POST http://localhost:5000/api/scrape \
   -H "Content-Type: application/json" \
   -d '{"url": "https://example.com"}'
+
+# Interact with a page
+curl -X POST http://localhost:5000/api/interact \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://www.amazon.com", "prompt": "Search for iPhone 16 Pro Max", "followUp": "Click on the first result and tell me the price"}'
 ```
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
-    All scrape options including formats, actions, and proxies
-  </Card>
   <Card title="Search docs" icon="magnifying-glass" href="/features/search">
     Search the web and get full page content
   </Card>
-  <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
-    Complete REST API documentation
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
   </Card>
   <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
     Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
+    Complete REST API documentation
   </Card>
 </CardGroup>

--- a/quickstarts/aspnet-core.mdx
+++ b/quickstarts/aspnet-core.mdx
@@ -1,0 +1,135 @@
+---
+title: "ASP.NET Core"
+description: "Use Firecrawl with ASP.NET Core to scrape, search, and interact with web data using the REST API."
+og:title: "ASP.NET Core Quickstart | Firecrawl"
+og:description: "Use Firecrawl with ASP.NET Core to scrape, search, and interact with web data using the REST API."
+---
+
+## Prerequisites
+
+- .NET 6.0+
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Configuration
+
+Add your API key to `appsettings.json`:
+
+```json
+{
+  "Firecrawl": {
+    "ApiKey": "fc-YOUR-API-KEY",
+    "BaseUrl": "https://api.firecrawl.dev/v2"
+  }
+}
+```
+
+Or use environment variables / user secrets:
+
+```bash
+export Firecrawl__ApiKey=fc-YOUR-API-KEY
+```
+
+## Create a service
+
+Create `Services/FirecrawlService.cs`:
+
+```csharp
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+public class FirecrawlService
+{
+    private readonly HttpClient _http;
+    private readonly string _baseUrl;
+
+    public FirecrawlService(IConfiguration config)
+    {
+        _baseUrl = config["Firecrawl:BaseUrl"] ?? "https://api.firecrawl.dev/v2";
+        _http = new HttpClient();
+        _http.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", config["Firecrawl:ApiKey"]);
+    }
+
+    public async Task<JsonDocument> ScrapeAsync(string url)
+    {
+        var content = new StringContent(
+            JsonSerializer.Serialize(new { url }),
+            Encoding.UTF8, "application/json");
+
+        var response = await _http.PostAsync($"{_baseUrl}/scrape", content);
+        response.EnsureSuccessStatusCode();
+        return JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+    }
+
+    public async Task<JsonDocument> SearchAsync(string query, int limit = 5)
+    {
+        var content = new StringContent(
+            JsonSerializer.Serialize(new { query, limit }),
+            Encoding.UTF8, "application/json");
+
+        var response = await _http.PostAsync($"{_baseUrl}/search", content);
+        response.EnsureSuccessStatusCode();
+        return JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+    }
+}
+```
+
+## Register and use
+
+In `Program.cs`:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddSingleton<FirecrawlService>();
+
+var app = builder.Build();
+
+app.MapPost("/api/scrape", async (FirecrawlService firecrawl, ScrapeRequest req) =>
+{
+    var result = await firecrawl.ScrapeAsync(req.Url);
+    return Results.Ok(result.RootElement);
+});
+
+app.MapPost("/api/search", async (FirecrawlService firecrawl, SearchRequest req) =>
+{
+    var result = await firecrawl.SearchAsync(req.Query, req.Limit);
+    return Results.Ok(result.RootElement);
+});
+
+app.Run();
+
+record ScrapeRequest(string Url);
+record SearchRequest(string Query, int Limit = 5);
+```
+
+## Run it
+
+```bash
+dotnet run
+```
+
+## Test it
+
+```bash
+curl -X POST http://localhost:5000/api/scrape \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}'
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
+    Complete REST API documentation
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+</CardGroup>

--- a/quickstarts/astro.mdx
+++ b/quickstarts/astro.mdx
@@ -1,0 +1,90 @@
+---
+title: "Astro"
+description: "Use Firecrawl with Astro to scrape, search, and interact with web data in your content-driven site."
+og:title: "Astro Quickstart | Firecrawl"
+og:description: "Use Firecrawl with Astro to scrape, search, and interact with web data in your content-driven site."
+---
+
+## Prerequisites
+
+- Astro project with SSR enabled (`output: "server"` or `"hybrid"`)
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Install the SDK
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+Add your API key to `.env`:
+
+```bash
+FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+## API endpoint
+
+Create `src/pages/api/scrape.ts`:
+
+```typescript
+import type { APIRoute } from "astro";
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({
+  apiKey: import.meta.env.FIRECRAWL_API_KEY,
+});
+
+export const POST: APIRoute = async ({ request }) => {
+  const { url } = await request.json();
+  const result = await firecrawl.scrape(url);
+  return new Response(JSON.stringify(result), {
+    headers: { "Content-Type": "application/json" },
+  });
+};
+```
+
+## Server-rendered page
+
+Fetch data at request time in an Astro page (`src/pages/scrape.astro`):
+
+```astro
+---
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({
+  apiKey: import.meta.env.FIRECRAWL_API_KEY,
+});
+
+const target = Astro.url.searchParams.get("url");
+let markdown = null;
+
+if (target) {
+  const result = await firecrawl.scrape(target);
+  markdown = result.markdown;
+}
+---
+
+<html>
+  <body>
+    <h1>Scraped Content</h1>
+    {markdown ? <pre>{markdown}</pre> : <p>Pass ?url= to scrape a page</p>}
+  </body>
+</html>
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Node SDK reference" icon="node" href="/sdks/node">
+    Full SDK reference with crawl, map, batch scrape, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/astro.mdx
+++ b/quickstarts/astro.mdx
@@ -22,7 +22,62 @@ Add your API key to `.env`:
 FIRECRAWL_API_KEY=fc-YOUR-API-KEY
 ```
 
-## API endpoint
+## Search the web
+
+Create `src/pages/api/search.ts`:
+
+```typescript
+import type { APIRoute } from "astro";
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({
+  apiKey: import.meta.env.FIRECRAWL_API_KEY,
+});
+
+export const POST: APIRoute = async ({ request }) => {
+  const { query } = await request.json();
+  const results = await firecrawl.search(query, { limit: 5 });
+  return new Response(JSON.stringify(results), {
+    headers: { "Content-Type": "application/json" },
+  });
+};
+```
+
+Or search at request time in a server-rendered page (`src/pages/search.astro`):
+
+```astro
+---
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({
+  apiKey: import.meta.env.FIRECRAWL_API_KEY,
+});
+
+const query = Astro.url.searchParams.get("q");
+let results = [];
+
+if (query) {
+  results = await firecrawl.search(query, { limit: 5 });
+}
+---
+
+<html>
+  <body>
+    <h1>Search Results</h1>
+    {results.length > 0 ? (
+      <ul>
+        {results.map((r) => (
+          <li><a href={r.url}>{r.title}</a></li>
+        ))}
+      </ul>
+    ) : (
+      <p>Pass ?q= to search the web</p>
+    )}
+  </body>
+</html>
+```
+
+## Scrape a page
 
 Create `src/pages/api/scrape.ts`:
 
@@ -43,9 +98,7 @@ export const POST: APIRoute = async ({ request }) => {
 };
 ```
 
-## Server-rendered page
-
-Fetch data at request time in an Astro page (`src/pages/scrape.astro`):
+Or scrape at request time in a server-rendered page (`src/pages/scrape.astro`):
 
 ```astro
 ---
@@ -70,6 +123,41 @@ if (target) {
     {markdown ? <pre>{markdown}</pre> : <p>Pass ?url= to scrape a page</p>}
   </body>
 </html>
+```
+
+## Interact with a page
+
+Create `src/pages/api/interact.ts`:
+
+```typescript
+import type { APIRoute } from "astro";
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({
+  apiKey: import.meta.env.FIRECRAWL_API_KEY,
+});
+
+export const POST: APIRoute = async () => {
+  const result = await firecrawl.scrape("https://www.amazon.com", {
+    formats: ["markdown"],
+  });
+
+  const scrapeId = result.metadata?.scrapeId;
+
+  await firecrawl.interact(scrapeId, {
+    prompt: "Search for iPhone 16 Pro Max",
+  });
+
+  const response = await firecrawl.interact(scrapeId, {
+    prompt: "Click on the first result and tell me the price",
+  });
+
+  await firecrawl.stopInteraction(scrapeId);
+
+  return new Response(JSON.stringify({ output: response.output }), {
+    headers: { "Content-Type": "application/json" },
+  });
+};
 ```
 
 ## Next steps

--- a/quickstarts/astro.mdx
+++ b/quickstarts/astro.mdx
@@ -57,7 +57,8 @@ const query = Astro.url.searchParams.get("q");
 let results = [];
 
 if (query) {
-  results = await firecrawl.search(query, { limit: 5 });
+  const searchData = await firecrawl.search(query, { limit: 5 });
+  results = searchData.web || [];
 }
 ---
 

--- a/quickstarts/aws-lambda.mdx
+++ b/quickstarts/aws-lambda.mdx
@@ -1,0 +1,118 @@
+---
+title: "AWS Lambda"
+description: "Use Firecrawl with AWS Lambda to scrape, search, and interact with web data in serverless functions."
+og:title: "AWS Lambda Quickstart | Firecrawl"
+og:description: "Use Firecrawl with AWS Lambda to scrape, search, and interact with web data in serverless functions."
+---
+
+## Prerequisites
+
+- AWS account with Lambda access
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Node.js Lambda
+
+### Setup
+
+```bash
+mkdir firecrawl-lambda && cd firecrawl-lambda
+npm init -y
+npm install @mendable/firecrawl-js
+```
+
+### Handler
+
+Create `index.mjs`:
+
+```javascript
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+
+export async function handler(event) {
+  const body = JSON.parse(event.body || "{}");
+
+  if (body.action === "search") {
+    const results = await firecrawl.search(body.query, { limit: 5 });
+    return {
+      statusCode: 200,
+      body: JSON.stringify(results),
+    };
+  }
+
+  const result = await firecrawl.scrape(body.url);
+  return {
+    statusCode: 200,
+    body: JSON.stringify(result),
+  };
+}
+```
+
+### Deploy
+
+Package and deploy with the AWS CLI:
+
+```bash
+zip -r function.zip index.mjs node_modules/
+
+aws lambda create-function \
+  --function-name firecrawl-scraper \
+  --runtime nodejs20.x \
+  --handler index.handler \
+  --zip-file fileb://function.zip \
+  --role arn:aws:iam::YOUR_ACCOUNT:role/lambda-role \
+  --environment Variables="{FIRECRAWL_API_KEY=fc-YOUR-API-KEY}" \
+  --timeout 60
+```
+
+## Python Lambda
+
+### Handler
+
+Create `lambda_function.py`:
+
+```python
+import json
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl()
+
+def handler(event, context):
+    body = json.loads(event.get("body", "{}"))
+
+    if body.get("action") == "search":
+        results = firecrawl.search(body["query"], limit=5)
+        return {
+            "statusCode": 200,
+            "body": json.dumps([{"title": r.title, "url": r.url} for r in results]),
+        }
+
+    result = firecrawl.scrape(body["url"])
+    return {
+        "statusCode": 200,
+        "body": json.dumps({"markdown": result.markdown}),
+    }
+```
+
+Package `firecrawl-py` as a Lambda layer or include it in your deployment package.
+
+<Note>
+Set the Lambda timeout to at least 30 seconds. Scraping dynamic pages can take longer than the default 3-second timeout.
+</Note>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Node SDK reference" icon="node" href="/sdks/node">
+    Full SDK reference with crawl, map, batch scrape, and more
+  </Card>
+  <Card title="Python SDK reference" icon="python" href="/sdks/python">
+    Full Python SDK reference
+  </Card>
+</CardGroup>

--- a/quickstarts/aws-lambda.mdx
+++ b/quickstarts/aws-lambda.mdx
@@ -1,8 +1,8 @@
 ---
 title: "AWS Lambda"
-description: "Use Firecrawl with AWS Lambda to scrape, search, and interact with web data in serverless functions."
+description: "Use Firecrawl with AWS Lambda to search, scrape, and interact with web data in serverless functions."
 og:title: "AWS Lambda Quickstart | Firecrawl"
-og:description: "Use Firecrawl with AWS Lambda to scrape, search, and interact with web data in serverless functions."
+og:description: "Use Firecrawl with AWS Lambda to search, scrape, and interact with web data in serverless functions."
 ---
 
 ## Prerequisites
@@ -10,9 +10,7 @@ og:description: "Use Firecrawl with AWS Lambda to scrape, search, and interact w
 - AWS account with Lambda access
 - A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
 
-## Node.js Lambda
-
-### Setup
+## Setup
 
 ```bash
 mkdir firecrawl-lambda && cd firecrawl-lambda
@@ -20,9 +18,9 @@ npm init -y
 npm install @mendable/firecrawl-js
 ```
 
-### Handler
+## Search the web
 
-Create `index.mjs`:
+Create `index.mjs` with a search handler:
 
 ```javascript
 import Firecrawl from "@mendable/firecrawl-js";
@@ -40,6 +38,16 @@ export async function handler(event) {
     };
   }
 
+  return { statusCode: 400, body: JSON.stringify({ error: "Unknown action" }) };
+}
+```
+
+## Scrape a page
+
+Add a `scrape` action to the same handler:
+
+```javascript
+if (body.action === "scrape") {
   const result = await firecrawl.scrape(body.url);
   return {
     statusCode: 200,
@@ -48,7 +56,33 @@ export async function handler(event) {
 }
 ```
 
-### Deploy
+## Interact with a page
+
+Add an `interact` action to control a live browser session — click buttons, fill forms, and extract dynamic content:
+
+```javascript
+if (body.action === "interact") {
+  const result = await firecrawl.scrape("https://www.amazon.com", {
+    formats: ["markdown"],
+  });
+  const scrapeId = result.metadata?.scrapeId;
+
+  await firecrawl.interact(scrapeId, {
+    prompt: "Search for iPhone 16 Pro Max",
+  });
+  const response = await firecrawl.interact(scrapeId, {
+    prompt: "Click on the first result and tell me the price",
+  });
+
+  await firecrawl.stopInteraction(scrapeId);
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ output: response.output }),
+  };
+}
+```
+
+## Deploy
 
 Package and deploy with the AWS CLI:
 
@@ -65,54 +99,23 @@ aws lambda create-function \
   --timeout 60
 ```
 
-## Python Lambda
-
-### Handler
-
-Create `lambda_function.py`:
-
-```python
-import json
-from firecrawl import Firecrawl
-
-firecrawl = Firecrawl()
-
-def handler(event, context):
-    body = json.loads(event.get("body", "{}"))
-
-    if body.get("action") == "search":
-        results = firecrawl.search(body["query"], limit=5)
-        return {
-            "statusCode": 200,
-            "body": json.dumps([{"title": r.title, "url": r.url} for r in results]),
-        }
-
-    result = firecrawl.scrape(body["url"])
-    return {
-        "statusCode": 200,
-        "body": json.dumps({"markdown": result.markdown}),
-    }
-```
-
-Package `firecrawl-py` as a Lambda layer or include it in your deployment package.
-
 <Note>
-Set the Lambda timeout to at least 30 seconds. Scraping dynamic pages can take longer than the default 3-second timeout.
+Set the Lambda timeout to at least 30 seconds. Scraping dynamic pages and interact sessions can take longer than the default 3-second timeout.
 </Note>
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
-    All scrape options including formats, actions, and proxies
-  </Card>
   <Card title="Search docs" icon="magnifying-glass" href="/features/search">
     Search the web and get full page content
   </Card>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
   <Card title="Node SDK reference" icon="node" href="/sdks/node">
     Full SDK reference with crawl, map, batch scrape, and more
-  </Card>
-  <Card title="Python SDK reference" icon="python" href="/sdks/python">
-    Full Python SDK reference
   </Card>
 </CardGroup>

--- a/quickstarts/bun.mdx
+++ b/quickstarts/bun.mdx
@@ -22,7 +22,7 @@ Add your API key to `.env`:
 FIRECRAWL_API_KEY=fc-YOUR-API-KEY
 ```
 
-## Create a scrape server
+## Search the web
 
 Bun has a built-in HTTP server. Create `index.ts`:
 
@@ -35,12 +35,6 @@ Bun.serve({
   port: 3000,
   async fetch(req) {
     const url = new URL(req.url);
-
-    if (req.method === "POST" && url.pathname === "/scrape") {
-      const { url: targetUrl } = await req.json();
-      const result = await firecrawl.scrape(targetUrl);
-      return Response.json(result);
-    }
 
     if (req.method === "POST" && url.pathname === "/search") {
       const { query } = await req.json();
@@ -61,6 +55,38 @@ Run it:
 bun run index.ts
 ```
 
+## Scrape a page
+
+Add a `/scrape` route to the same server:
+
+```typescript
+if (req.method === "POST" && url.pathname === "/scrape") {
+  const { url: targetUrl } = await req.json();
+  const result = await firecrawl.scrape(targetUrl);
+  return Response.json(result);
+}
+```
+
+## Interact with a page
+
+Use interact to control a live browser session — click buttons, fill forms, and extract dynamic content.
+
+```typescript
+if (req.method === "POST" && url.pathname === "/interact") {
+  const { url: targetUrl } = await req.json();
+
+  const result = await firecrawl.scrape(targetUrl, { formats: ['markdown'] });
+  const scrapeId = result.metadata?.scrapeId;
+
+  await firecrawl.interact(scrapeId, { prompt: 'Search for iPhone 16 Pro Max' });
+  const response = await firecrawl.interact(scrapeId, { prompt: 'Click on the first result and tell me the price' });
+
+  await firecrawl.stopInteraction(scrapeId);
+
+  return Response.json({ output: response.output });
+}
+```
+
 ## Script usage
 
 Use Firecrawl in a standalone Bun script:
@@ -69,12 +95,12 @@ Use Firecrawl in a standalone Bun script:
 import Firecrawl from "@mendable/firecrawl-js";
 
 const app = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
-const result = await app.scrape("https://example.com");
-console.log(result.markdown);
+const results = await app.search("firecrawl web scraping", { limit: 5 });
+console.log(results);
 ```
 
 ```bash
-bun run scrape.ts
+bun run search.ts
 ```
 
 ## Next steps

--- a/quickstarts/bun.mdx
+++ b/quickstarts/bun.mdx
@@ -1,0 +1,95 @@
+---
+title: "Bun"
+description: "Use Firecrawl with Bun to build fast web scraping and search servers."
+og:title: "Bun Quickstart | Firecrawl"
+og:description: "Use Firecrawl with Bun to build fast web scraping and search servers."
+---
+
+## Prerequisites
+
+- Bun 1.0+
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Install the SDK
+
+```bash
+bun add @mendable/firecrawl-js
+```
+
+Add your API key to `.env`:
+
+```bash
+FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+## Create a scrape server
+
+Bun has a built-in HTTP server. Create `index.ts`:
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+
+Bun.serve({
+  port: 3000,
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    if (req.method === "POST" && url.pathname === "/scrape") {
+      const { url: targetUrl } = await req.json();
+      const result = await firecrawl.scrape(targetUrl);
+      return Response.json(result);
+    }
+
+    if (req.method === "POST" && url.pathname === "/search") {
+      const { query } = await req.json();
+      const results = await firecrawl.search(query, { limit: 5 });
+      return Response.json(results);
+    }
+
+    return new Response("Not found", { status: 404 });
+  },
+});
+
+console.log("Server running on port 3000");
+```
+
+Run it:
+
+```bash
+bun run index.ts
+```
+
+## Script usage
+
+Use Firecrawl in a standalone Bun script:
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+
+const app = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+const result = await app.scrape("https://example.com");
+console.log(result.markdown);
+```
+
+```bash
+bun run scrape.ts
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Node SDK reference" icon="node" href="/sdks/node">
+    Full SDK reference with crawl, map, batch scrape, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/cloudflare-workers.mdx
+++ b/quickstarts/cloudflare-workers.mdx
@@ -1,0 +1,89 @@
+---
+title: "Cloudflare Workers"
+description: "Use Firecrawl with Cloudflare Workers to scrape, search, and interact with web data at the edge."
+og:title: "Cloudflare Workers Quickstart | Firecrawl"
+og:description: "Use Firecrawl with Cloudflare Workers to scrape, search, and interact with web data at the edge."
+---
+
+## Prerequisites
+
+- Wrangler CLI (`npm install -g wrangler`)
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Setup
+
+```bash
+npm create cloudflare@latest my-scraper
+cd my-scraper
+npm install @mendable/firecrawl-js
+```
+
+Add your API key as a secret:
+
+```bash
+wrangler secret put FIRECRAWL_API_KEY
+```
+
+## Worker with scrape and search
+
+Edit `src/index.ts`:
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+
+export interface Env {
+  FIRECRAWL_API_KEY: string;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const firecrawl = new Firecrawl({ apiKey: env.FIRECRAWL_API_KEY });
+    const url = new URL(request.url);
+
+    if (request.method === "POST" && url.pathname === "/scrape") {
+      const { url: targetUrl } = await request.json() as { url: string };
+      const result = await firecrawl.scrape(targetUrl);
+      return Response.json(result);
+    }
+
+    if (request.method === "POST" && url.pathname === "/search") {
+      const { query } = await request.json() as { query: string };
+      const results = await firecrawl.search(query, { limit: 5 });
+      return Response.json(results);
+    }
+
+    return new Response("Not found", { status: 404 });
+  },
+};
+```
+
+## Deploy
+
+```bash
+wrangler deploy
+```
+
+## Test it
+
+```bash
+curl -X POST https://my-scraper.<your-subdomain>.workers.dev/scrape \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}'
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Node SDK reference" icon="node" href="/sdks/node">
+    Full SDK reference with crawl, map, batch scrape, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/cloudflare-workers.mdx
+++ b/quickstarts/cloudflare-workers.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Cloudflare Workers"
-description: "Use Firecrawl with Cloudflare Workers to scrape, search, and interact with web data at the edge."
+description: "Use Firecrawl with Cloudflare Workers to search, scrape, and interact with web data at the edge."
 og:title: "Cloudflare Workers Quickstart | Firecrawl"
-og:description: "Use Firecrawl with Cloudflare Workers to scrape, search, and interact with web data at the edge."
+og:description: "Use Firecrawl with Cloudflare Workers to search, scrape, and interact with web data at the edge."
 ---
 
 ## Prerequisites
@@ -24,7 +24,9 @@ Add your API key as a secret:
 wrangler secret put FIRECRAWL_API_KEY
 ```
 
-## Worker with scrape and search
+## Search the web
+
+Create a handler that searches the web and returns results with full page content.
 
 Edit `src/index.ts`:
 
@@ -40,14 +42,8 @@ export default {
     const firecrawl = new Firecrawl({ apiKey: env.FIRECRAWL_API_KEY });
     const url = new URL(request.url);
 
-    if (request.method === "POST" && url.pathname === "/scrape") {
-      const { url: targetUrl } = await request.json() as { url: string };
-      const result = await firecrawl.scrape(targetUrl);
-      return Response.json(result);
-    }
-
     if (request.method === "POST" && url.pathname === "/search") {
-      const { query } = await request.json() as { query: string };
+      const { query } = (await request.json()) as { query: string };
       const results = await firecrawl.search(query, { limit: 5 });
       return Response.json(results);
     }
@@ -55,6 +51,41 @@ export default {
     return new Response("Not found", { status: 404 });
   },
 };
+```
+
+## Scrape a page
+
+Add a `/scrape` route to extract clean markdown from any URL.
+
+```typescript
+if (request.method === "POST" && url.pathname === "/scrape") {
+  const { url: targetUrl } = (await request.json()) as { url: string };
+  const result = await firecrawl.scrape(targetUrl);
+  return Response.json(result);
+}
+```
+
+## Interact with a page
+
+Add an `/interact` route to control a live browser session — click buttons, fill forms, and extract dynamic content.
+
+```typescript
+if (request.method === "POST" && url.pathname === "/interact") {
+  const result = await firecrawl.scrape("https://www.amazon.com", {
+    formats: ["markdown"],
+  });
+  const scrapeId = result.metadata?.scrapeId;
+
+  await firecrawl.interact(scrapeId, {
+    prompt: "Search for iPhone 16 Pro Max",
+  });
+  const response = await firecrawl.interact(scrapeId, {
+    prompt: "Click on the first result and tell me the price",
+  });
+
+  await firecrawl.stopInteraction(scrapeId);
+  return Response.json({ output: response.output });
+}
 ```
 
 ## Deploy
@@ -66,19 +97,19 @@ wrangler deploy
 ## Test it
 
 ```bash
-curl -X POST https://my-scraper.<your-subdomain>.workers.dev/scrape \
+curl -X POST https://my-scraper.<your-subdomain>.workers.dev/search \
   -H "Content-Type: application/json" \
-  -d '{"url": "https://example.com"}'
+  -d '{"query": "firecrawl web scraping"}'
 ```
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
-    All scrape options including formats, actions, and proxies
-  </Card>
   <Card title="Search docs" icon="magnifying-glass" href="/features/search">
     Search the web and get full page content
+  </Card>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
   </Card>
   <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
     Click, fill forms, and extract dynamic content

--- a/quickstarts/deno-deploy.mdx
+++ b/quickstarts/deno-deploy.mdx
@@ -1,0 +1,86 @@
+---
+title: "Deno Deploy"
+description: "Use Firecrawl with Deno Deploy to scrape, search, and interact with web data at the edge."
+og:title: "Deno Deploy Quickstart | Firecrawl"
+og:description: "Use Firecrawl with Deno Deploy to scrape, search, and interact with web data at the edge."
+---
+
+## Prerequisites
+
+- Deno 1.40+ or Deno 2
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Create the server
+
+Create `main.ts`:
+
+```typescript
+import Firecrawl from "npm:@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({
+  apiKey: Deno.env.get("FIRECRAWL_API_KEY"),
+});
+
+Deno.serve(async (req) => {
+  const url = new URL(req.url);
+
+  if (req.method === "POST" && url.pathname === "/scrape") {
+    const { url: targetUrl } = await req.json();
+    const result = await firecrawl.scrape(targetUrl);
+    return Response.json(result);
+  }
+
+  if (req.method === "POST" && url.pathname === "/search") {
+    const { query } = await req.json();
+    const results = await firecrawl.search(query, { limit: 5 });
+    return Response.json(results);
+  }
+
+  return new Response("Not found", { status: 404 });
+});
+```
+
+## Run locally
+
+```bash
+FIRECRAWL_API_KEY=fc-YOUR-API-KEY deno run --allow-net --allow-env main.ts
+```
+
+## Deploy
+
+Install the Deno Deploy CLI (`deployctl`) and deploy:
+
+```bash
+deployctl deploy --project=my-scraper main.ts
+```
+
+Set the environment variable in the Deno Deploy dashboard or via CLI:
+
+```bash
+deployctl env set FIRECRAWL_API_KEY=fc-YOUR-API-KEY --project=my-scraper
+```
+
+## Test it
+
+```bash
+curl -X POST https://my-scraper.deno.dev/scrape \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}'
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Node SDK reference" icon="node" href="/sdks/node">
+    Full SDK reference with crawl, map, batch scrape, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/deno-deploy.mdx
+++ b/quickstarts/deno-deploy.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Deno Deploy"
-description: "Use Firecrawl with Deno Deploy to scrape, search, and interact with web data at the edge."
+description: "Use Firecrawl with Deno Deploy to search, scrape, and interact with web data at the edge."
 og:title: "Deno Deploy Quickstart | Firecrawl"
-og:description: "Use Firecrawl with Deno Deploy to scrape, search, and interact with web data at the edge."
+og:description: "Use Firecrawl with Deno Deploy to search, scrape, and interact with web data at the edge."
 ---
 
 ## Prerequisites
@@ -10,7 +10,7 @@ og:description: "Use Firecrawl with Deno Deploy to scrape, search, and interact 
 - Deno 1.40+ or Deno 2
 - A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
 
-## Create the server
+## Setup
 
 Create `main.ts`:
 
@@ -20,15 +20,15 @@ import Firecrawl from "npm:@mendable/firecrawl-js";
 const firecrawl = new Firecrawl({
   apiKey: Deno.env.get("FIRECRAWL_API_KEY"),
 });
+```
 
+## Search the web
+
+Add a `/search` route that searches the web and returns results with full page content.
+
+```typescript
 Deno.serve(async (req) => {
   const url = new URL(req.url);
-
-  if (req.method === "POST" && url.pathname === "/scrape") {
-    const { url: targetUrl } = await req.json();
-    const result = await firecrawl.scrape(targetUrl);
-    return Response.json(result);
-  }
 
   if (req.method === "POST" && url.pathname === "/search") {
     const { query } = await req.json();
@@ -38,6 +38,42 @@ Deno.serve(async (req) => {
 
   return new Response("Not found", { status: 404 });
 });
+```
+
+## Scrape a page
+
+Add a `/scrape` route to extract clean markdown from any URL.
+
+```typescript
+if (req.method === "POST" && url.pathname === "/scrape") {
+  const { url: targetUrl } = await req.json();
+  const result = await firecrawl.scrape(targetUrl);
+  return Response.json(result);
+}
+```
+
+## Interact with a page
+
+Add an `/interact` route to control a live browser session — click buttons, fill forms, and extract dynamic content.
+
+```typescript
+if (req.method === "POST" && url.pathname === "/interact") {
+  const result = await firecrawl.scrape("https://www.amazon.com", {
+    formats: ["markdown"],
+  });
+  const scrapeId = result.metadata?.scrapeId;
+
+  await firecrawl.interact(scrapeId, {
+    prompt: "Search for iPhone 16 Pro Max",
+  });
+  const response = await firecrawl.interact(scrapeId, {
+    prompt: "Click on the first result and tell me the price",
+  });
+  console.log(response.output);
+
+  await firecrawl.stopInteraction(scrapeId);
+  return Response.json({ output: response.output });
+}
 ```
 
 ## Run locally
@@ -63,19 +99,19 @@ deployctl env set FIRECRAWL_API_KEY=fc-YOUR-API-KEY --project=my-scraper
 ## Test it
 
 ```bash
-curl -X POST https://my-scraper.deno.dev/scrape \
+curl -X POST https://my-scraper.deno.dev/search \
   -H "Content-Type: application/json" \
-  -d '{"url": "https://example.com"}'
+  -d '{"query": "firecrawl web scraping"}'
 ```
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
-    All scrape options including formats, actions, and proxies
-  </Card>
   <Card title="Search docs" icon="magnifying-glass" href="/features/search">
     Search the web and get full page content
+  </Card>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
   </Card>
   <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
     Click, fill forms, and extract dynamic content

--- a/quickstarts/django.mdx
+++ b/quickstarts/django.mdx
@@ -22,9 +22,9 @@ Add your API key to your Django settings or environment:
 export FIRECRAWL_API_KEY=fc-YOUR-API-KEY
 ```
 
-## Create a view
+## Create views
 
-Add a scrape view to your Django app. In `views.py`:
+Add search, scrape, and interact views to your Django app. In `views.py`:
 
 ```python
 import json
@@ -35,6 +35,17 @@ from django.views.decorators.http import require_POST
 from firecrawl import Firecrawl
 
 firecrawl = Firecrawl(api_key=os.environ["FIRECRAWL_API_KEY"])
+
+
+@csrf_exempt
+@require_POST
+def search_view(request):
+    body = json.loads(request.body)
+    results = firecrawl.search(body["query"], limit=body.get("limit", 5))
+    return JsonResponse(
+        [{"title": r.title, "url": r.url} for r in results],
+        safe=False,
+    )
 
 
 @csrf_exempt
@@ -50,13 +61,26 @@ def scrape_view(request):
 
 @csrf_exempt
 @require_POST
-def search_view(request):
+def interact_start_view(request):
     body = json.loads(request.body)
-    results = firecrawl.search(body["query"], limit=body.get("limit", 5))
-    return JsonResponse(
-        [{"title": r.title, "url": r.url} for r in results],
-        safe=False,
-    )
+    result = firecrawl.scrape(body["url"], formats=["markdown"])
+    return JsonResponse({"scrape_id": result.metadata.scrape_id})
+
+
+@csrf_exempt
+@require_POST
+def interact_view(request):
+    body = json.loads(request.body)
+    response = firecrawl.interact(body["scrape_id"], prompt=body["prompt"])
+    return JsonResponse({"output": response.output})
+
+
+@csrf_exempt
+@require_POST
+def interact_stop_view(request):
+    body = json.loads(request.body)
+    firecrawl.stop_interaction(body["scrape_id"])
+    return JsonResponse({"status": "stopped"})
 ```
 
 ## Wire up URLs
@@ -68,8 +92,11 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("api/scrape/", views.scrape_view),
     path("api/search/", views.search_view),
+    path("api/scrape/", views.scrape_view),
+    path("api/interact/start/", views.interact_start_view),
+    path("api/interact/", views.interact_view),
+    path("api/interact/stop/", views.interact_stop_view),
 ]
 ```
 
@@ -78,9 +105,20 @@ urlpatterns = [
 ```bash
 python manage.py runserver
 
+# Search the web
+curl -X POST http://localhost:8000/api/search/ \
+  -H "Content-Type: application/json" \
+  -d '{"query": "firecrawl web scraping", "limit": 5}'
+
+# Scrape a page
 curl -X POST http://localhost:8000/api/scrape/ \
   -H "Content-Type: application/json" \
   -d '{"url": "https://example.com"}'
+
+# Start an interactive session
+curl -X POST http://localhost:8000/api/interact/start/ \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://www.amazon.com"}'
 ```
 
 ## Management command

--- a/quickstarts/django.mdx
+++ b/quickstarts/django.mdx
@@ -43,7 +43,7 @@ def search_view(request):
     body = json.loads(request.body)
     results = firecrawl.search(body["query"], limit=body.get("limit", 5))
     return JsonResponse(
-        [{"title": r.title, "url": r.url} for r in results],
+        [{"title": r.title, "url": r.url} for r in results.web],
         safe=False,
     )
 

--- a/quickstarts/django.mdx
+++ b/quickstarts/django.mdx
@@ -1,0 +1,127 @@
+---
+title: "Django"
+description: "Use Firecrawl with Django to scrape, search, and interact with web data in your Python web application."
+og:title: "Django Quickstart | Firecrawl"
+og:description: "Use Firecrawl with Django to scrape, search, and interact with web data in your Python web application."
+---
+
+## Prerequisites
+
+- Django 4+ project
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Install the SDK
+
+```bash
+pip install firecrawl-py
+```
+
+Add your API key to your Django settings or environment:
+
+```bash
+export FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+## Create a view
+
+Add a scrape view to your Django app. In `views.py`:
+
+```python
+import json
+import os
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(api_key=os.environ["FIRECRAWL_API_KEY"])
+
+
+@csrf_exempt
+@require_POST
+def scrape_view(request):
+    body = json.loads(request.body)
+    result = firecrawl.scrape(body["url"])
+    return JsonResponse({
+        "markdown": result.markdown,
+        "metadata": result.metadata,
+    })
+
+
+@csrf_exempt
+@require_POST
+def search_view(request):
+    body = json.loads(request.body)
+    results = firecrawl.search(body["query"], limit=body.get("limit", 5))
+    return JsonResponse(
+        [{"title": r.title, "url": r.url} for r in results],
+        safe=False,
+    )
+```
+
+## Wire up URLs
+
+In `urls.py`:
+
+```python
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path("api/scrape/", views.scrape_view),
+    path("api/search/", views.search_view),
+]
+```
+
+## Test it
+
+```bash
+python manage.py runserver
+
+curl -X POST http://localhost:8000/api/scrape/ \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}'
+```
+
+## Management command
+
+Use Firecrawl in a Django management command for scripts and data pipelines. Create `management/commands/scrape.py`:
+
+```python
+import os
+from django.core.management.base import BaseCommand
+from firecrawl import Firecrawl
+
+
+class Command(BaseCommand):
+    help = "Scrape a URL and print the markdown"
+
+    def add_arguments(self, parser):
+        parser.add_argument("url", type=str)
+
+    def handle(self, *args, **options):
+        firecrawl = Firecrawl(api_key=os.environ["FIRECRAWL_API_KEY"])
+        result = firecrawl.scrape(options["url"])
+        self.stdout.write(result.markdown)
+```
+
+```bash
+python manage.py scrape https://example.com
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Python SDK reference" icon="python" href="/sdks/python">
+    Full SDK reference with crawl, map, async, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/dotnet.mdx
+++ b/quickstarts/dotnet.mdx
@@ -10,7 +10,7 @@ og:description: "Get started with Firecrawl in .NET. Scrape, search, and interac
 - .NET 6.0+
 - A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
 
-## Scrape a page
+## Search the web
 
 Firecrawl works with .NET through the REST API using `HttpClient`.
 
@@ -24,15 +24,44 @@ var client = new HttpClient();
 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
 
 var content = new StringContent(
+    JsonSerializer.Serialize(new { query = "firecrawl web scraping", limit = 5 }),
+    Encoding.UTF8,
+    "application/json"
+);
+
+var response = await client.PostAsync("https://api.firecrawl.dev/v2/search", content);
+var json = await response.Content.ReadAsStringAsync();
+Console.WriteLine(json);
+```
+
+<Accordion title="Example response">
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "url": "https://docs.firecrawl.dev",
+      "title": "Firecrawl Documentation",
+      "markdown": "# Firecrawl\n\nFirecrawl is a web scraping API..."
+    }
+  ]
+}
+```
+</Accordion>
+
+## Scrape a page
+
+```csharp
+var scrapeContent = new StringContent(
     JsonSerializer.Serialize(new { url = "https://example.com" }),
     Encoding.UTF8,
     "application/json"
 );
 
-var response = await client.PostAsync("https://api.firecrawl.dev/v2/scrape", content);
-var json = await response.Content.ReadAsStringAsync();
+var scrapeResponse = await client.PostAsync("https://api.firecrawl.dev/v2/scrape", scrapeContent);
+var scrapeJson = await scrapeResponse.Content.ReadAsStringAsync();
 
-using var doc = JsonDocument.Parse(json);
+using var doc = JsonDocument.Parse(scrapeJson);
 var markdown = doc.RootElement.GetProperty("data").GetProperty("markdown").GetString();
 Console.WriteLine(markdown);
 ```
@@ -52,18 +81,63 @@ Console.WriteLine(markdown);
 ```
 </Accordion>
 
-## Search the web
+## Interact with a page
+
+Start a browser session, interact with the page using natural-language prompts, then close the session.
+
+### Step 1 — Scrape to start a session
 
 ```csharp
-var searchContent = new StringContent(
-    JsonSerializer.Serialize(new { query = "firecrawl web scraping", limit = 5 }),
+var sessionContent = new StringContent(
+    JsonSerializer.Serialize(new { url = "https://www.amazon.com", formats = new[] { "markdown" } }),
     Encoding.UTF8,
     "application/json"
 );
 
-var searchResponse = await client.PostAsync("https://api.firecrawl.dev/v2/search", searchContent);
-var searchJson = await searchResponse.Content.ReadAsStringAsync();
-Console.WriteLine(searchJson);
+var sessionResponse = await client.PostAsync("https://api.firecrawl.dev/v2/scrape", sessionContent);
+var sessionJson = await sessionResponse.Content.ReadAsStringAsync();
+
+using var sessionDoc = JsonDocument.Parse(sessionJson);
+var scrapeId = sessionDoc.RootElement
+    .GetProperty("data")
+    .GetProperty("metadata")
+    .GetProperty("scrapeId")
+    .GetString();
+
+Console.WriteLine($"scrapeId: {scrapeId}");
+```
+
+### Step 2 — Send interactions
+
+```csharp
+var interactUrl = $"https://api.firecrawl.dev/v2/scrape/{scrapeId}/interact";
+
+// Search for a product
+var searchBody = new StringContent(
+    JsonSerializer.Serialize(new { prompt = "Search for iPhone 16 Pro Max" }),
+    Encoding.UTF8,
+    "application/json"
+);
+
+var searchResult = await client.PostAsync(interactUrl, searchBody);
+Console.WriteLine(await searchResult.Content.ReadAsStringAsync());
+
+// Click on the first result
+var clickBody = new StringContent(
+    JsonSerializer.Serialize(new { prompt = "Click on the first result and tell me the price" }),
+    Encoding.UTF8,
+    "application/json"
+);
+
+var clickResult = await client.PostAsync(interactUrl, clickBody);
+Console.WriteLine(await clickResult.Content.ReadAsStringAsync());
+```
+
+### Step 3 — Stop the session
+
+```csharp
+await client.DeleteAsync(interactUrl);
+Console.WriteLine("Session stopped");
 ```
 
 ## Reusable client class
@@ -114,23 +188,23 @@ public class FirecrawlClient
 
 // Usage
 var firecrawl = new FirecrawlClient(Environment.GetEnvironmentVariable("FIRECRAWL_API_KEY")!);
-var result = await firecrawl.ScrapeAsync("https://example.com");
-Console.WriteLine(result.RootElement.GetProperty("data").GetProperty("markdown").GetString());
+var result = await firecrawl.SearchAsync("firecrawl web scraping");
+Console.WriteLine(result.RootElement);
 ```
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
-    All scrape options including formats, actions, and proxies
-  </Card>
   <Card title="Search docs" icon="magnifying-glass" href="/features/search">
     Search the web and get full page content
   </Card>
-  <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
-    Complete REST API documentation
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
   </Card>
   <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
     Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
+    Complete REST API documentation
   </Card>
 </CardGroup>

--- a/quickstarts/dotnet.mdx
+++ b/quickstarts/dotnet.mdx
@@ -38,13 +38,15 @@ Console.WriteLine(json);
 ```json
 {
   "success": true,
-  "data": [
-    {
-      "url": "https://docs.firecrawl.dev",
-      "title": "Firecrawl Documentation",
-      "markdown": "# Firecrawl\n\nFirecrawl is a web scraping API..."
-    }
-  ]
+  "data": {
+    "web": [
+      {
+        "url": "https://docs.firecrawl.dev",
+        "title": "Firecrawl Documentation",
+        "markdown": "# Firecrawl\n\nFirecrawl is a web scraping API..."
+      }
+    ]
+  }
 }
 ```
 </Accordion>

--- a/quickstarts/dotnet.mdx
+++ b/quickstarts/dotnet.mdx
@@ -1,0 +1,136 @@
+---
+title: ".NET"
+description: "Get started with Firecrawl in .NET. Scrape, search, and interact with web data using the REST API."
+og:title: ".NET Quickstart | Firecrawl"
+og:description: "Get started with Firecrawl in .NET. Scrape, search, and interact with web data using the REST API."
+---
+
+## Prerequisites
+
+- .NET 6.0+
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Scrape a page
+
+Firecrawl works with .NET through the REST API using `HttpClient`.
+
+```csharp
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+var apiKey = Environment.GetEnvironmentVariable("FIRECRAWL_API_KEY");
+var client = new HttpClient();
+client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+var content = new StringContent(
+    JsonSerializer.Serialize(new { url = "https://example.com" }),
+    Encoding.UTF8,
+    "application/json"
+);
+
+var response = await client.PostAsync("https://api.firecrawl.dev/v2/scrape", content);
+var json = await response.Content.ReadAsStringAsync();
+
+using var doc = JsonDocument.Parse(json);
+var markdown = doc.RootElement.GetProperty("data").GetProperty("markdown").GetString();
+Console.WriteLine(markdown);
+```
+
+<Accordion title="Example response">
+```json
+{
+  "success": true,
+  "data": {
+    "markdown": "# Example Domain\n\nThis domain is for use in illustrative examples...",
+    "metadata": {
+      "title": "Example Domain",
+      "sourceURL": "https://example.com"
+    }
+  }
+}
+```
+</Accordion>
+
+## Search the web
+
+```csharp
+var searchContent = new StringContent(
+    JsonSerializer.Serialize(new { query = "firecrawl web scraping", limit = 5 }),
+    Encoding.UTF8,
+    "application/json"
+);
+
+var searchResponse = await client.PostAsync("https://api.firecrawl.dev/v2/search", searchContent);
+var searchJson = await searchResponse.Content.ReadAsStringAsync();
+Console.WriteLine(searchJson);
+```
+
+## Reusable client class
+
+For repeated use, wrap the API in a typed client:
+
+```csharp
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+public class FirecrawlClient
+{
+    private readonly HttpClient _http;
+    private const string BaseUrl = "https://api.firecrawl.dev/v2";
+
+    public FirecrawlClient(string apiKey)
+    {
+        _http = new HttpClient();
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+    }
+
+    private async Task<JsonDocument> PostAsync(string endpoint, object payload)
+    {
+        var content = new StringContent(
+            JsonSerializer.Serialize(payload),
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        var response = await _http.PostAsync($"{BaseUrl}{endpoint}", content);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync();
+        return JsonDocument.Parse(json);
+    }
+
+    public async Task<JsonDocument> ScrapeAsync(string url)
+    {
+        return await PostAsync("/scrape", new { url });
+    }
+
+    public async Task<JsonDocument> SearchAsync(string query, int limit = 5)
+    {
+        return await PostAsync("/search", new { query, limit });
+    }
+}
+
+// Usage
+var firecrawl = new FirecrawlClient(Environment.GetEnvironmentVariable("FIRECRAWL_API_KEY")!);
+var result = await firecrawl.ScrapeAsync("https://example.com");
+Console.WriteLine(result.RootElement.GetProperty("data").GetProperty("markdown").GetString());
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
+    Complete REST API documentation
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+</CardGroup>

--- a/quickstarts/elixir.mdx
+++ b/quickstarts/elixir.mdx
@@ -33,7 +33,7 @@ config :firecrawl, api_key: System.get_env("FIRECRAWL_API_KEY")
 ```elixir
 {:ok, result} = Firecrawl.search_and_scrape(query: "firecrawl web scraping", limit: 5)
 
-for entry <- result.body["data"] do
+for entry <- result.body["data"]["web"] do
   IO.puts("#{entry["title"]} - #{entry["url"]}")
 end
 ```

--- a/quickstarts/elixir.mdx
+++ b/quickstarts/elixir.mdx
@@ -1,0 +1,125 @@
+---
+title: "Elixir"
+description: "Get started with Firecrawl in Elixir. Search, scrape, and interact with web data using the official SDK."
+og:title: "Elixir Quickstart | Firecrawl"
+og:description: "Get started with Firecrawl in Elixir. Search, scrape, and interact with web data using the official SDK."
+---
+
+## Prerequisites
+
+- Elixir 1.14+ and OTP 25+
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Install the SDK
+
+Add `firecrawl` to your `mix.exs`:
+
+```elixir
+defp deps do
+  [
+    {:firecrawl, "~> 1.0"}
+  ]
+end
+```
+
+Configure your API key in `config/config.exs`:
+
+```elixir
+config :firecrawl, api_key: System.get_env("FIRECRAWL_API_KEY")
+```
+
+## Search the web
+
+```elixir
+{:ok, result} = Firecrawl.search_and_scrape(query: "firecrawl web scraping", limit: 5)
+
+for entry <- result.body["data"] do
+  IO.puts("#{entry["title"]} - #{entry["url"]}")
+end
+```
+
+## Scrape a page
+
+```elixir
+{:ok, result} = Firecrawl.scrape_and_extract_from_url(url: "https://example.com")
+IO.puts(result.body["data"]["markdown"])
+```
+
+<Accordion title="Example response">
+```json
+{
+  "success": true,
+  "data": {
+    "markdown": "# Example Domain\n\nThis domain is for use in illustrative examples...",
+    "metadata": {
+      "title": "Example Domain",
+      "sourceURL": "https://example.com"
+    }
+  }
+}
+```
+</Accordion>
+
+## Interact with a page
+
+Scrape a page, then keep working with it using the browser session API.
+
+```elixir
+{:ok, scrape} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://www.amazon.com",
+  formats: ["markdown"]
+)
+
+scrape_id = get_in(scrape.body, ["data", "metadata", "scrapeId"])
+
+# Use the REST API for interact (prompt-based)
+headers = [
+  {"Authorization", "Bearer #{Application.get_env(:firecrawl, :api_key)}"},
+  {"Content-Type", "application/json"}
+]
+
+{:ok, _} = Req.post(
+  "https://api.firecrawl.dev/v2/scrape/#{scrape_id}/interact",
+  json: %{prompt: "Search for iPhone 16 Pro Max"},
+  headers: headers
+)
+
+{:ok, response} = Req.post(
+  "https://api.firecrawl.dev/v2/scrape/#{scrape_id}/interact",
+  json: %{prompt: "Click on the first result and tell me the price"},
+  headers: headers
+)
+
+IO.inspect(response.body)
+
+# Stop the session
+Req.delete(
+  "https://api.firecrawl.dev/v2/scrape/#{scrape_id}/interact",
+  headers: headers
+)
+```
+
+## Environment variable
+
+Set `FIRECRAWL_API_KEY` instead of hardcoding:
+
+```bash
+export FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Elixir SDK reference" icon="droplet" href="/sdks/elixir">
+    Full SDK reference with crawl, map, batch scrape, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/express.mdx
+++ b/quickstarts/express.mdx
@@ -1,0 +1,82 @@
+---
+title: "Express"
+description: "Use Firecrawl with Express to build web scraping and search APIs."
+og:title: "Express Quickstart | Firecrawl"
+og:description: "Use Firecrawl with Express to build web scraping and search APIs."
+---
+
+## Prerequisites
+
+- Node.js 18+
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Setup
+
+```bash
+npm install express @mendable/firecrawl-js
+```
+
+Add your API key to `.env`:
+
+```bash
+FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+## Create a scrape endpoint
+
+```javascript
+import express from "express";
+import Firecrawl from "@mendable/firecrawl-js";
+
+const app = express();
+app.use(express.json());
+
+const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+
+app.post("/scrape", async (req, res) => {
+  try {
+    const { url } = req.body;
+    const result = await firecrawl.scrape(url);
+    res.json(result);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+app.post("/search", async (req, res) => {
+  try {
+    const { query } = req.body;
+    const results = await firecrawl.search(query, { limit: 5 });
+    res.json(results);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+app.listen(3000, () => console.log("Server running on port 3000"));
+```
+
+## Test it
+
+```bash
+curl -X POST http://localhost:3000/scrape \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}'
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Node SDK reference" icon="node" href="/sdks/node">
+    Full SDK reference with crawl, map, batch scrape, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/express.mdx
+++ b/quickstarts/express.mdx
@@ -22,7 +22,7 @@ Add your API key to `.env`:
 FIRECRAWL_API_KEY=fc-YOUR-API-KEY
 ```
 
-## Create a scrape endpoint
+## Search the web
 
 ```javascript
 import express from "express";
@@ -32,16 +32,6 @@ const app = express();
 app.use(express.json());
 
 const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
-
-app.post("/scrape", async (req, res) => {
-  try {
-    const { url } = req.body;
-    const result = await firecrawl.scrape(url);
-    res.json(result);
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-});
 
 app.post("/search", async (req, res) => {
   try {
@@ -56,12 +46,50 @@ app.post("/search", async (req, res) => {
 app.listen(3000, () => console.log("Server running on port 3000"));
 ```
 
+## Scrape a page
+
+```javascript
+app.post("/scrape", async (req, res) => {
+  try {
+    const { url } = req.body;
+    const result = await firecrawl.scrape(url);
+    res.json(result);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+```
+
+## Interact with a page
+
+Use interact to control a live browser session — click buttons, fill forms, and extract dynamic content.
+
+```javascript
+app.post("/interact", async (req, res) => {
+  try {
+    const { url } = req.body;
+
+    const result = await firecrawl.scrape(url, { formats: ['markdown'] });
+    const scrapeId = result.metadata?.scrapeId;
+
+    await firecrawl.interact(scrapeId, { prompt: 'Search for iPhone 16 Pro Max' });
+    const response = await firecrawl.interact(scrapeId, { prompt: 'Click on the first result and tell me the price' });
+
+    await firecrawl.stopInteraction(scrapeId);
+
+    res.json({ output: response.output });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+```
+
 ## Test it
 
 ```bash
-curl -X POST http://localhost:3000/scrape \
+curl -X POST http://localhost:3000/search \
   -H "Content-Type: application/json" \
-  -d '{"url": "https://example.com"}'
+  -d '{"query": "firecrawl web scraping"}'
 ```
 
 ## Next steps

--- a/quickstarts/fastapi.mdx
+++ b/quickstarts/fastapi.mdx
@@ -36,13 +36,24 @@ app = FastAPI()
 firecrawl = Firecrawl(api_key=os.environ["FIRECRAWL_API_KEY"])
 
 
+class SearchRequest(BaseModel):
+    query: str
+    limit: int = 5
+
+
 class ScrapeRequest(BaseModel):
     url: str
 
 
-class SearchRequest(BaseModel):
-    query: str
-    limit: int = 5
+class InteractRequest(BaseModel):
+    scrape_id: str
+    prompt: str
+
+
+@app.post("/search")
+async def search(req: SearchRequest):
+    results = firecrawl.search(req.query, limit=req.limit)
+    return [{"title": r.title, "url": r.url} for r in results]
 
 
 @app.post("/scrape")
@@ -51,10 +62,22 @@ async def scrape(req: ScrapeRequest):
     return {"markdown": result.markdown, "metadata": result.metadata}
 
 
-@app.post("/search")
-async def search(req: SearchRequest):
-    results = firecrawl.search(req.query, limit=req.limit)
-    return [{"title": r.title, "url": r.url} for r in results]
+@app.post("/interact/start")
+async def interact_start(req: ScrapeRequest):
+    result = firecrawl.scrape(req.url, formats=["markdown"])
+    return {"scrape_id": result.metadata.scrape_id}
+
+
+@app.post("/interact")
+async def interact(req: InteractRequest):
+    response = firecrawl.interact(req.scrape_id, prompt=req.prompt)
+    return {"output": response.output}
+
+
+@app.post("/interact/stop")
+async def interact_stop(req: InteractRequest):
+    firecrawl.stop_interaction(req.scrape_id)
+    return {"status": "stopped"}
 ```
 
 ## Run it
@@ -66,9 +89,20 @@ uvicorn main:app --reload
 ## Test it
 
 ```bash
+# Search the web
+curl -X POST http://localhost:8000/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "firecrawl web scraping", "limit": 5}'
+
+# Scrape a page
 curl -X POST http://localhost:8000/scrape \
   -H "Content-Type: application/json" \
   -d '{"url": "https://example.com"}'
+
+# Start an interactive session, then send prompts
+curl -X POST http://localhost:8000/interact/start \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://www.amazon.com"}'
 ```
 
 FastAPI auto-generates interactive docs at `http://localhost:8000/docs`.

--- a/quickstarts/fastapi.mdx
+++ b/quickstarts/fastapi.mdx
@@ -53,7 +53,7 @@ class InteractRequest(BaseModel):
 @app.post("/search")
 async def search(req: SearchRequest):
     results = firecrawl.search(req.query, limit=req.limit)
-    return [{"title": r.title, "url": r.url} for r in results]
+    return [{"title": r.title, "url": r.url} for r in results.web]
 
 
 @app.post("/scrape")

--- a/quickstarts/fastapi.mdx
+++ b/quickstarts/fastapi.mdx
@@ -1,0 +1,106 @@
+---
+title: "FastAPI"
+description: "Use Firecrawl with FastAPI to build async web scraping and search APIs in Python."
+og:title: "FastAPI Quickstart | Firecrawl"
+og:description: "Use Firecrawl with FastAPI to build async web scraping and search APIs in Python."
+---
+
+## Prerequisites
+
+- Python 3.8+
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Setup
+
+```bash
+pip install fastapi uvicorn firecrawl-py
+```
+
+Add your API key to `.env`:
+
+```bash
+FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+## Create the API
+
+Create `main.py`:
+
+```python
+import os
+from fastapi import FastAPI
+from pydantic import BaseModel
+from firecrawl import Firecrawl
+
+app = FastAPI()
+firecrawl = Firecrawl(api_key=os.environ["FIRECRAWL_API_KEY"])
+
+
+class ScrapeRequest(BaseModel):
+    url: str
+
+
+class SearchRequest(BaseModel):
+    query: str
+    limit: int = 5
+
+
+@app.post("/scrape")
+async def scrape(req: ScrapeRequest):
+    result = firecrawl.scrape(req.url)
+    return {"markdown": result.markdown, "metadata": result.metadata}
+
+
+@app.post("/search")
+async def search(req: SearchRequest):
+    results = firecrawl.search(req.query, limit=req.limit)
+    return [{"title": r.title, "url": r.url} for r in results]
+```
+
+## Run it
+
+```bash
+uvicorn main:app --reload
+```
+
+## Test it
+
+```bash
+curl -X POST http://localhost:8000/scrape \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}'
+```
+
+FastAPI auto-generates interactive docs at `http://localhost:8000/docs`.
+
+## Async variant
+
+For better concurrency under load, use `AsyncFirecrawl`:
+
+```python
+from firecrawl import AsyncFirecrawl
+
+async_firecrawl = AsyncFirecrawl(api_key=os.environ["FIRECRAWL_API_KEY"])
+
+@app.post("/scrape-async")
+async def scrape_async(req: ScrapeRequest):
+    result = await async_firecrawl.scrape(req.url)
+    return {"markdown": result.markdown}
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Python SDK reference" icon="python" href="/sdks/python">
+    Full SDK reference with crawl, map, async, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/fastify.mdx
+++ b/quickstarts/fastify.mdx
@@ -22,7 +22,7 @@ Add your API key to `.env`:
 FIRECRAWL_API_KEY=fc-YOUR-API-KEY
 ```
 
-## Create a scrape server
+## Search the web
 
 ```javascript
 import Fastify from "fastify";
@@ -31,17 +31,41 @@ import Firecrawl from "@mendable/firecrawl-js";
 const fastify = Fastify({ logger: true });
 const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
 
-fastify.post("/scrape", async (request) => {
-  const { url } = request.body;
-  return firecrawl.scrape(url);
-});
-
 fastify.post("/search", async (request) => {
   const { query } = request.body;
   return firecrawl.search(query, { limit: 5 });
 });
 
 fastify.listen({ port: 3000 });
+```
+
+## Scrape a page
+
+```javascript
+fastify.post("/scrape", async (request) => {
+  const { url } = request.body;
+  return firecrawl.scrape(url);
+});
+```
+
+## Interact with a page
+
+Use interact to control a live browser session — click buttons, fill forms, and extract dynamic content.
+
+```javascript
+fastify.post("/interact", async (request) => {
+  const { url } = request.body;
+
+  const result = await firecrawl.scrape(url, { formats: ['markdown'] });
+  const scrapeId = result.metadata?.scrapeId;
+
+  await firecrawl.interact(scrapeId, { prompt: 'Search for iPhone 16 Pro Max' });
+  const response = await firecrawl.interact(scrapeId, { prompt: 'Click on the first result and tell me the price' });
+
+  await firecrawl.stopInteraction(scrapeId);
+
+  return { output: response.output };
+});
 ```
 
 ## As a Fastify plugin
@@ -63,18 +87,18 @@ Register the plugin, then use `fastify.firecrawl` in any route:
 ```javascript
 fastify.register(firecrawlPlugin);
 
-fastify.post("/scrape", async function (request) {
-  const { url } = request.body;
-  return this.firecrawl.scrape(url);
+fastify.post("/search", async function (request) {
+  const { query } = request.body;
+  return this.firecrawl.search(query, { limit: 5 });
 });
 ```
 
 ## Test it
 
 ```bash
-curl -X POST http://localhost:3000/scrape \
+curl -X POST http://localhost:3000/search \
   -H "Content-Type: application/json" \
-  -d '{"url": "https://example.com"}'
+  -d '{"query": "firecrawl web scraping"}'
 ```
 
 ## Next steps

--- a/quickstarts/fastify.mdx
+++ b/quickstarts/fastify.mdx
@@ -1,0 +1,95 @@
+---
+title: "Fastify"
+description: "Use Firecrawl with Fastify to build high-performance web scraping and search APIs."
+og:title: "Fastify Quickstart | Firecrawl"
+og:description: "Use Firecrawl with Fastify to build high-performance web scraping and search APIs."
+---
+
+## Prerequisites
+
+- Node.js 18+
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Setup
+
+```bash
+npm install fastify @mendable/firecrawl-js
+```
+
+Add your API key to `.env`:
+
+```bash
+FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+## Create a scrape server
+
+```javascript
+import Fastify from "fastify";
+import Firecrawl from "@mendable/firecrawl-js";
+
+const fastify = Fastify({ logger: true });
+const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+
+fastify.post("/scrape", async (request) => {
+  const { url } = request.body;
+  return firecrawl.scrape(url);
+});
+
+fastify.post("/search", async (request) => {
+  const { query } = request.body;
+  return firecrawl.search(query, { limit: 5 });
+});
+
+fastify.listen({ port: 3000 });
+```
+
+## As a Fastify plugin
+
+Encapsulate the client in a plugin for reuse across routes:
+
+```javascript
+import fp from "fastify-plugin";
+import Firecrawl from "@mendable/firecrawl-js";
+
+export default fp(async function firecrawlPlugin(fastify) {
+  const client = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+  fastify.decorate("firecrawl", client);
+});
+```
+
+Register the plugin, then use `fastify.firecrawl` in any route:
+
+```javascript
+fastify.register(firecrawlPlugin);
+
+fastify.post("/scrape", async function (request) {
+  const { url } = request.body;
+  return this.firecrawl.scrape(url);
+});
+```
+
+## Test it
+
+```bash
+curl -X POST http://localhost:3000/scrape \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}'
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Node SDK reference" icon="node" href="/sdks/node">
+    Full SDK reference with crawl, map, batch scrape, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/flask.mdx
+++ b/quickstarts/flask.mdx
@@ -35,6 +35,13 @@ app = Flask(__name__)
 firecrawl = Firecrawl(api_key=os.environ["FIRECRAWL_API_KEY"])
 
 
+@app.post("/search")
+def search():
+    data = request.get_json()
+    results = firecrawl.search(data["query"], limit=data.get("limit", 5))
+    return jsonify([{"title": r.title, "url": r.url} for r in results])
+
+
 @app.post("/scrape")
 def scrape():
     data = request.get_json()
@@ -42,11 +49,25 @@ def scrape():
     return jsonify(markdown=result.markdown, metadata=result.metadata)
 
 
-@app.post("/search")
-def search():
+@app.post("/interact/start")
+def interact_start():
     data = request.get_json()
-    results = firecrawl.search(data["query"], limit=data.get("limit", 5))
-    return jsonify([{"title": r.title, "url": r.url} for r in results])
+    result = firecrawl.scrape(data["url"], formats=["markdown"])
+    return jsonify(scrape_id=result.metadata.scrape_id)
+
+
+@app.post("/interact")
+def interact():
+    data = request.get_json()
+    response = firecrawl.interact(data["scrape_id"], prompt=data["prompt"])
+    return jsonify(output=response.output)
+
+
+@app.post("/interact/stop")
+def interact_stop():
+    data = request.get_json()
+    firecrawl.stop_interaction(data["scrape_id"])
+    return jsonify(status="stopped")
 
 
 if __name__ == "__main__":
@@ -62,9 +83,20 @@ flask run
 ## Test it
 
 ```bash
+# Search the web
+curl -X POST http://localhost:5000/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "firecrawl web scraping", "limit": 5}'
+
+# Scrape a page
 curl -X POST http://localhost:5000/scrape \
   -H "Content-Type: application/json" \
   -d '{"url": "https://example.com"}'
+
+# Start an interactive session
+curl -X POST http://localhost:5000/interact/start \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://www.amazon.com"}'
 ```
 
 ## Next steps

--- a/quickstarts/flask.mdx
+++ b/quickstarts/flask.mdx
@@ -39,7 +39,7 @@ firecrawl = Firecrawl(api_key=os.environ["FIRECRAWL_API_KEY"])
 def search():
     data = request.get_json()
     results = firecrawl.search(data["query"], limit=data.get("limit", 5))
-    return jsonify([{"title": r.title, "url": r.url} for r in results])
+    return jsonify([{"title": r.title, "url": r.url} for r in results.web])
 
 
 @app.post("/scrape")

--- a/quickstarts/flask.mdx
+++ b/quickstarts/flask.mdx
@@ -1,0 +1,85 @@
+---
+title: "Flask"
+description: "Use Firecrawl with Flask to build web scraping and search APIs in Python."
+og:title: "Flask Quickstart | Firecrawl"
+og:description: "Use Firecrawl with Flask to build web scraping and search APIs in Python."
+---
+
+## Prerequisites
+
+- Python 3.8+
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Setup
+
+```bash
+pip install flask firecrawl-py
+```
+
+Add your API key to `.env`:
+
+```bash
+FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+## Create the app
+
+Create `app.py`:
+
+```python
+import os
+from flask import Flask, request, jsonify
+from firecrawl import Firecrawl
+
+app = Flask(__name__)
+firecrawl = Firecrawl(api_key=os.environ["FIRECRAWL_API_KEY"])
+
+
+@app.post("/scrape")
+def scrape():
+    data = request.get_json()
+    result = firecrawl.scrape(data["url"])
+    return jsonify(markdown=result.markdown, metadata=result.metadata)
+
+
+@app.post("/search")
+def search():
+    data = request.get_json()
+    results = firecrawl.search(data["query"], limit=data.get("limit", 5))
+    return jsonify([{"title": r.title, "url": r.url} for r in results])
+
+
+if __name__ == "__main__":
+    app.run(debug=True)
+```
+
+## Run it
+
+```bash
+flask run
+```
+
+## Test it
+
+```bash
+curl -X POST http://localhost:5000/scrape \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}'
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Python SDK reference" icon="python" href="/sdks/python">
+    Full SDK reference with crawl, map, async, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/go.mdx
+++ b/quickstarts/go.mdx
@@ -1,0 +1,159 @@
+---
+title: "Go"
+description: "Get started with Firecrawl in Go. Scrape, search, and interact with web data using the REST API."
+og:title: "Go Quickstart | Firecrawl"
+og:description: "Get started with Firecrawl in Go. Scrape, search, and interact with web data using the REST API."
+---
+
+## Prerequisites
+
+- Go 1.21+
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Scrape a page
+
+Firecrawl works with Go through the REST API. Use `net/http` to make requests directly.
+
+```go
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+func main() {
+	apiKey := os.Getenv("FIRECRAWL_API_KEY")
+
+	body, _ := json.Marshal(map[string]string{
+		"url": "https://example.com",
+	})
+
+	req, _ := http.NewRequest("POST", "https://api.firecrawl.dev/v2/scrape", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "request failed: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	result, _ := io.ReadAll(resp.Body)
+	fmt.Println(string(result))
+}
+```
+
+<Accordion title="Example response">
+```json
+{
+  "success": true,
+  "data": {
+    "markdown": "# Example Domain\n\nThis domain is for use in illustrative examples...",
+    "metadata": {
+      "title": "Example Domain",
+      "sourceURL": "https://example.com"
+    }
+  }
+}
+```
+</Accordion>
+
+## Search the web
+
+```go
+body, _ := json.Marshal(map[string]interface{}{
+	"query": "firecrawl web scraping",
+	"limit": 5,
+})
+
+req, _ := http.NewRequest("POST", "https://api.firecrawl.dev/v2/search", bytes.NewReader(body))
+req.Header.Set("Authorization", "Bearer "+apiKey)
+req.Header.Set("Content-Type", "application/json")
+
+resp, err := http.DefaultClient.Do(req)
+if err != nil {
+	fmt.Fprintf(os.Stderr, "request failed: %v\n", err)
+	os.Exit(1)
+}
+defer resp.Body.Close()
+
+result, _ := io.ReadAll(resp.Body)
+fmt.Println(string(result))
+```
+
+## Reusable helper
+
+For repeated use, wrap the API in a small helper:
+
+```go
+type FirecrawlClient struct {
+	APIKey  string
+	BaseURL string
+	Client  *http.Client
+}
+
+func NewFirecrawlClient(apiKey string) *FirecrawlClient {
+	return &FirecrawlClient{
+		APIKey:  apiKey,
+		BaseURL: "https://api.firecrawl.dev/v2",
+		Client:  &http.Client{},
+	}
+}
+
+func (fc *FirecrawlClient) post(endpoint string, payload interface{}) ([]byte, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", fc.BaseURL+endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+fc.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := fc.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return io.ReadAll(resp.Body)
+}
+
+func (fc *FirecrawlClient) Scrape(url string) ([]byte, error) {
+	return fc.post("/scrape", map[string]string{"url": url})
+}
+
+func (fc *FirecrawlClient) Search(query string, limit int) ([]byte, error) {
+	return fc.post("/search", map[string]interface{}{"query": query, "limit": limit})
+}
+```
+
+<Note>
+A [community Go SDK](https://github.com/mendableai/firecrawl-go) is available for the v1 API. See the [Go SDK docs](/sdks/go) for details.
+</Note>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
+    Complete REST API documentation
+  </Card>
+  <Card title="Go SDK (v1)" icon="golang" href="/sdks/go">
+    Community Go SDK for the v1 API
+  </Card>
+</CardGroup>

--- a/quickstarts/go.mdx
+++ b/quickstarts/go.mdx
@@ -54,13 +54,15 @@ func main() {
 ```json
 {
   "success": true,
-  "data": [
-    {
-      "url": "https://docs.firecrawl.dev",
-      "title": "Firecrawl Documentation",
-      "markdown": "# Firecrawl\n\nFirecrawl is a web scraping API..."
-    }
-  ]
+  "data": {
+    "web": [
+      {
+        "url": "https://docs.firecrawl.dev",
+        "title": "Firecrawl Documentation",
+        "markdown": "# Firecrawl\n\nFirecrawl is a web scraping API..."
+      }
+    ]
+  }
 }
 ```
 </Accordion>

--- a/quickstarts/go.mdx
+++ b/quickstarts/go.mdx
@@ -10,7 +10,7 @@ og:description: "Get started with Firecrawl in Go. Scrape, search, and interact 
 - Go 1.21+
 - A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
 
-## Scrape a page
+## Search the web
 
 Firecrawl works with Go through the REST API. Use `net/http` to make requests directly.
 
@@ -29,11 +29,12 @@ import (
 func main() {
 	apiKey := os.Getenv("FIRECRAWL_API_KEY")
 
-	body, _ := json.Marshal(map[string]string{
-		"url": "https://example.com",
+	body, _ := json.Marshal(map[string]interface{}{
+		"query": "firecrawl web scraping",
+		"limit": 5,
 	})
 
-	req, _ := http.NewRequest("POST", "https://api.firecrawl.dev/v2/scrape", bytes.NewReader(body))
+	req, _ := http.NewRequest("POST", "https://api.firecrawl.dev/v2/search", bytes.NewReader(body))
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -53,26 +54,25 @@ func main() {
 ```json
 {
   "success": true,
-  "data": {
-    "markdown": "# Example Domain\n\nThis domain is for use in illustrative examples...",
-    "metadata": {
-      "title": "Example Domain",
-      "sourceURL": "https://example.com"
+  "data": [
+    {
+      "url": "https://docs.firecrawl.dev",
+      "title": "Firecrawl Documentation",
+      "markdown": "# Firecrawl\n\nFirecrawl is a web scraping API..."
     }
-  }
+  ]
 }
 ```
 </Accordion>
 
-## Search the web
+## Scrape a page
 
 ```go
-body, _ := json.Marshal(map[string]interface{}{
-	"query": "firecrawl web scraping",
-	"limit": 5,
+body, _ := json.Marshal(map[string]string{
+	"url": "https://example.com",
 })
 
-req, _ := http.NewRequest("POST", "https://api.firecrawl.dev/v2/search", bytes.NewReader(body))
+req, _ := http.NewRequest("POST", "https://api.firecrawl.dev/v2/scrape", bytes.NewReader(body))
 req.Header.Set("Authorization", "Bearer "+apiKey)
 req.Header.Set("Content-Type", "application/json")
 
@@ -85,6 +85,112 @@ defer resp.Body.Close()
 
 result, _ := io.ReadAll(resp.Body)
 fmt.Println(string(result))
+```
+
+<Accordion title="Example response">
+```json
+{
+  "success": true,
+  "data": {
+    "markdown": "# Example Domain\n\nThis domain is for use in illustrative examples...",
+    "metadata": {
+      "title": "Example Domain",
+      "sourceURL": "https://example.com"
+    }
+  }
+}
+```
+</Accordion>
+
+## Interact with a page
+
+Start a browser session, interact with the page using natural-language prompts, then close the session.
+
+### Step 1 — Scrape to start a session
+
+```go
+body, _ := json.Marshal(map[string]interface{}{
+	"url":     "https://www.amazon.com",
+	"formats": []string{"markdown"},
+})
+
+req, _ := http.NewRequest("POST", "https://api.firecrawl.dev/v2/scrape", bytes.NewReader(body))
+req.Header.Set("Authorization", "Bearer "+apiKey)
+req.Header.Set("Content-Type", "application/json")
+
+resp, err := http.DefaultClient.Do(req)
+if err != nil {
+	fmt.Fprintf(os.Stderr, "request failed: %v\n", err)
+	os.Exit(1)
+}
+defer resp.Body.Close()
+
+var scrapeResult map[string]interface{}
+json.NewDecoder(resp.Body).Decode(&scrapeResult)
+
+data := scrapeResult["data"].(map[string]interface{})
+metadata := data["metadata"].(map[string]interface{})
+scrapeId := metadata["scrapeId"].(string)
+fmt.Println("scrapeId:", scrapeId)
+```
+
+### Step 2 — Send interactions
+
+```go
+// Search for a product
+interactBody, _ := json.Marshal(map[string]string{
+	"prompt": "Search for iPhone 16 Pro Max",
+})
+
+interactURL := fmt.Sprintf("https://api.firecrawl.dev/v2/scrape/%s/interact", scrapeId)
+req, _ = http.NewRequest("POST", interactURL, bytes.NewReader(interactBody))
+req.Header.Set("Authorization", "Bearer "+apiKey)
+req.Header.Set("Content-Type", "application/json")
+
+resp, err = http.DefaultClient.Do(req)
+if err != nil {
+	fmt.Fprintf(os.Stderr, "interact failed: %v\n", err)
+	os.Exit(1)
+}
+defer resp.Body.Close()
+
+result, _ := io.ReadAll(resp.Body)
+fmt.Println(string(result))
+
+// Click on the first result
+interactBody, _ = json.Marshal(map[string]string{
+	"prompt": "Click on the first result and tell me the price",
+})
+
+req, _ = http.NewRequest("POST", interactURL, bytes.NewReader(interactBody))
+req.Header.Set("Authorization", "Bearer "+apiKey)
+req.Header.Set("Content-Type", "application/json")
+
+resp, err = http.DefaultClient.Do(req)
+if err != nil {
+	fmt.Fprintf(os.Stderr, "interact failed: %v\n", err)
+	os.Exit(1)
+}
+defer resp.Body.Close()
+
+result, _ = io.ReadAll(resp.Body)
+fmt.Println(string(result))
+```
+
+### Step 3 — Stop the session
+
+```go
+req, _ = http.NewRequest("DELETE", interactURL, nil)
+req.Header.Set("Authorization", "Bearer "+apiKey)
+
+resp, err = http.DefaultClient.Do(req)
+if err != nil {
+	fmt.Fprintf(os.Stderr, "delete failed: %v\n", err)
+	os.Exit(1)
+}
+defer resp.Body.Close()
+
+fmt.Println("Session stopped")
 ```
 
 ## Reusable helper
@@ -144,16 +250,16 @@ A [community Go SDK](https://github.com/mendableai/firecrawl-go) is available fo
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
-    All scrape options including formats, actions, and proxies
-  </Card>
   <Card title="Search docs" icon="magnifying-glass" href="/features/search">
     Search the web and get full page content
   </Card>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
   <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
     Complete REST API documentation
-  </Card>
-  <Card title="Go SDK (v1)" icon="golang" href="/sdks/go">
-    Community Go SDK for the v1 API
   </Card>
 </CardGroup>

--- a/quickstarts/hono.mdx
+++ b/quickstarts/hono.mdx
@@ -1,0 +1,85 @@
+---
+title: "Hono"
+description: "Use Firecrawl with Hono to build lightweight web scraping and search APIs that run anywhere."
+og:title: "Hono Quickstart | Firecrawl"
+og:description: "Use Firecrawl with Hono to build lightweight web scraping and search APIs that run anywhere."
+---
+
+## Prerequisites
+
+- Node.js 18+, Bun, or Deno
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Setup
+
+```bash
+npm install hono @mendable/firecrawl-js
+```
+
+Add your API key to `.env`:
+
+```bash
+FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+## Create a scrape server
+
+```typescript
+import { Hono } from "hono";
+import Firecrawl from "@mendable/firecrawl-js";
+
+const app = new Hono();
+const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+
+app.post("/scrape", async (c) => {
+  const { url } = await c.req.json();
+  const result = await firecrawl.scrape(url);
+  return c.json(result);
+});
+
+app.post("/search", async (c) => {
+  const { query } = await c.req.json();
+  const results = await firecrawl.search(query, { limit: 5 });
+  return c.json(results);
+});
+
+export default app;
+```
+
+## Deploy anywhere
+
+Hono runs on multiple runtimes. For Cloudflare Workers, pass the API key from the environment binding:
+
+```typescript
+import { Hono } from "hono";
+import Firecrawl from "@mendable/firecrawl-js";
+
+type Bindings = { FIRECRAWL_API_KEY: string };
+const app = new Hono<{ Bindings: Bindings }>();
+
+app.post("/scrape", async (c) => {
+  const firecrawl = new Firecrawl({ apiKey: c.env.FIRECRAWL_API_KEY });
+  const { url } = await c.req.json();
+  const result = await firecrawl.scrape(url);
+  return c.json(result);
+});
+
+export default app;
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Node SDK reference" icon="node" href="/sdks/node">
+    Full SDK reference with crawl, map, batch scrape, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/hono.mdx
+++ b/quickstarts/hono.mdx
@@ -22,7 +22,7 @@ Add your API key to `.env`:
 FIRECRAWL_API_KEY=fc-YOUR-API-KEY
 ```
 
-## Create a scrape server
+## Search the web
 
 ```typescript
 import { Hono } from "hono";
@@ -31,12 +31,6 @@ import Firecrawl from "@mendable/firecrawl-js";
 const app = new Hono();
 const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
 
-app.post("/scrape", async (c) => {
-  const { url } = await c.req.json();
-  const result = await firecrawl.scrape(url);
-  return c.json(result);
-});
-
 app.post("/search", async (c) => {
   const { query } = await c.req.json();
   const results = await firecrawl.search(query, { limit: 5 });
@@ -44,6 +38,36 @@ app.post("/search", async (c) => {
 });
 
 export default app;
+```
+
+## Scrape a page
+
+```typescript
+app.post("/scrape", async (c) => {
+  const { url } = await c.req.json();
+  const result = await firecrawl.scrape(url);
+  return c.json(result);
+});
+```
+
+## Interact with a page
+
+Use interact to control a live browser session — click buttons, fill forms, and extract dynamic content.
+
+```typescript
+app.post("/interact", async (c) => {
+  const { url } = await c.req.json();
+
+  const result = await firecrawl.scrape(url, { formats: ['markdown'] });
+  const scrapeId = result.metadata?.scrapeId;
+
+  await firecrawl.interact(scrapeId, { prompt: 'Search for iPhone 16 Pro Max' });
+  const response = await firecrawl.interact(scrapeId, { prompt: 'Click on the first result and tell me the price' });
+
+  await firecrawl.stopInteraction(scrapeId);
+
+  return c.json({ output: response.output });
+});
 ```
 
 ## Deploy anywhere
@@ -57,11 +81,11 @@ import Firecrawl from "@mendable/firecrawl-js";
 type Bindings = { FIRECRAWL_API_KEY: string };
 const app = new Hono<{ Bindings: Bindings }>();
 
-app.post("/scrape", async (c) => {
+app.post("/search", async (c) => {
   const firecrawl = new Firecrawl({ apiKey: c.env.FIRECRAWL_API_KEY });
-  const { url } = await c.req.json();
-  const result = await firecrawl.scrape(url);
-  return c.json(result);
+  const { query } = await c.req.json();
+  const results = await firecrawl.search(query, { limit: 5 });
+  return c.json(results);
 });
 
 export default app;

--- a/quickstarts/java.mdx
+++ b/quickstarts/java.mdx
@@ -81,7 +81,7 @@ System.out.println(doc.getMarkdown());
 
 ## Interact with a page
 
-Open a browser session, perform actions with natural-language prompts, and close it when done:
+Open a browser session, run Playwright code against it, and close it when done:
 
 ```java
 import com.firecrawl.models.ScrapeOptions;
@@ -92,12 +92,11 @@ Document doc = client.scrape("https://www.amazon.com",
     ScrapeOptions.builder().formats(List.of((Object) "markdown")).build());
 String scrapeId = (String) doc.getMetadata().get("scrapeId");
 
-client.interact(scrapeId, "Search for iPhone 16 Pro Max", "node", 60);
-BrowserExecuteResponse response = client.interact(scrapeId,
-    "Click on the first result and tell me the price", "node", 60);
-System.out.println(response.getStdout());
+BrowserExecuteResponse run = client.interact(scrapeId,
+    "const title = await page.title(); console.log(title);");
+System.out.println(run.getStdout());
 
-client.stopInteraction(scrapeId);
+client.stopInteractiveBrowser(scrapeId);
 ```
 
 ## Environment variable

--- a/quickstarts/java.mdx
+++ b/quickstarts/java.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Java"
-description: "Get started with Firecrawl in Java. Scrape, search, and interact with web data using the official SDK."
+description: "Get started with Firecrawl in Java. Search, scrape, and interact with web data using the official SDK."
 og:title: "Java Quickstart | Firecrawl"
-og:description: "Get started with Firecrawl in Java. Scrape, search, and interact with web data using the official SDK."
+og:description: "Get started with Firecrawl in Java. Search, scrape, and interact with web data using the official SDK."
 ---
 
 ## Prerequisites
@@ -31,11 +31,12 @@ dependencies {
   </Tab>
 </Tabs>
 
-## Scrape a page
+## Search the web
 
 ```java
 import com.firecrawl.client.FirecrawlClient;
-import com.firecrawl.models.Document;
+import com.firecrawl.models.SearchData;
+import com.firecrawl.models.SearchOptions;
 
 public class Main {
     public static void main(String[] args) {
@@ -43,10 +44,27 @@ public class Main {
             .apiKey("fc-YOUR-API-KEY")
             .build();
 
-        Document doc = client.scrape("https://example.com");
-        System.out.println(doc.getMarkdown());
+        SearchData results = client.search(
+            "firecrawl web scraping",
+            SearchOptions.builder().limit(5).build()
+        );
+
+        if (results.getWeb() != null) {
+            for (var result : results.getWeb()) {
+                System.out.println(result.get("title") + " - " + result.get("url"));
+            }
+        }
     }
 }
+```
+
+## Scrape a page
+
+```java
+import com.firecrawl.models.Document;
+
+Document doc = client.scrape("https://example.com");
+System.out.println(doc.getMarkdown());
 ```
 
 <Accordion title="Example response">
@@ -61,49 +79,25 @@ public class Main {
 ```
 </Accordion>
 
-## Search the web
+## Interact with a page
+
+Open a browser session, perform actions with natural-language prompts, and close it when done:
 
 ```java
-import com.firecrawl.models.SearchData;
-import com.firecrawl.models.SearchOptions;
-
-SearchData results = client.search(
-    "firecrawl web scraping",
-    SearchOptions.builder().limit(5).build()
-);
-
-if (results.getWeb() != null) {
-    for (var result : results.getWeb()) {
-        System.out.println(result.get("title") + " - " + result.get("url"));
-    }
-}
-```
-
-## Extract structured data
-
-```java
-import com.firecrawl.models.JsonFormat;
 import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.BrowserExecuteResponse;
 import java.util.List;
-import java.util.Map;
 
-Document doc = client.scrape(
-    "https://example.com",
-    ScrapeOptions.builder()
-        .formats(List.of((Object) JsonFormat.builder()
-            .prompt("Extract the page title and description")
-            .schema(Map.of(
-                "type", "object",
-                "properties", Map.of(
-                    "title", Map.of("type", "string"),
-                    "description", Map.of("type", "string")
-                )
-            ))
-            .build()))
-        .build()
-);
+Document doc = client.scrape("https://www.amazon.com",
+    ScrapeOptions.builder().formats(List.of((Object) "markdown")).build());
+String scrapeId = (String) doc.getMetadata().get("scrapeId");
 
-System.out.println(doc.getJson());
+client.interact(scrapeId, "Search for iPhone 16 Pro Max", "node", 60);
+BrowserExecuteResponse response = client.interact(scrapeId,
+    "Click on the first result and tell me the price", "node", 60);
+System.out.println(response.getStdout());
+
+client.stopInteraction(scrapeId);
 ```
 
 ## Environment variable
@@ -121,11 +115,11 @@ FirecrawlClient client = FirecrawlClient.fromEnv();
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
-    All scrape options including formats, actions, and proxies
-  </Card>
   <Card title="Search docs" icon="magnifying-glass" href="/features/search">
     Search the web and get full page content
+  </Card>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
   </Card>
   <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
     Click, fill forms, and extract dynamic content

--- a/quickstarts/java.mdx
+++ b/quickstarts/java.mdx
@@ -1,0 +1,136 @@
+---
+title: "Java"
+description: "Get started with Firecrawl in Java. Scrape, search, and interact with web data using the official SDK."
+og:title: "Java Quickstart | Firecrawl"
+og:description: "Get started with Firecrawl in Java. Scrape, search, and interact with web data using the official SDK."
+---
+
+## Prerequisites
+
+- Java 11+
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Install the SDK
+
+<Tabs>
+  <Tab title="Gradle (Kotlin DSL)">
+```kotlin
+dependencies {
+    implementation("com.firecrawl:firecrawl-java:1.2.0")
+}
+```
+  </Tab>
+  <Tab title="Maven">
+```xml
+<dependency>
+    <groupId>com.firecrawl</groupId>
+    <artifactId>firecrawl-java</artifactId>
+    <version>1.2.0</version>
+</dependency>
+```
+  </Tab>
+</Tabs>
+
+## Scrape a page
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+import com.firecrawl.models.Document;
+
+public class Main {
+    public static void main(String[] args) {
+        FirecrawlClient client = FirecrawlClient.builder()
+            .apiKey("fc-YOUR-API-KEY")
+            .build();
+
+        Document doc = client.scrape("https://example.com");
+        System.out.println(doc.getMarkdown());
+    }
+}
+```
+
+<Accordion title="Example response">
+```json
+{
+  "markdown": "# Example Domain\n\nThis domain is for use in illustrative examples...",
+  "metadata": {
+    "title": "Example Domain",
+    "sourceURL": "https://example.com"
+  }
+}
+```
+</Accordion>
+
+## Search the web
+
+```java
+import com.firecrawl.models.SearchData;
+import com.firecrawl.models.SearchOptions;
+
+SearchData results = client.search(
+    "firecrawl web scraping",
+    SearchOptions.builder().limit(5).build()
+);
+
+if (results.getWeb() != null) {
+    for (var result : results.getWeb()) {
+        System.out.println(result.get("title") + " - " + result.get("url"));
+    }
+}
+```
+
+## Extract structured data
+
+```java
+import com.firecrawl.models.JsonFormat;
+import com.firecrawl.models.ScrapeOptions;
+import java.util.List;
+import java.util.Map;
+
+Document doc = client.scrape(
+    "https://example.com",
+    ScrapeOptions.builder()
+        .formats(List.of((Object) JsonFormat.builder()
+            .prompt("Extract the page title and description")
+            .schema(Map.of(
+                "type", "object",
+                "properties", Map.of(
+                    "title", Map.of("type", "string"),
+                    "description", Map.of("type", "string")
+                )
+            ))
+            .build()))
+        .build()
+);
+
+System.out.println(doc.getJson());
+```
+
+## Environment variable
+
+Instead of passing `apiKey` directly, set the `FIRECRAWL_API_KEY` environment variable:
+
+```bash
+export FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+```java
+FirecrawlClient client = FirecrawlClient.fromEnv();
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Java SDK reference" icon="java" href="/sdks/java">
+    Full SDK reference with crawl, map, batch scrape, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/laravel.mdx
+++ b/quickstarts/laravel.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Laravel"
-description: "Use Firecrawl with Laravel to scrape, search, and interact with web data using the REST API."
+description: "Use Firecrawl with Laravel to search, scrape, and interact with web data using the REST API."
 og:title: "Laravel Quickstart | Firecrawl"
-og:description: "Use Firecrawl with Laravel to scrape, search, and interact with web data using the REST API."
+og:description: "Use Firecrawl with Laravel to search, scrape, and interact with web data using the REST API."
 ---
 
 ## Prerequisites
@@ -49,14 +49,6 @@ class FirecrawlService
         $this->baseUrl = config('services.firecrawl.base_url');
     }
 
-    public function scrape(string $url, array $options = []): array
-    {
-        $response = Http::withToken($this->apiKey)
-            ->post("{$this->baseUrl}/scrape", array_merge(['url' => $url], $options));
-
-        return $response->json();
-    }
-
     public function search(string $query, int $limit = 5): array
     {
         $response = Http::withToken($this->apiKey)
@@ -66,6 +58,42 @@ class FirecrawlService
             ]);
 
         return $response->json();
+    }
+
+    public function scrape(string $url, array $options = []): array
+    {
+        $response = Http::withToken($this->apiKey)
+            ->post("{$this->baseUrl}/scrape", array_merge(['url' => $url], $options));
+
+        return $response->json();
+    }
+
+    public function interact(string $url, string $prompt, ?string $followUp = null): array
+    {
+        // 1. Scrape to open a browser session
+        $scrapeResult = $this->scrape($url, ['formats' => ['markdown']]);
+        $scrapeId = $scrapeResult['data']['metadata']['scrapeId'];
+
+        // 2. Send first prompt
+        Http::withToken($this->apiKey)
+            ->post("{$this->baseUrl}/scrape/{$scrapeId}/interact", [
+                'prompt' => $prompt,
+            ]);
+
+        // 3. Send follow-up prompt
+        $result = null;
+        if ($followUp) {
+            $result = Http::withToken($this->apiKey)
+                ->post("{$this->baseUrl}/scrape/{$scrapeId}/interact", [
+                    'prompt' => $followUp,
+                ])->json();
+        }
+
+        // 4. Close the session
+        Http::withToken($this->apiKey)
+            ->delete("{$this->baseUrl}/scrape/{$scrapeId}/interact");
+
+        return $result ?? $scrapeResult;
     }
 }
 ```
@@ -86,17 +114,32 @@ class FirecrawlController extends Controller
 {
     public function __construct(private FirecrawlService $firecrawl) {}
 
+    public function search(Request $request)
+    {
+        $validated = $request->validate(['query' => 'required|string']);
+        return response()->json(
+            $this->firecrawl->search($validated['query'], $request->input('limit', 5))
+        );
+    }
+
     public function scrape(Request $request)
     {
         $validated = $request->validate(['url' => 'required|url']);
         return response()->json($this->firecrawl->scrape($validated['url']));
     }
 
-    public function search(Request $request)
+    public function interact(Request $request)
     {
-        $validated = $request->validate(['query' => 'required|string']);
+        $validated = $request->validate([
+            'url' => 'required|url',
+            'prompt' => 'required|string',
+        ]);
         return response()->json(
-            $this->firecrawl->search($validated['query'], $request->input('limit', 5))
+            $this->firecrawl->interact(
+                $validated['url'],
+                $validated['prompt'],
+                $request->input('followUp')
+            )
         );
     }
 }
@@ -109,8 +152,9 @@ In `routes/api.php`:
 ```php
 use App\Http\Controllers\FirecrawlController;
 
-Route::post('/scrape', [FirecrawlController::class, 'scrape']);
 Route::post('/search', [FirecrawlController::class, 'search']);
+Route::post('/scrape', [FirecrawlController::class, 'scrape']);
+Route::post('/interact', [FirecrawlController::class, 'interact']);
 ```
 
 ## Test it
@@ -118,53 +162,35 @@ Route::post('/search', [FirecrawlController::class, 'search']);
 ```bash
 php artisan serve
 
+# Search the web
+curl -X POST http://localhost:8000/api/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "firecrawl web scraping"}'
+
+# Scrape a page
 curl -X POST http://localhost:8000/api/scrape \
   -H "Content-Type: application/json" \
   -d '{"url": "https://example.com"}'
-```
 
-## Artisan command
-
-Use Firecrawl from the command line. Create a command with `php artisan make:command ScrapeUrl`:
-
-```php
-<?php
-
-namespace App\Console\Commands;
-
-use App\Services\FirecrawlService;
-use Illuminate\Console\Command;
-
-class ScrapeUrl extends Command
-{
-    protected $signature = 'scrape:url {url}';
-    protected $description = 'Scrape a URL and output markdown';
-
-    public function handle(FirecrawlService $firecrawl): void
-    {
-        $result = $firecrawl->scrape($this->argument('url'));
-        $this->line($result['data']['markdown'] ?? 'No content');
-    }
-}
-```
-
-```bash
-php artisan scrape:url https://example.com
+# Interact with a page
+curl -X POST http://localhost:8000/api/interact \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://www.amazon.com", "prompt": "Search for iPhone 16 Pro Max", "followUp": "Click on the first result and tell me the price"}'
 ```
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
-    All scrape options including formats, actions, and proxies
-  </Card>
   <Card title="Search docs" icon="magnifying-glass" href="/features/search">
     Search the web and get full page content
   </Card>
-  <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
-    Complete REST API documentation
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
   </Card>
   <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
     Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
+    Complete REST API documentation
   </Card>
 </CardGroup>

--- a/quickstarts/laravel.mdx
+++ b/quickstarts/laravel.mdx
@@ -1,0 +1,170 @@
+---
+title: "Laravel"
+description: "Use Firecrawl with Laravel to scrape, search, and interact with web data using the REST API."
+og:title: "Laravel Quickstart | Firecrawl"
+og:description: "Use Firecrawl with Laravel to scrape, search, and interact with web data using the REST API."
+---
+
+## Prerequisites
+
+- Laravel 10+ project
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Configuration
+
+Add your API key to `.env`:
+
+```bash
+FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+Add the config entry to `config/services.php`:
+
+```php
+'firecrawl' => [
+    'api_key' => env('FIRECRAWL_API_KEY'),
+    'base_url' => env('FIRECRAWL_API_URL', 'https://api.firecrawl.dev/v2'),
+],
+```
+
+## Create a service class
+
+Create `app/Services/FirecrawlService.php`:
+
+```php
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+
+class FirecrawlService
+{
+    private string $apiKey;
+    private string $baseUrl;
+
+    public function __construct()
+    {
+        $this->apiKey = config('services.firecrawl.api_key');
+        $this->baseUrl = config('services.firecrawl.base_url');
+    }
+
+    public function scrape(string $url, array $options = []): array
+    {
+        $response = Http::withToken($this->apiKey)
+            ->post("{$this->baseUrl}/scrape", array_merge(['url' => $url], $options));
+
+        return $response->json();
+    }
+
+    public function search(string $query, int $limit = 5): array
+    {
+        $response = Http::withToken($this->apiKey)
+            ->post("{$this->baseUrl}/search", [
+                'query' => $query,
+                'limit' => $limit,
+            ]);
+
+        return $response->json();
+    }
+}
+```
+
+## Create a controller
+
+Create `app/Http/Controllers/FirecrawlController.php`:
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\FirecrawlService;
+use Illuminate\Http\Request;
+
+class FirecrawlController extends Controller
+{
+    public function __construct(private FirecrawlService $firecrawl) {}
+
+    public function scrape(Request $request)
+    {
+        $validated = $request->validate(['url' => 'required|url']);
+        return response()->json($this->firecrawl->scrape($validated['url']));
+    }
+
+    public function search(Request $request)
+    {
+        $validated = $request->validate(['query' => 'required|string']);
+        return response()->json(
+            $this->firecrawl->search($validated['query'], $request->input('limit', 5))
+        );
+    }
+}
+```
+
+## Register routes
+
+In `routes/api.php`:
+
+```php
+use App\Http\Controllers\FirecrawlController;
+
+Route::post('/scrape', [FirecrawlController::class, 'scrape']);
+Route::post('/search', [FirecrawlController::class, 'search']);
+```
+
+## Test it
+
+```bash
+php artisan serve
+
+curl -X POST http://localhost:8000/api/scrape \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}'
+```
+
+## Artisan command
+
+Use Firecrawl from the command line. Create a command with `php artisan make:command ScrapeUrl`:
+
+```php
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\FirecrawlService;
+use Illuminate\Console\Command;
+
+class ScrapeUrl extends Command
+{
+    protected $signature = 'scrape:url {url}';
+    protected $description = 'Scrape a URL and output markdown';
+
+    public function handle(FirecrawlService $firecrawl): void
+    {
+        $result = $firecrawl->scrape($this->argument('url'));
+        $this->line($result['data']['markdown'] ?? 'No content');
+    }
+}
+```
+
+```bash
+php artisan scrape:url https://example.com
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
+    Complete REST API documentation
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+</CardGroup>

--- a/quickstarts/nestjs.mdx
+++ b/quickstarts/nestjs.mdx
@@ -38,12 +38,26 @@ export class FirecrawlService {
     this.client = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
   }
 
+  async search(query: string, limit = 5) {
+    return this.client.search(query, { limit });
+  }
+
   async scrape(url: string) {
     return this.client.scrape(url);
   }
 
-  async search(query: string, limit = 5) {
-    return this.client.search(query, { limit });
+  async interact(url: string, prompts: string[]) {
+    const result = await this.client.scrape(url, { formats: ['markdown'] });
+    const scrapeId = result.metadata?.scrapeId;
+
+    const responses = [];
+    for (const prompt of prompts) {
+      const response = await this.client.interact(scrapeId, { prompt });
+      responses.push(response);
+    }
+
+    await this.client.stopInteraction(scrapeId);
+    return responses;
   }
 }
 ```
@@ -60,14 +74,19 @@ import { FirecrawlService } from "./firecrawl.service";
 export class FirecrawlController {
   constructor(private readonly firecrawlService: FirecrawlService) {}
 
+  @Post("search")
+  async search(@Body("query") query: string) {
+    return this.firecrawlService.search(query);
+  }
+
   @Post("scrape")
   async scrape(@Body("url") url: string) {
     return this.firecrawlService.scrape(url);
   }
 
-  @Post("search")
-  async search(@Body("query") query: string) {
-    return this.firecrawlService.search(query);
+  @Post("interact")
+  async interact(@Body("url") url: string, @Body("prompts") prompts: string[]) {
+    return this.firecrawlService.interact(url, prompts);
   }
 }
 ```
@@ -94,9 +113,9 @@ Import `FirecrawlModule` in your `AppModule`.
 ## Test it
 
 ```bash
-curl -X POST http://localhost:3000/firecrawl/scrape \
+curl -X POST http://localhost:3000/firecrawl/search \
   -H "Content-Type: application/json" \
-  -d '{"url": "https://example.com"}'
+  -d '{"query": "firecrawl web scraping"}'
 ```
 
 ## Next steps

--- a/quickstarts/nestjs.mdx
+++ b/quickstarts/nestjs.mdx
@@ -1,0 +1,117 @@
+---
+title: "NestJS"
+description: "Use Firecrawl with NestJS to build structured web scraping and search services."
+og:title: "NestJS Quickstart | Firecrawl"
+og:description: "Use Firecrawl with NestJS to build structured web scraping and search services."
+---
+
+## Prerequisites
+
+- NestJS project (`@nestjs/cli`)
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Install the SDK
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+Add your API key to `.env`:
+
+```bash
+FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+## Create a Firecrawl service
+
+Create `src/firecrawl/firecrawl.service.ts`:
+
+```typescript
+import { Injectable } from "@nestjs/common";
+import Firecrawl from "@mendable/firecrawl-js";
+
+@Injectable()
+export class FirecrawlService {
+  private readonly client: Firecrawl;
+
+  constructor() {
+    this.client = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+  }
+
+  async scrape(url: string) {
+    return this.client.scrape(url);
+  }
+
+  async search(query: string, limit = 5) {
+    return this.client.search(query, { limit });
+  }
+}
+```
+
+## Create a controller
+
+Create `src/firecrawl/firecrawl.controller.ts`:
+
+```typescript
+import { Body, Controller, Post } from "@nestjs/common";
+import { FirecrawlService } from "./firecrawl.service";
+
+@Controller("firecrawl")
+export class FirecrawlController {
+  constructor(private readonly firecrawlService: FirecrawlService) {}
+
+  @Post("scrape")
+  async scrape(@Body("url") url: string) {
+    return this.firecrawlService.scrape(url);
+  }
+
+  @Post("search")
+  async search(@Body("query") query: string) {
+    return this.firecrawlService.search(query);
+  }
+}
+```
+
+## Register the module
+
+Create `src/firecrawl/firecrawl.module.ts`:
+
+```typescript
+import { Module } from "@nestjs/common";
+import { FirecrawlService } from "./firecrawl.service";
+import { FirecrawlController } from "./firecrawl.controller";
+
+@Module({
+  providers: [FirecrawlService],
+  controllers: [FirecrawlController],
+  exports: [FirecrawlService],
+})
+export class FirecrawlModule {}
+```
+
+Import `FirecrawlModule` in your `AppModule`.
+
+## Test it
+
+```bash
+curl -X POST http://localhost:3000/firecrawl/scrape \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}'
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Node SDK reference" icon="node" href="/sdks/node">
+    Full SDK reference with crawl, map, batch scrape, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/nextjs.mdx
+++ b/quickstarts/nextjs.mdx
@@ -1,0 +1,107 @@
+---
+title: "Next.js"
+description: "Use Firecrawl with Next.js to scrape, search, and interact with web data in your React application."
+og:title: "Next.js Quickstart | Firecrawl"
+og:description: "Use Firecrawl with Next.js to scrape, search, and interact with web data in your React application."
+---
+
+## Prerequisites
+
+- Next.js 14+ project (App Router)
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Install the SDK
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+## Set your API key
+
+Add your API key to `.env.local`:
+
+```bash
+FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+## Server-side scraping
+
+Use Firecrawl in a Server Component or Route Handler. The SDK should only run server-side since it requires your API key.
+
+### Route Handler
+
+Create `app/api/scrape/route.ts`:
+
+```typescript
+import { NextResponse } from "next/server";
+import Firecrawl from "@mendable/firecrawl-js";
+
+const app = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+
+export async function POST(request: Request) {
+  const { url } = await request.json();
+  const result = await app.scrape(url);
+
+  return NextResponse.json(result);
+}
+```
+
+### Server Component
+
+Fetch data directly in a Server Component at `app/page.tsx`:
+
+```tsx
+import Firecrawl from "@mendable/firecrawl-js";
+
+const app = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+
+export default async function Page() {
+  const result = await app.scrape("https://example.com");
+
+  return (
+    <article>
+      <h1>Scraped Content</h1>
+      <pre>{result.markdown}</pre>
+    </article>
+  );
+}
+```
+
+## Server Action
+
+Create `app/actions.ts` for use from Client Components:
+
+```typescript
+"use server";
+
+import Firecrawl from "@mendable/firecrawl-js";
+
+const app = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+
+export async function scrapeUrl(url: string) {
+  const result = await app.scrape(url);
+  return result.markdown;
+}
+
+export async function searchWeb(query: string) {
+  const results = await app.search(query, { limit: 5 });
+  return results.map((r) => ({ title: r.title, url: r.url }));
+}
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Node SDK reference" icon="node" href="/sdks/node">
+    Full SDK reference with crawl, map, batch scrape, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/nextjs.mdx
+++ b/quickstarts/nextjs.mdx
@@ -24,9 +24,46 @@ Add your API key to `.env.local`:
 FIRECRAWL_API_KEY=fc-YOUR-API-KEY
 ```
 
-## Server-side scraping
+## Search the web
 
-Use Firecrawl in a Server Component or Route Handler. The SDK should only run server-side since it requires your API key.
+The SDK should only run server-side since it requires your API key.
+
+### Route Handler
+
+Create `app/api/search/route.ts`:
+
+```typescript
+import { NextResponse } from "next/server";
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+
+export async function POST(request: Request) {
+  const { query } = await request.json();
+  const results = await firecrawl.search(query, { limit: 5 });
+
+  return NextResponse.json(results);
+}
+```
+
+### Server Action
+
+Create `app/actions.ts` for use from Client Components:
+
+```typescript
+"use server";
+
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+
+export async function searchWeb(query: string) {
+  const results = await firecrawl.search(query, { limit: 5 });
+  return results.map((r) => ({ title: r.title, url: r.url }));
+}
+```
+
+## Scrape a page
 
 ### Route Handler
 
@@ -36,11 +73,11 @@ Create `app/api/scrape/route.ts`:
 import { NextResponse } from "next/server";
 import Firecrawl from "@mendable/firecrawl-js";
 
-const app = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
 
 export async function POST(request: Request) {
   const { url } = await request.json();
-  const result = await app.scrape(url);
+  const result = await firecrawl.scrape(url);
 
   return NextResponse.json(result);
 }
@@ -53,10 +90,10 @@ Fetch data directly in a Server Component at `app/page.tsx`:
 ```tsx
 import Firecrawl from "@mendable/firecrawl-js";
 
-const app = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
 
 export default async function Page() {
-  const result = await app.scrape("https://example.com");
+  const result = await firecrawl.scrape("https://example.com");
 
   return (
     <article>
@@ -67,25 +104,32 @@ export default async function Page() {
 }
 ```
 
-## Server Action
+## Interact with a page
 
-Create `app/actions.ts` for use from Client Components:
+Use interact to control a live browser session — click buttons, fill forms, and extract dynamic content.
+
+### Route Handler
+
+Create `app/api/interact/route.ts`:
 
 ```typescript
-"use server";
-
+import { NextResponse } from "next/server";
 import Firecrawl from "@mendable/firecrawl-js";
 
-const app = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
 
-export async function scrapeUrl(url: string) {
-  const result = await app.scrape(url);
-  return result.markdown;
-}
+export async function POST(request: Request) {
+  const { url, prompts } = await request.json();
 
-export async function searchWeb(query: string) {
-  const results = await app.search(query, { limit: 5 });
-  return results.map((r) => ({ title: r.title, url: r.url }));
+  const result = await firecrawl.scrape(url, { formats: ['markdown'] });
+  const scrapeId = result.metadata?.scrapeId;
+
+  await firecrawl.interact(scrapeId, { prompt: 'Search for iPhone 16 Pro Max' });
+  const response = await firecrawl.interact(scrapeId, { prompt: 'Click on the first result and tell me the price' });
+
+  await firecrawl.stopInteraction(scrapeId);
+
+  return NextResponse.json({ output: response.output });
 }
 ```
 

--- a/quickstarts/nextjs.mdx
+++ b/quickstarts/nextjs.mdx
@@ -59,7 +59,7 @@ const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
 
 export async function searchWeb(query: string) {
   const results = await firecrawl.search(query, { limit: 5 });
-  return results.map((r) => ({ title: r.title, url: r.url }));
+  return (results.web || []).map((r) => ({ title: r.title, url: r.url }));
 }
 ```
 

--- a/quickstarts/nodejs.mdx
+++ b/quickstarts/nodejs.mdx
@@ -1,0 +1,98 @@
+---
+title: "Node.js"
+description: "Get started with Firecrawl in Node.js. Scrape, search, and interact with web data using the official SDK."
+og:title: "Node.js Quickstart | Firecrawl"
+og:description: "Get started with Firecrawl in Node.js. Scrape, search, and interact with web data using the official SDK."
+---
+
+## Prerequisites
+
+- Node.js 18+
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Install the SDK
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+## Scrape a page
+
+```javascript
+import Firecrawl from '@mendable/firecrawl-js';
+
+const app = new Firecrawl({ apiKey: "fc-YOUR-API-KEY" });
+const result = await app.scrape("https://example.com");
+
+console.log(result.markdown);
+```
+
+<Accordion title="Example response">
+```json
+{
+  "markdown": "# Example Domain\n\nThis domain is for use in illustrative examples...",
+  "metadata": {
+    "title": "Example Domain",
+    "sourceURL": "https://example.com"
+  }
+}
+```
+</Accordion>
+
+## Search the web
+
+```javascript
+const results = await app.search("firecrawl web scraping");
+
+for (const result of results) {
+  console.log(result.title, result.url);
+}
+```
+
+## Extract structured data
+
+```javascript
+const data = await app.scrape("https://example.com", {
+  formats: [{
+    type: "json",
+    schema: {
+      type: "object",
+      properties: {
+        title: { type: "string" },
+        description: { type: "string" }
+      }
+    }
+  }]
+});
+
+console.log(data.json);
+```
+
+## Environment variable
+
+Instead of passing `apiKey` directly, set the `FIRECRAWL_API_KEY` environment variable:
+
+```bash
+export FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+```javascript
+const app = new Firecrawl();
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Node SDK reference" icon="node" href="/sdks/node">
+    Full SDK reference with crawl, map, batch scrape, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/nodejs.mdx
+++ b/quickstarts/nodejs.mdx
@@ -16,12 +16,34 @@ og:description: "Get started with Firecrawl in Node.js. Scrape, search, and inte
 npm install @mendable/firecrawl-js
 ```
 
-## Scrape a page
+## Environment variable
+
+Instead of passing `apiKey` directly, set the `FIRECRAWL_API_KEY` environment variable:
+
+```bash
+export FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+```javascript
+const app = new Firecrawl();
+```
+
+## Search the web
 
 ```javascript
 import Firecrawl from '@mendable/firecrawl-js';
 
 const app = new Firecrawl({ apiKey: "fc-YOUR-API-KEY" });
+const results = await app.search("firecrawl web scraping", { limit: 5 });
+
+for (const result of results) {
+  console.log(result.title, result.url);
+}
+```
+
+## Scrape a page
+
+```javascript
 const result = await app.scrape("https://example.com");
 
 console.log(result.markdown);
@@ -39,45 +61,19 @@ console.log(result.markdown);
 ```
 </Accordion>
 
-## Search the web
+## Interact with a page
+
+Use interact to control a live browser session — click buttons, fill forms, and extract dynamic content.
 
 ```javascript
-const results = await app.search("firecrawl web scraping");
+const result = await app.scrape('https://www.amazon.com', { formats: ['markdown'] });
+const scrapeId = result.metadata?.scrapeId;
 
-for (const result of results) {
-  console.log(result.title, result.url);
-}
-```
+await app.interact(scrapeId, { prompt: 'Search for iPhone 16 Pro Max' });
+const response = await app.interact(scrapeId, { prompt: 'Click on the first result and tell me the price' });
+console.log(response.output);
 
-## Extract structured data
-
-```javascript
-const data = await app.scrape("https://example.com", {
-  formats: [{
-    type: "json",
-    schema: {
-      type: "object",
-      properties: {
-        title: { type: "string" },
-        description: { type: "string" }
-      }
-    }
-  }]
-});
-
-console.log(data.json);
-```
-
-## Environment variable
-
-Instead of passing `apiKey` directly, set the `FIRECRAWL_API_KEY` environment variable:
-
-```bash
-export FIRECRAWL_API_KEY=fc-YOUR-API-KEY
-```
-
-```javascript
-const app = new Firecrawl();
+await app.stopInteraction(scrapeId);
 ```
 
 ## Next steps

--- a/quickstarts/nodejs.mdx
+++ b/quickstarts/nodejs.mdx
@@ -36,7 +36,7 @@ import Firecrawl from '@mendable/firecrawl-js';
 const app = new Firecrawl({ apiKey: "fc-YOUR-API-KEY" });
 const results = await app.search("firecrawl web scraping", { limit: 5 });
 
-for (const result of results) {
+for (const result of results.web) {
   console.log(result.title, result.url);
 }
 ```

--- a/quickstarts/nuxt.mdx
+++ b/quickstarts/nuxt.mdx
@@ -1,0 +1,97 @@
+---
+title: "Nuxt"
+description: "Use Firecrawl with Nuxt to scrape, search, and interact with web data in your Vue application."
+og:title: "Nuxt Quickstart | Firecrawl"
+og:description: "Use Firecrawl with Nuxt to scrape, search, and interact with web data in your Vue application."
+---
+
+## Prerequisites
+
+- Nuxt 3+ project
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Install the SDK
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+Add your API key to `.env`:
+
+```bash
+FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+## Server API route
+
+Create `server/api/scrape.post.ts`:
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+});
+
+export default defineEventHandler(async (event) => {
+  const { url } = await readBody(event);
+  const result = await firecrawl.scrape(url);
+  return result;
+});
+```
+
+Create `server/api/search.post.ts`:
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+});
+
+export default defineEventHandler(async (event) => {
+  const { query } = await readBody(event);
+  const results = await firecrawl.search(query, { limit: 5 });
+  return results;
+});
+```
+
+## Use from a page
+
+Call the API route from a Vue component using `useFetch`:
+
+```vue
+<script setup>
+const url = ref("https://example.com");
+const { data, execute } = useFetch("/api/scrape", {
+  method: "POST",
+  body: { url },
+  immediate: false,
+});
+</script>
+
+<template>
+  <div>
+    <input v-model="url" placeholder="Enter URL" />
+    <button @click="execute()">Scrape</button>
+    <pre v-if="data">{{ data.markdown }}</pre>
+  </div>
+</template>
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Node SDK reference" icon="node" href="/sdks/node">
+    Full SDK reference with crawl, map, batch scrape, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/nuxt.mdx
+++ b/quickstarts/nuxt.mdx
@@ -22,23 +22,7 @@ Add your API key to `.env`:
 FIRECRAWL_API_KEY=fc-YOUR-API-KEY
 ```
 
-## Server API route
-
-Create `server/api/scrape.post.ts`:
-
-```typescript
-import Firecrawl from "@mendable/firecrawl-js";
-
-const firecrawl = new Firecrawl({
-  apiKey: process.env.FIRECRAWL_API_KEY,
-});
-
-export default defineEventHandler(async (event) => {
-  const { url } = await readBody(event);
-  const result = await firecrawl.scrape(url);
-  return result;
-});
-```
+## Search the web
 
 Create `server/api/search.post.ts`:
 
@@ -56,9 +40,50 @@ export default defineEventHandler(async (event) => {
 });
 ```
 
-## Use from a page
+Call it from a Vue component:
 
-Call the API route from a Vue component using `useFetch`:
+```vue
+<script setup>
+const query = ref("");
+const { data, execute } = useFetch("/api/search", {
+  method: "POST",
+  body: { query },
+  immediate: false,
+});
+</script>
+
+<template>
+  <div>
+    <input v-model="query" placeholder="Search the web..." />
+    <button @click="execute()">Search</button>
+    <ul v-if="data">
+      <li v-for="result in data" :key="result.url">
+        <a :href="result.url">{{ result.title }}</a>
+      </li>
+    </ul>
+  </div>
+</template>
+```
+
+## Scrape a page
+
+Create `server/api/scrape.post.ts`:
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+});
+
+export default defineEventHandler(async (event) => {
+  const { url } = await readBody(event);
+  const result = await firecrawl.scrape(url);
+  return result;
+});
+```
+
+Call it from a Vue component:
 
 ```vue
 <script setup>
@@ -77,6 +102,38 @@ const { data, execute } = useFetch("/api/scrape", {
     <pre v-if="data">{{ data.markdown }}</pre>
   </div>
 </template>
+```
+
+## Interact with a page
+
+Create `server/api/interact.post.ts`:
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+});
+
+export default defineEventHandler(async (event) => {
+  const result = await firecrawl.scrape("https://www.amazon.com", {
+    formats: ["markdown"],
+  });
+
+  const scrapeId = result.metadata?.scrapeId;
+
+  await firecrawl.interact(scrapeId, {
+    prompt: "Search for iPhone 16 Pro Max",
+  });
+
+  const response = await firecrawl.interact(scrapeId, {
+    prompt: "Click on the first result and tell me the price",
+  });
+
+  await firecrawl.stopInteraction(scrapeId);
+
+  return { output: response.output };
+});
 ```
 
 ## Next steps

--- a/quickstarts/nuxt.mdx
+++ b/quickstarts/nuxt.mdx
@@ -56,8 +56,8 @@ const { data, execute } = useFetch("/api/search", {
   <div>
     <input v-model="query" placeholder="Search the web..." />
     <button @click="execute()">Search</button>
-    <ul v-if="data">
-      <li v-for="result in data" :key="result.url">
+    <ul v-if="data?.web">
+      <li v-for="result in data.web" :key="result.url">
         <a :href="result.url">{{ result.title }}</a>
       </li>
     </ul>

--- a/quickstarts/php.mdx
+++ b/quickstarts/php.mdx
@@ -1,0 +1,155 @@
+---
+title: "PHP"
+description: "Get started with Firecrawl in PHP. Scrape, search, and interact with web data using the REST API."
+og:title: "PHP Quickstart | Firecrawl"
+og:description: "Get started with Firecrawl in PHP. Scrape, search, and interact with web data using the REST API."
+---
+
+## Prerequisites
+
+- PHP 8.0+ with cURL extension
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Scrape a page
+
+Firecrawl works with PHP through the REST API using cURL.
+
+```php
+<?php
+$apiKey = getenv('FIRECRAWL_API_KEY');
+
+$ch = curl_init('https://api.firecrawl.dev/v2/scrape');
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST => true,
+    CURLOPT_HTTPHEADER => [
+        'Authorization: Bearer ' . $apiKey,
+        'Content-Type: application/json',
+    ],
+    CURLOPT_POSTFIELDS => json_encode([
+        'url' => 'https://example.com',
+    ]),
+]);
+
+$response = curl_exec($ch);
+curl_close($ch);
+
+$data = json_decode($response, true);
+echo $data['data']['markdown'];
+```
+
+<Accordion title="Example response">
+```json
+{
+  "success": true,
+  "data": {
+    "markdown": "# Example Domain\n\nThis domain is for use in illustrative examples...",
+    "metadata": {
+      "title": "Example Domain",
+      "sourceURL": "https://example.com"
+    }
+  }
+}
+```
+</Accordion>
+
+## Search the web
+
+```php
+<?php
+$ch = curl_init('https://api.firecrawl.dev/v2/search');
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST => true,
+    CURLOPT_HTTPHEADER => [
+        'Authorization: Bearer ' . $apiKey,
+        'Content-Type: application/json',
+    ],
+    CURLOPT_POSTFIELDS => json_encode([
+        'query' => 'firecrawl web scraping',
+        'limit' => 5,
+    ]),
+]);
+
+$response = curl_exec($ch);
+curl_close($ch);
+
+$results = json_decode($response, true);
+foreach ($results['data'] as $result) {
+    echo $result['title'] . ' - ' . $result['url'] . "\n";
+}
+```
+
+## Reusable helper class
+
+For repeated use, wrap the API in a class:
+
+```php
+<?php
+class Firecrawl
+{
+    private string $apiKey;
+    private string $baseUrl = 'https://api.firecrawl.dev/v2';
+
+    public function __construct(string $apiKey)
+    {
+        $this->apiKey = $apiKey;
+    }
+
+    private function post(string $endpoint, array $payload): array
+    {
+        $ch = curl_init($this->baseUrl . $endpoint);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_POST => true,
+            CURLOPT_HTTPHEADER => [
+                'Authorization: Bearer ' . $this->apiKey,
+                'Content-Type: application/json',
+            ],
+            CURLOPT_POSTFIELDS => json_encode($payload),
+        ]);
+
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($httpCode >= 400) {
+            throw new \RuntimeException("Firecrawl API error: HTTP $httpCode");
+        }
+
+        return json_decode($response, true);
+    }
+
+    public function scrape(string $url, array $options = []): array
+    {
+        return $this->post('/scrape', array_merge(['url' => $url], $options));
+    }
+
+    public function search(string $query, int $limit = 5): array
+    {
+        return $this->post('/search', ['query' => $query, 'limit' => $limit]);
+    }
+}
+
+// Usage
+$app = new Firecrawl(getenv('FIRECRAWL_API_KEY'));
+$result = $app->scrape('https://example.com');
+echo $result['data']['markdown'];
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
+    Complete REST API documentation
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+</CardGroup>

--- a/quickstarts/php.mdx
+++ b/quickstarts/php.mdx
@@ -10,7 +10,7 @@ og:description: "Get started with Firecrawl in PHP. Scrape, search, and interact
 - PHP 8.0+ with cURL extension
 - A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
 
-## Scrape a page
+## Search the web
 
 Firecrawl works with PHP through the REST API using cURL.
 
@@ -18,6 +18,48 @@ Firecrawl works with PHP through the REST API using cURL.
 <?php
 $apiKey = getenv('FIRECRAWL_API_KEY');
 
+$ch = curl_init('https://api.firecrawl.dev/v2/search');
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST => true,
+    CURLOPT_HTTPHEADER => [
+        'Authorization: Bearer ' . $apiKey,
+        'Content-Type: application/json',
+    ],
+    CURLOPT_POSTFIELDS => json_encode([
+        'query' => 'firecrawl web scraping',
+        'limit' => 5,
+    ]),
+]);
+
+$response = curl_exec($ch);
+curl_close($ch);
+
+$results = json_decode($response, true);
+foreach ($results['data'] as $result) {
+    echo $result['title'] . ' - ' . $result['url'] . "\n";
+}
+```
+
+<Accordion title="Example response">
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "url": "https://docs.firecrawl.dev",
+      "title": "Firecrawl Documentation",
+      "markdown": "# Firecrawl\n\nFirecrawl is a web scraping API..."
+    }
+  ]
+}
+```
+</Accordion>
+
+## Scrape a page
+
+```php
+<?php
 $ch = curl_init('https://api.firecrawl.dev/v2/scrape');
 curl_setopt_array($ch, [
     CURLOPT_RETURNTRANSFER => true,
@@ -53,11 +95,15 @@ echo $data['data']['markdown'];
 ```
 </Accordion>
 
-## Search the web
+## Interact with a page
+
+Start a browser session, interact with the page using natural-language prompts, then close the session.
+
+### Step 1 — Scrape to start a session
 
 ```php
 <?php
-$ch = curl_init('https://api.firecrawl.dev/v2/search');
+$ch = curl_init('https://api.firecrawl.dev/v2/scrape');
 curl_setopt_array($ch, [
     CURLOPT_RETURNTRANSFER => true,
     CURLOPT_POST => true,
@@ -66,18 +112,77 @@ curl_setopt_array($ch, [
         'Content-Type: application/json',
     ],
     CURLOPT_POSTFIELDS => json_encode([
-        'query' => 'firecrawl web scraping',
-        'limit' => 5,
+        'url' => 'https://www.amazon.com',
+        'formats' => ['markdown'],
     ]),
 ]);
 
 $response = curl_exec($ch);
 curl_close($ch);
 
-$results = json_decode($response, true);
-foreach ($results['data'] as $result) {
-    echo $result['title'] . ' - ' . $result['url'] . "\n";
-}
+$scrapeResult = json_decode($response, true);
+$scrapeId = $scrapeResult['data']['metadata']['scrapeId'];
+echo "scrapeId: $scrapeId\n";
+```
+
+### Step 2 — Send interactions
+
+```php
+<?php
+$interactUrl = "https://api.firecrawl.dev/v2/scrape/$scrapeId/interact";
+$headers = [
+    'Authorization: Bearer ' . $apiKey,
+    'Content-Type: application/json',
+];
+
+// Search for a product
+$ch = curl_init($interactUrl);
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST => true,
+    CURLOPT_HTTPHEADER => $headers,
+    CURLOPT_POSTFIELDS => json_encode([
+        'prompt' => 'Search for iPhone 16 Pro Max',
+    ]),
+]);
+
+$response = curl_exec($ch);
+curl_close($ch);
+echo $response . "\n";
+
+// Click on the first result
+$ch = curl_init($interactUrl);
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST => true,
+    CURLOPT_HTTPHEADER => $headers,
+    CURLOPT_POSTFIELDS => json_encode([
+        'prompt' => 'Click on the first result and tell me the price',
+    ]),
+]);
+
+$response = curl_exec($ch);
+curl_close($ch);
+echo $response . "\n";
+```
+
+### Step 3 — Stop the session
+
+```php
+<?php
+$ch = curl_init($interactUrl);
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_CUSTOMREQUEST => 'DELETE',
+    CURLOPT_HTTPHEADER => [
+        'Authorization: Bearer ' . $apiKey,
+    ],
+]);
+
+curl_exec($ch);
+curl_close($ch);
+
+echo "Session stopped\n";
 ```
 
 ## Reusable helper class
@@ -140,16 +245,16 @@ echo $result['data']['markdown'];
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
-    All scrape options including formats, actions, and proxies
-  </Card>
   <Card title="Search docs" icon="magnifying-glass" href="/features/search">
     Search the web and get full page content
   </Card>
-  <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
-    Complete REST API documentation
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
   </Card>
   <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
     Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
+    Complete REST API documentation
   </Card>
 </CardGroup>

--- a/quickstarts/php.mdx
+++ b/quickstarts/php.mdx
@@ -36,7 +36,7 @@ $response = curl_exec($ch);
 curl_close($ch);
 
 $results = json_decode($response, true);
-foreach ($results['data'] as $result) {
+foreach ($results['data']['web'] as $result) {
     echo $result['title'] . ' - ' . $result['url'] . "\n";
 }
 ```
@@ -45,13 +45,15 @@ foreach ($results['data'] as $result) {
 ```json
 {
   "success": true,
-  "data": [
-    {
-      "url": "https://docs.firecrawl.dev",
-      "title": "Firecrawl Documentation",
-      "markdown": "# Firecrawl\n\nFirecrawl is a web scraping API..."
-    }
-  ]
+  "data": {
+    "web": [
+      {
+        "url": "https://docs.firecrawl.dev",
+        "title": "Firecrawl Documentation",
+        "markdown": "# Firecrawl\n\nFirecrawl is a web scraping API..."
+      }
+    ]
+  }
 }
 ```
 </Accordion>

--- a/quickstarts/python.mdx
+++ b/quickstarts/python.mdx
@@ -1,0 +1,95 @@
+---
+title: "Python"
+description: "Get started with Firecrawl in Python. Scrape, search, and interact with web data using the official SDK."
+og:title: "Python Quickstart | Firecrawl"
+og:description: "Get started with Firecrawl in Python. Scrape, search, and interact with web data using the official SDK."
+---
+
+## Prerequisites
+
+- Python 3.8+
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Install the SDK
+
+```bash
+pip install firecrawl-py
+```
+
+## Scrape a page
+
+```python
+from firecrawl import Firecrawl
+
+app = Firecrawl(api_key="fc-YOUR-API-KEY")
+result = app.scrape("https://example.com")
+
+print(result.markdown)
+```
+
+<Accordion title="Example response">
+```json
+{
+  "markdown": "# Example Domain\n\nThis domain is for use in illustrative examples...",
+  "metadata": {
+    "title": "Example Domain",
+    "sourceURL": "https://example.com"
+  }
+}
+```
+</Accordion>
+
+## Search the web
+
+```python
+results = app.search("firecrawl web scraping")
+
+for result in results:
+    print(result.title, result.url)
+```
+
+## Extract structured data
+
+```python
+data = app.scrape("https://example.com", formats=[{
+    "type": "json",
+    "schema": {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string"},
+            "description": {"type": "string"}
+        }
+    }
+}])
+
+print(data.json)
+```
+
+## Environment variable
+
+Instead of passing `api_key` directly, set the `FIRECRAWL_API_KEY` environment variable:
+
+```bash
+export FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+```python
+app = Firecrawl()
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Python SDK reference" icon="python" href="/sdks/python">
+    Full SDK reference with crawl, map, async, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/python.mdx
+++ b/quickstarts/python.mdx
@@ -16,14 +16,22 @@ og:description: "Get started with Firecrawl in Python. Scrape, search, and inter
 pip install firecrawl-py
 ```
 
-## Scrape a page
+## Search the web
 
 ```python
 from firecrawl import Firecrawl
 
 app = Firecrawl(api_key="fc-YOUR-API-KEY")
-result = app.scrape("https://example.com")
+results = app.search("firecrawl web scraping", limit=5)
 
+for result in results:
+    print(result.title, result.url)
+```
+
+## Scrape a page
+
+```python
+result = app.scrape("https://example.com")
 print(result.markdown)
 ```
 
@@ -39,30 +47,19 @@ print(result.markdown)
 ```
 </Accordion>
 
-## Search the web
+## Interact with a page
+
+Use Interact to control a live browser session — click buttons, fill forms, and extract dynamic content.
 
 ```python
-results = app.search("firecrawl web scraping")
+result = app.scrape("https://www.amazon.com", formats=["markdown"])
+scrape_id = result.metadata.scrape_id
 
-for result in results:
-    print(result.title, result.url)
-```
+app.interact(scrape_id, prompt="Search for iPhone 16 Pro Max")
+response = app.interact(scrape_id, prompt="Click on the first result and tell me the price")
+print(response.output)
 
-## Extract structured data
-
-```python
-data = app.scrape("https://example.com", formats=[{
-    "type": "json",
-    "schema": {
-        "type": "object",
-        "properties": {
-            "title": {"type": "string"},
-            "description": {"type": "string"}
-        }
-    }
-}])
-
-print(data.json)
+app.stop_interaction(scrape_id)
 ```
 
 ## Environment variable

--- a/quickstarts/python.mdx
+++ b/quickstarts/python.mdx
@@ -24,7 +24,7 @@ from firecrawl import Firecrawl
 app = Firecrawl(api_key="fc-YOUR-API-KEY")
 results = app.search("firecrawl web scraping", limit=5)
 
-for result in results:
+for result in results.web:
     print(result.title, result.url)
 ```
 

--- a/quickstarts/rails.mdx
+++ b/quickstarts/rails.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Rails"
-description: "Use Firecrawl with Ruby on Rails to scrape, search, and interact with web data using the REST API."
+description: "Use Firecrawl with Ruby on Rails to search, scrape, and interact with web data using the REST API."
 og:title: "Rails Quickstart | Firecrawl"
-og:description: "Use Firecrawl with Ruby on Rails to scrape, search, and interact with web data using the REST API."
+og:description: "Use Firecrawl with Ruby on Rails to search, scrape, and interact with web data using the REST API."
 ---
 
 ## Prerequisites
@@ -34,12 +34,32 @@ class FirecrawlService
     @api_key = api_key
   end
 
+  def search(query, limit: 5)
+    post("/search", { query: query, limit: limit })
+  end
+
   def scrape(url, **options)
     post("/scrape", { url: url }.merge(options))
   end
 
-  def search(query, limit: 5)
-    post("/search", { query: query, limit: limit })
+  def interact(url, prompt, follow_up: nil)
+    # 1. Scrape to open a browser session
+    scrape_result = scrape(url, formats: ["markdown"])
+    scrape_id = scrape_result.dig("data", "metadata", "scrapeId")
+
+    # 2. Send first prompt
+    post("/scrape/#{scrape_id}/interact", { prompt: prompt })
+
+    # 3. Send follow-up prompt
+    result = nil
+    if follow_up
+      result = post("/scrape/#{scrape_id}/interact", { prompt: follow_up })
+    end
+
+    # 4. Close the session
+    delete("/scrape/#{scrape_id}/interact")
+
+    result || scrape_result
   end
 
   private
@@ -57,6 +77,16 @@ class FirecrawlService
 
     JSON.parse(response.body)
   end
+
+  def delete(endpoint)
+    uri = URI("#{BASE_URL}#{endpoint}")
+    request = Net::HTTP::Delete.new(uri)
+    request["Authorization"] = "Bearer #{@api_key}"
+
+    Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+      http.request(request)
+    end
+  end
 end
 ```
 
@@ -65,7 +95,7 @@ end
 Generate a controller:
 
 ```bash
-rails generate controller Firecrawl scrape search --skip-routes
+rails generate controller Firecrawl search scrape interact --skip-routes
 ```
 
 Edit `app/controllers/firecrawl_controller.rb`:
@@ -74,15 +104,25 @@ Edit `app/controllers/firecrawl_controller.rb`:
 class FirecrawlController < ApplicationController
   skip_before_action :verify_authenticity_token
 
+  def search
+    service = FirecrawlService.new
+    result = service.search(params.require(:query), limit: params.fetch(:limit, 5).to_i)
+    render json: result
+  end
+
   def scrape
     service = FirecrawlService.new
     result = service.scrape(params.require(:url))
     render json: result
   end
 
-  def search
+  def interact
     service = FirecrawlService.new
-    result = service.search(params.require(:query), limit: params.fetch(:limit, 5).to_i)
+    result = service.interact(
+      params.require(:url),
+      params.require(:prompt),
+      follow_up: params[:followUp]
+    )
     render json: result
   end
 end
@@ -94,8 +134,9 @@ In `config/routes.rb`:
 
 ```ruby
 Rails.application.routes.draw do
-  post "api/scrape", to: "firecrawl#scrape"
   post "api/search", to: "firecrawl#search"
+  post "api/scrape", to: "firecrawl#scrape"
+  post "api/interact", to: "firecrawl#interact"
 end
 ```
 
@@ -104,40 +145,35 @@ end
 ```bash
 rails server
 
+# Search the web
+curl -X POST http://localhost:3000/api/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "firecrawl web scraping"}'
+
+# Scrape a page
 curl -X POST http://localhost:3000/api/scrape \
   -H "Content-Type: application/json" \
   -d '{"url": "https://example.com"}'
-```
 
-## Rake task
-
-Use Firecrawl from the command line. Create `lib/tasks/scrape.rake`:
-
-```ruby
-desc "Scrape a URL and print the markdown"
-task :scrape, [:url] => :environment do |_t, args|
-  result = FirecrawlService.new.scrape(args[:url])
-  puts result.dig("data", "markdown")
-end
-```
-
-```bash
-rails scrape["https://example.com"]
+# Interact with a page
+curl -X POST http://localhost:3000/api/interact \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://www.amazon.com", "prompt": "Search for iPhone 16 Pro Max", "followUp": "Click on the first result and tell me the price"}'
 ```
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
-    All scrape options including formats, actions, and proxies
-  </Card>
   <Card title="Search docs" icon="magnifying-glass" href="/features/search">
     Search the web and get full page content
   </Card>
-  <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
-    Complete REST API documentation
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
   </Card>
   <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
     Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
+    Complete REST API documentation
   </Card>
 </CardGroup>

--- a/quickstarts/rails.mdx
+++ b/quickstarts/rails.mdx
@@ -1,0 +1,143 @@
+---
+title: "Rails"
+description: "Use Firecrawl with Ruby on Rails to scrape, search, and interact with web data using the REST API."
+og:title: "Rails Quickstart | Firecrawl"
+og:description: "Use Firecrawl with Ruby on Rails to scrape, search, and interact with web data using the REST API."
+---
+
+## Prerequisites
+
+- Ruby 3.0+ and Rails 7+
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Configuration
+
+Add your API key to your Rails credentials or environment:
+
+```bash
+export FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+## Create a service
+
+Create `app/services/firecrawl_service.rb`:
+
+```ruby
+require "net/http"
+require "json"
+require "uri"
+
+class FirecrawlService
+  BASE_URL = "https://api.firecrawl.dev/v2"
+
+  def initialize(api_key: ENV.fetch("FIRECRAWL_API_KEY"))
+    @api_key = api_key
+  end
+
+  def scrape(url, **options)
+    post("/scrape", { url: url }.merge(options))
+  end
+
+  def search(query, limit: 5)
+    post("/search", { query: query, limit: limit })
+  end
+
+  private
+
+  def post(endpoint, payload)
+    uri = URI("#{BASE_URL}#{endpoint}")
+    request = Net::HTTP::Post.new(uri)
+    request["Authorization"] = "Bearer #{@api_key}"
+    request["Content-Type"] = "application/json"
+    request.body = payload.to_json
+
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+      http.request(request)
+    end
+
+    JSON.parse(response.body)
+  end
+end
+```
+
+## Create a controller
+
+Generate a controller:
+
+```bash
+rails generate controller Firecrawl scrape search --skip-routes
+```
+
+Edit `app/controllers/firecrawl_controller.rb`:
+
+```ruby
+class FirecrawlController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def scrape
+    service = FirecrawlService.new
+    result = service.scrape(params.require(:url))
+    render json: result
+  end
+
+  def search
+    service = FirecrawlService.new
+    result = service.search(params.require(:query), limit: params.fetch(:limit, 5).to_i)
+    render json: result
+  end
+end
+```
+
+## Add routes
+
+In `config/routes.rb`:
+
+```ruby
+Rails.application.routes.draw do
+  post "api/scrape", to: "firecrawl#scrape"
+  post "api/search", to: "firecrawl#search"
+end
+```
+
+## Test it
+
+```bash
+rails server
+
+curl -X POST http://localhost:3000/api/scrape \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}'
+```
+
+## Rake task
+
+Use Firecrawl from the command line. Create `lib/tasks/scrape.rake`:
+
+```ruby
+desc "Scrape a URL and print the markdown"
+task :scrape, [:url] => :environment do |_t, args|
+  result = FirecrawlService.new.scrape(args[:url])
+  puts result.dig("data", "markdown")
+end
+```
+
+```bash
+rails scrape["https://example.com"]
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
+    Complete REST API documentation
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+</CardGroup>

--- a/quickstarts/remix.mdx
+++ b/quickstarts/remix.mdx
@@ -1,0 +1,109 @@
+---
+title: "Remix"
+description: "Use Firecrawl with Remix to scrape, search, and interact with web data in your full-stack React app."
+og:title: "Remix Quickstart | Firecrawl"
+og:description: "Use Firecrawl with Remix to scrape, search, and interact with web data in your full-stack React app."
+---
+
+## Prerequisites
+
+- Remix project
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Install the SDK
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+Add your API key to `.env`:
+
+```bash
+FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+## Loader (server-side data fetching)
+
+Use Firecrawl in a `loader` to fetch data at request time. Create `app/routes/scrape.tsx`:
+
+```tsx
+import { json, type LoaderFunctionArgs } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const target = url.searchParams.get("url");
+  if (!target) return json({ markdown: null });
+
+  const result = await firecrawl.scrape(target);
+  return json({ markdown: result.markdown });
+}
+
+export default function ScrapePage() {
+  const { markdown } = useLoaderData<typeof loader>();
+
+  return (
+    <div>
+      <h1>Scraped Content</h1>
+      {markdown ? <pre>{markdown}</pre> : <p>Pass ?url= to scrape a page</p>}
+    </div>
+  );
+}
+```
+
+## Action (form submission)
+
+Use Firecrawl in an `action` to handle form submissions. Create `app/routes/search.tsx`:
+
+```tsx
+import { json, type ActionFunctionArgs } from "@remix-run/node";
+import { Form, useActionData } from "@remix-run/react";
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+
+export async function action({ request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+  const query = formData.get("query") as string;
+  const results = await firecrawl.search(query, { limit: 5 });
+  return json({ results: results.map((r) => ({ title: r.title, url: r.url })) });
+}
+
+export default function SearchPage() {
+  const data = useActionData<typeof action>();
+
+  return (
+    <div>
+      <Form method="post">
+        <input name="query" placeholder="Search the web..." />
+        <button type="submit">Search</button>
+      </Form>
+      {data?.results?.map((r, i) => (
+        <div key={i}>
+          <a href={r.url}>{r.title}</a>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Node SDK reference" icon="node" href="/sdks/node">
+    Full SDK reference with crawl, map, batch scrape, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/remix.mdx
+++ b/quickstarts/remix.mdx
@@ -37,7 +37,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
   const query = formData.get("query") as string;
   const results = await firecrawl.search(query, { limit: 5 });
-  return json({ results: results.map((r) => ({ title: r.title, url: r.url })) });
+  return json({ results: (results.web || []).map((r) => ({ title: r.title, url: r.url })) });
 }
 
 export default function SearchPage() {

--- a/quickstarts/remix.mdx
+++ b/quickstarts/remix.mdx
@@ -22,39 +22,7 @@ Add your API key to `.env`:
 FIRECRAWL_API_KEY=fc-YOUR-API-KEY
 ```
 
-## Loader (server-side data fetching)
-
-Use Firecrawl in a `loader` to fetch data at request time. Create `app/routes/scrape.tsx`:
-
-```tsx
-import { json, type LoaderFunctionArgs } from "@remix-run/node";
-import { useLoaderData } from "@remix-run/react";
-import Firecrawl from "@mendable/firecrawl-js";
-
-const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
-
-export async function loader({ request }: LoaderFunctionArgs) {
-  const url = new URL(request.url);
-  const target = url.searchParams.get("url");
-  if (!target) return json({ markdown: null });
-
-  const result = await firecrawl.scrape(target);
-  return json({ markdown: result.markdown });
-}
-
-export default function ScrapePage() {
-  const { markdown } = useLoaderData<typeof loader>();
-
-  return (
-    <div>
-      <h1>Scraped Content</h1>
-      {markdown ? <pre>{markdown}</pre> : <p>Pass ?url= to scrape a page</p>}
-    </div>
-  );
-}
-```
-
-## Action (form submission)
+## Search the web
 
 Use Firecrawl in an `action` to handle form submissions. Create `app/routes/search.tsx`:
 
@@ -86,6 +54,79 @@ export default function SearchPage() {
           <a href={r.url}>{r.title}</a>
         </div>
       ))}
+    </div>
+  );
+}
+```
+
+## Scrape a page
+
+Use Firecrawl in a `loader` to fetch data at request time. Create `app/routes/scrape.tsx`:
+
+```tsx
+import { json, type LoaderFunctionArgs } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const target = url.searchParams.get("url");
+  if (!target) return json({ markdown: null });
+
+  const result = await firecrawl.scrape(target);
+  return json({ markdown: result.markdown });
+}
+
+export default function ScrapePage() {
+  const { markdown } = useLoaderData<typeof loader>();
+
+  return (
+    <div>
+      <h1>Scraped Content</h1>
+      {markdown ? <pre>{markdown}</pre> : <p>Pass ?url= to scrape a page</p>}
+    </div>
+  );
+}
+```
+
+## Interact with a page
+
+Use interact to control a live browser session — click buttons, fill forms, and extract dynamic content. Create `app/routes/interact.tsx`:
+
+```tsx
+import { json, type ActionFunctionArgs } from "@remix-run/node";
+import { Form, useActionData } from "@remix-run/react";
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+
+export async function action({ request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+  const url = formData.get("url") as string;
+
+  const result = await firecrawl.scrape(url, { formats: ['markdown'] });
+  const scrapeId = result.metadata?.scrapeId;
+
+  await firecrawl.interact(scrapeId, { prompt: 'Search for iPhone 16 Pro Max' });
+  const response = await firecrawl.interact(scrapeId, { prompt: 'Click on the first result and tell me the price' });
+
+  await firecrawl.stopInteraction(scrapeId);
+
+  return json({ output: response.output });
+}
+
+export default function InteractPage() {
+  const data = useActionData<typeof action>();
+
+  return (
+    <div>
+      <Form method="post">
+        <input name="url" placeholder="URL to interact with..." />
+        <button type="submit">Interact</button>
+      </Form>
+      {data?.output && <pre>{data.output}</pre>}
     </div>
   );
 }

--- a/quickstarts/ruby.mdx
+++ b/quickstarts/ruby.mdx
@@ -1,0 +1,113 @@
+---
+title: "Ruby"
+description: "Get started with Firecrawl in Ruby. Search, scrape, and interact with web data using the REST API."
+og:title: "Ruby Quickstart | Firecrawl"
+og:description: "Get started with Firecrawl in Ruby. Search, scrape, and interact with web data using the REST API."
+---
+
+## Prerequisites
+
+- Ruby 3.0+
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Search the web
+
+Firecrawl works with Ruby through the REST API using `net/http`.
+
+```ruby
+require "net/http"
+require "json"
+require "uri"
+
+api_key = ENV.fetch("FIRECRAWL_API_KEY")
+
+uri = URI("https://api.firecrawl.dev/v2/search")
+request = Net::HTTP::Post.new(uri)
+request["Authorization"] = "Bearer #{api_key}"
+request["Content-Type"] = "application/json"
+request.body = { query: "firecrawl web scraping", limit: 5 }.to_json
+
+response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
+results = JSON.parse(response.body)
+
+results["data"].each do |result|
+  puts "#{result['title']} - #{result['url']}"
+end
+```
+
+## Scrape a page
+
+```ruby
+uri = URI("https://api.firecrawl.dev/v2/scrape")
+request = Net::HTTP::Post.new(uri)
+request["Authorization"] = "Bearer #{api_key}"
+request["Content-Type"] = "application/json"
+request.body = { url: "https://example.com" }.to_json
+
+response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
+data = JSON.parse(response.body)
+
+puts data.dig("data", "markdown")
+```
+
+<Accordion title="Example response">
+```json
+{
+  "success": true,
+  "data": {
+    "markdown": "# Example Domain\n\nThis domain is for use in illustrative examples...",
+    "metadata": {
+      "title": "Example Domain",
+      "sourceURL": "https://example.com"
+    }
+  }
+}
+```
+</Accordion>
+
+## Interact with a page
+
+Scrape a page, then keep working with it using natural language prompts.
+
+```ruby
+uri = URI("https://api.firecrawl.dev/v2/scrape")
+request = Net::HTTP::Post.new(uri)
+request["Authorization"] = "Bearer #{api_key}"
+request["Content-Type"] = "application/json"
+request.body = { url: "https://www.amazon.com", formats: ["markdown"] }.to_json
+
+response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
+scrape_id = JSON.parse(response.body).dig("data", "metadata", "scrapeId")
+
+interact_uri = URI("https://api.firecrawl.dev/v2/scrape/#{scrape_id}/interact")
+interact_req = Net::HTTP::Post.new(interact_uri)
+interact_req["Authorization"] = "Bearer #{api_key}"
+interact_req["Content-Type"] = "application/json"
+interact_req.body = { prompt: "Search for iPhone 16 Pro Max" }.to_json
+
+interact_resp = Net::HTTP.start(interact_uri.hostname, interact_uri.port, use_ssl: true) { |http| http.request(interact_req) }
+puts JSON.parse(interact_resp.body)
+
+# Stop the session
+delete_uri = URI("https://api.firecrawl.dev/v2/scrape/#{scrape_id}/interact")
+delete_req = Net::HTTP::Delete.new(delete_uri)
+delete_req["Authorization"] = "Bearer #{api_key}"
+Net::HTTP.start(delete_uri.hostname, delete_uri.port, use_ssl: true) { |http| http.request(delete_req) }
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
+    Complete REST API documentation
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+</CardGroup>

--- a/quickstarts/ruby.mdx
+++ b/quickstarts/ruby.mdx
@@ -30,7 +30,7 @@ request.body = { query: "firecrawl web scraping", limit: 5 }.to_json
 response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
 results = JSON.parse(response.body)
 
-results["data"].each do |result|
+results["data"]["web"].each do |result|
   puts "#{result['title']} - #{result['url']}"
 end
 ```

--- a/quickstarts/rust.mdx
+++ b/quickstarts/rust.mdx
@@ -1,0 +1,94 @@
+---
+title: "Rust"
+description: "Get started with Firecrawl in Rust. Scrape, search, and interact with web data using the firecrawl crate."
+og:title: "Rust Quickstart | Firecrawl"
+og:description: "Get started with Firecrawl in Rust. Scrape, search, and interact with web data using the firecrawl crate."
+---
+
+## Prerequisites
+
+- Rust 1.70+ with Cargo
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Install the crate
+
+Add `firecrawl` to your `Cargo.toml`:
+
+```toml
+[dependencies]
+firecrawl = "1"
+tokio = { version = "1", features = ["full"] }
+```
+
+## Scrape a page
+
+```rust
+use firecrawl::v2::Client;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new("fc-YOUR-API-KEY")?;
+    let doc = client.scrape("https://example.com", None).await?;
+
+    println!("{}", doc.markdown.unwrap_or_default());
+    Ok(())
+}
+```
+
+<Accordion title="Example response">
+```json
+{
+  "markdown": "# Example Domain\n\nThis domain is for use in illustrative examples...",
+  "metadata": {
+    "title": "Example Domain",
+    "sourceURL": "https://example.com"
+  }
+}
+```
+</Accordion>
+
+## Search the web
+
+```rust
+use firecrawl::v2::Client;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new("fc-YOUR-API-KEY")?;
+    let results = client.search("firecrawl web scraping", None).await?;
+
+    for result in &results {
+        println!("{} - {}", result.title.as_deref().unwrap_or(""), result.url.as_deref().unwrap_or(""));
+    }
+    Ok(())
+}
+```
+
+## Environment variable
+
+Set `FIRECRAWL_API_KEY` instead of passing the key directly:
+
+```bash
+export FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+<Note>
+The `firecrawl` crate also supports the v1 API via `FirecrawlApp`. See the [Rust SDK docs](/sdks/rust) for the full API surface.
+</Note>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Rust SDK reference" icon="rust" href="/sdks/rust">
+    Full SDK reference with crawl, map, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/rust.mdx
+++ b/quickstarts/rust.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Rust"
-description: "Get started with Firecrawl in Rust. Scrape, search, and interact with web data using the firecrawl crate."
+description: "Get started with Firecrawl in Rust. Search, scrape, and interact with web data using the firecrawl crate."
 og:title: "Rust Quickstart | Firecrawl"
-og:description: "Get started with Firecrawl in Rust. Scrape, search, and interact with web data using the firecrawl crate."
+og:description: "Get started with Firecrawl in Rust. Search, scrape, and interact with web data using the firecrawl crate."
 ---
 
 ## Prerequisites
@@ -18,34 +18,9 @@ Add `firecrawl` to your `Cargo.toml`:
 [dependencies]
 firecrawl = "1"
 tokio = { version = "1", features = ["full"] }
+serde_json = "1"
+reqwest = { version = "0.12", features = ["json"] }
 ```
-
-## Scrape a page
-
-```rust
-use firecrawl::v2::Client;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = Client::new("fc-YOUR-API-KEY")?;
-    let doc = client.scrape("https://example.com", None).await?;
-
-    println!("{}", doc.markdown.unwrap_or_default());
-    Ok(())
-}
-```
-
-<Accordion title="Example response">
-```json
-{
-  "markdown": "# Example Domain\n\nThis domain is for use in illustrative examples...",
-  "metadata": {
-    "title": "Example Domain",
-    "sourceURL": "https://example.com"
-  }
-}
-```
-</Accordion>
 
 ## Search the web
 
@@ -64,6 +39,68 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+## Scrape a page
+
+```rust
+let doc = client.scrape("https://example.com", None).await?;
+println!("{}", doc.markdown.unwrap_or_default());
+```
+
+<Accordion title="Example response">
+```json
+{
+  "markdown": "# Example Domain\n\nThis domain is for use in illustrative examples...",
+  "metadata": {
+    "title": "Example Domain",
+    "sourceURL": "https://example.com"
+  }
+}
+```
+</Accordion>
+
+## Interact with a page
+
+The interact API uses prompt-based commands over HTTP. Scrape a page to get a `scrapeId`, then send prompts to control the browser session:
+
+```rust
+use reqwest::Client as HttpClient;
+use serde_json::json;
+
+let api_key = "fc-YOUR-API-KEY";
+let http = HttpClient::new();
+
+// 1. Scrape to open a browser session
+let scrape_res: serde_json::Value = http
+    .post("https://api.firecrawl.dev/v2/scrape")
+    .bearer_auth(api_key)
+    .json(&json!({ "url": "https://www.amazon.com", "formats": ["markdown"] }))
+    .send().await?
+    .json().await?;
+
+let scrape_id = scrape_res["data"]["metadata"]["scrapeId"]
+    .as_str().unwrap();
+
+// 2. Send prompts to interact
+http.post(format!("https://api.firecrawl.dev/v2/scrape/{scrape_id}/interact"))
+    .bearer_auth(api_key)
+    .json(&json!({ "prompt": "Search for iPhone 16 Pro Max" }))
+    .send().await?;
+
+let interact_res: serde_json::Value = http
+    .post(format!("https://api.firecrawl.dev/v2/scrape/{scrape_id}/interact"))
+    .bearer_auth(api_key)
+    .json(&json!({ "prompt": "Click on the first result and tell me the price" }))
+    .send().await?
+    .json().await?;
+
+println!("{}", interact_res);
+
+// 3. Close the session
+http.delete(format!("https://api.firecrawl.dev/v2/scrape/{scrape_id}/interact"))
+    .bearer_auth(api_key)
+    .send().await?;
+```
+
 ## Environment variable
 
 Set `FIRECRAWL_API_KEY` instead of passing the key directly:
@@ -79,11 +116,11 @@ The `firecrawl` crate also supports the v1 API via `FirecrawlApp`. See the [Rust
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
-    All scrape options including formats, actions, and proxies
-  </Card>
   <Card title="Search docs" icon="magnifying-glass" href="/features/search">
     Search the web and get full page content
+  </Card>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
   </Card>
   <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
     Click, fill forms, and extract dynamic content

--- a/quickstarts/spring-boot.mdx
+++ b/quickstarts/spring-boot.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Spring Boot"
-description: "Use Firecrawl with Spring Boot to scrape, search, and interact with web data using the official Java SDK."
+description: "Use Firecrawl with Spring Boot to search, scrape, and interact with web data using the official Java SDK."
 og:title: "Spring Boot Quickstart | Firecrawl"
-og:description: "Use Firecrawl with Spring Boot to scrape, search, and interact with web data using the official Java SDK."
+og:description: "Use Firecrawl with Spring Boot to search, scrape, and interact with web data using the official Java SDK."
 ---
 
 ## Prerequisites
@@ -77,8 +77,11 @@ import com.firecrawl.client.FirecrawlClient;
 import com.firecrawl.models.Document;
 import com.firecrawl.models.SearchData;
 import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.BrowserExecuteResponse;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -91,6 +94,16 @@ public class FirecrawlController {
         this.firecrawl = firecrawl;
     }
 
+    @PostMapping("/search")
+    public SearchData search(@RequestBody Map<String, Object> body) {
+        return firecrawl.search(
+            (String) body.get("query"),
+            SearchOptions.builder()
+                .limit((int) body.getOrDefault("limit", 5))
+                .build()
+        );
+    }
+
     @PostMapping("/scrape")
     public Map<String, Object> scrape(@RequestBody Map<String, String> body) {
         Document doc = firecrawl.scrape(body.get("url"));
@@ -100,14 +113,19 @@ public class FirecrawlController {
         );
     }
 
-    @PostMapping("/search")
-    public SearchData search(@RequestBody Map<String, Object> body) {
-        return firecrawl.search(
-            (String) body.get("query"),
-            SearchOptions.builder()
-                .limit((int) body.getOrDefault("limit", 5))
-                .build()
-        );
+    @PostMapping("/interact")
+    public Map<String, Object> interact(@RequestBody Map<String, String> body) {
+        Document doc = firecrawl.scrape(body.get("url"),
+            ScrapeOptions.builder().formats(List.of((Object) "markdown")).build());
+        String scrapeId = (String) doc.getMetadata().get("scrapeId");
+
+        firecrawl.interact(scrapeId, body.get("prompt"), "node", 60);
+        BrowserExecuteResponse response = firecrawl.interact(scrapeId,
+            body.getOrDefault("followUp", "Describe what you see"), "node", 60);
+
+        firecrawl.stopInteraction(scrapeId);
+
+        return Map.of("result", response.getStdout());
     }
 }
 ```
@@ -121,19 +139,30 @@ public class FirecrawlController {
 ## Test it
 
 ```bash
+# Search the web
+curl -X POST http://localhost:8080/api/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "firecrawl web scraping"}'
+
+# Scrape a page
 curl -X POST http://localhost:8080/api/scrape \
   -H "Content-Type: application/json" \
   -d '{"url": "https://example.com"}'
+
+# Interact with a page
+curl -X POST http://localhost:8080/api/interact \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://www.amazon.com", "prompt": "Search for iPhone 16 Pro Max", "followUp": "Click on the first result and tell me the price"}'
 ```
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
-    All scrape options including formats, actions, and proxies
-  </Card>
   <Card title="Search docs" icon="magnifying-glass" href="/features/search">
     Search the web and get full page content
+  </Card>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
   </Card>
   <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
     Click, fill forms, and extract dynamic content

--- a/quickstarts/spring-boot.mdx
+++ b/quickstarts/spring-boot.mdx
@@ -1,0 +1,144 @@
+---
+title: "Spring Boot"
+description: "Use Firecrawl with Spring Boot to scrape, search, and interact with web data using the official Java SDK."
+og:title: "Spring Boot Quickstart | Firecrawl"
+og:description: "Use Firecrawl with Spring Boot to scrape, search, and interact with web data using the official Java SDK."
+---
+
+## Prerequisites
+
+- Java 17+ and Spring Boot 3+
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Add the dependency
+
+<Tabs>
+  <Tab title="Gradle (Kotlin DSL)">
+```kotlin
+dependencies {
+    implementation("com.firecrawl:firecrawl-java:1.2.0")
+}
+```
+  </Tab>
+  <Tab title="Maven">
+```xml
+<dependency>
+    <groupId>com.firecrawl</groupId>
+    <artifactId>firecrawl-java</artifactId>
+    <version>1.2.0</version>
+</dependency>
+```
+  </Tab>
+</Tabs>
+
+## Configuration
+
+Add your API key to `application.properties`:
+
+```properties
+firecrawl.api-key=${FIRECRAWL_API_KEY}
+```
+
+Or set it as an environment variable:
+
+```bash
+export FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+## Create a configuration bean
+
+Create `FirecrawlConfig.java`:
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FirecrawlConfig {
+
+    @Bean
+    public FirecrawlClient firecrawlClient(
+            @Value("${firecrawl.api-key}") String apiKey) {
+        return FirecrawlClient.builder()
+            .apiKey(apiKey)
+            .build();
+    }
+}
+```
+
+## Create a REST controller
+
+Create `FirecrawlController.java`:
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+import com.firecrawl.models.Document;
+import com.firecrawl.models.SearchData;
+import com.firecrawl.models.SearchOptions;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api")
+public class FirecrawlController {
+
+    private final FirecrawlClient firecrawl;
+
+    public FirecrawlController(FirecrawlClient firecrawl) {
+        this.firecrawl = firecrawl;
+    }
+
+    @PostMapping("/scrape")
+    public Map<String, Object> scrape(@RequestBody Map<String, String> body) {
+        Document doc = firecrawl.scrape(body.get("url"));
+        return Map.of(
+            "markdown", doc.getMarkdown(),
+            "metadata", doc.getMetadata()
+        );
+    }
+
+    @PostMapping("/search")
+    public SearchData search(@RequestBody Map<String, Object> body) {
+        return firecrawl.search(
+            (String) body.get("query"),
+            SearchOptions.builder()
+                .limit((int) body.getOrDefault("limit", 5))
+                .build()
+        );
+    }
+}
+```
+
+## Run it
+
+```bash
+./gradlew bootRun
+```
+
+## Test it
+
+```bash
+curl -X POST http://localhost:8080/api/scrape \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}'
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Java SDK reference" icon="java" href="/sdks/java">
+    Full SDK reference with crawl, map, batch scrape, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/spring-boot.mdx
+++ b/quickstarts/spring-boot.mdx
@@ -119,11 +119,10 @@ public class FirecrawlController {
             ScrapeOptions.builder().formats(List.of((Object) "markdown")).build());
         String scrapeId = (String) doc.getMetadata().get("scrapeId");
 
-        firecrawl.interact(scrapeId, body.get("prompt"), "node", 60);
         BrowserExecuteResponse response = firecrawl.interact(scrapeId,
-            body.getOrDefault("followUp", "Describe what you see"), "node", 60);
+            body.getOrDefault("code", "const title = await page.title(); console.log(title);"));
 
-        firecrawl.stopInteraction(scrapeId);
+        firecrawl.stopInteractiveBrowser(scrapeId);
 
         return Map.of("result", response.getStdout());
     }
@@ -152,7 +151,7 @@ curl -X POST http://localhost:8080/api/scrape \
 # Interact with a page
 curl -X POST http://localhost:8080/api/interact \
   -H "Content-Type: application/json" \
-  -d '{"url": "https://www.amazon.com", "prompt": "Search for iPhone 16 Pro Max", "followUp": "Click on the first result and tell me the price"}'
+  -d '{"url": "https://www.amazon.com", "code": "const title = await page.title(); console.log(title);"}'
 ```
 
 ## Next steps

--- a/quickstarts/supabase-edge-functions.mdx
+++ b/quickstarts/supabase-edge-functions.mdx
@@ -1,0 +1,103 @@
+---
+title: "Supabase Edge Functions"
+description: "Use Firecrawl with Supabase Edge Functions to scrape, search, and interact with web data at the edge."
+og:title: "Supabase Edge Functions Quickstart | Firecrawl"
+og:description: "Use Firecrawl with Supabase Edge Functions to scrape, search, and interact with web data at the edge."
+---
+
+## Prerequisites
+
+- Supabase project with CLI (`supabase init`)
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Create the function
+
+```bash
+supabase functions new scrape
+```
+
+## Write the handler
+
+Edit `supabase/functions/scrape/index.ts`:
+
+```typescript
+import Firecrawl from "npm:@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({
+  apiKey: Deno.env.get("FIRECRAWL_API_KEY"),
+});
+
+Deno.serve(async (req) => {
+  const { url } = await req.json();
+  const result = await firecrawl.scrape(url);
+
+  return new Response(JSON.stringify(result), {
+    headers: { "Content-Type": "application/json" },
+  });
+});
+```
+
+## Set the secret
+
+```bash
+supabase secrets set FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+## Deploy
+
+```bash
+supabase functions deploy scrape
+```
+
+## Test it
+
+```bash
+curl -X POST https://<project-ref>.supabase.co/functions/v1/scrape \
+  -H "Authorization: Bearer <ANON_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}'
+```
+
+## Search function
+
+Create a second function for search:
+
+```bash
+supabase functions new search
+```
+
+Edit `supabase/functions/search/index.ts`:
+
+```typescript
+import Firecrawl from "npm:@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({
+  apiKey: Deno.env.get("FIRECRAWL_API_KEY"),
+});
+
+Deno.serve(async (req) => {
+  const { query } = await req.json();
+  const results = await firecrawl.search(query, { limit: 5 });
+
+  return new Response(JSON.stringify(results), {
+    headers: { "Content-Type": "application/json" },
+  });
+});
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Node SDK reference" icon="node" href="/sdks/node">
+    Full SDK reference with crawl, map, batch scrape, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/supabase-edge-functions.mdx
+++ b/quickstarts/supabase-edge-functions.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Supabase Edge Functions"
-description: "Use Firecrawl with Supabase Edge Functions to scrape, search, and interact with web data at the edge."
+description: "Use Firecrawl with Supabase Edge Functions to search, scrape, and interact with web data at the edge."
 og:title: "Supabase Edge Functions Quickstart | Firecrawl"
-og:description: "Use Firecrawl with Supabase Edge Functions to scrape, search, and interact with web data at the edge."
+og:description: "Use Firecrawl with Supabase Edge Functions to search, scrape, and interact with web data at the edge."
 ---
 
 ## Prerequisites
@@ -10,63 +10,23 @@ og:description: "Use Firecrawl with Supabase Edge Functions to scrape, search, a
 - Supabase project with CLI (`supabase init`)
 - A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
 
-## Create the function
+## Setup
 
 ```bash
-supabase functions new scrape
+supabase functions new firecrawl-search
+supabase functions new firecrawl-scrape
+supabase functions new firecrawl-interact
 ```
 
-## Write the handler
-
-Edit `supabase/functions/scrape/index.ts`:
-
-```typescript
-import Firecrawl from "npm:@mendable/firecrawl-js";
-
-const firecrawl = new Firecrawl({
-  apiKey: Deno.env.get("FIRECRAWL_API_KEY"),
-});
-
-Deno.serve(async (req) => {
-  const { url } = await req.json();
-  const result = await firecrawl.scrape(url);
-
-  return new Response(JSON.stringify(result), {
-    headers: { "Content-Type": "application/json" },
-  });
-});
-```
-
-## Set the secret
+Set the secret:
 
 ```bash
 supabase secrets set FIRECRAWL_API_KEY=fc-YOUR-API-KEY
 ```
 
-## Deploy
+## Search the web
 
-```bash
-supabase functions deploy scrape
-```
-
-## Test it
-
-```bash
-curl -X POST https://<project-ref>.supabase.co/functions/v1/scrape \
-  -H "Authorization: Bearer <ANON_KEY>" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://example.com"}'
-```
-
-## Search function
-
-Create a second function for search:
-
-```bash
-supabase functions new search
-```
-
-Edit `supabase/functions/search/index.ts`:
+Edit `supabase/functions/firecrawl-search/index.ts`:
 
 ```typescript
 import Firecrawl from "npm:@mendable/firecrawl-js";
@@ -85,14 +45,85 @@ Deno.serve(async (req) => {
 });
 ```
 
+## Scrape a page
+
+Edit `supabase/functions/firecrawl-scrape/index.ts`:
+
+```typescript
+import Firecrawl from "npm:@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({
+  apiKey: Deno.env.get("FIRECRAWL_API_KEY"),
+});
+
+Deno.serve(async (req) => {
+  const { url } = await req.json();
+  const result = await firecrawl.scrape(url);
+
+  return new Response(JSON.stringify(result), {
+    headers: { "Content-Type": "application/json" },
+  });
+});
+```
+
+## Interact with a page
+
+Edit `supabase/functions/firecrawl-interact/index.ts`:
+
+```typescript
+import Firecrawl from "npm:@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({
+  apiKey: Deno.env.get("FIRECRAWL_API_KEY"),
+});
+
+Deno.serve(async (_req) => {
+  const result = await firecrawl.scrape("https://www.amazon.com", {
+    formats: ["markdown"],
+  });
+  const scrapeId = result.metadata?.scrapeId;
+
+  await firecrawl.interact(scrapeId, {
+    prompt: "Search for iPhone 16 Pro Max",
+  });
+  const response = await firecrawl.interact(scrapeId, {
+    prompt: "Click on the first result and tell me the price",
+  });
+  console.log(response.output);
+
+  await firecrawl.stopInteraction(scrapeId);
+
+  return new Response(JSON.stringify({ output: response.output }), {
+    headers: { "Content-Type": "application/json" },
+  });
+});
+```
+
+## Deploy
+
+```bash
+supabase functions deploy firecrawl-search
+supabase functions deploy firecrawl-scrape
+supabase functions deploy firecrawl-interact
+```
+
+## Test it
+
+```bash
+curl -X POST https://<project-ref>.supabase.co/functions/v1/firecrawl-search \
+  -H "Authorization: Bearer <ANON_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "firecrawl web scraping"}'
+```
+
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
-    All scrape options including formats, actions, and proxies
-  </Card>
   <Card title="Search docs" icon="magnifying-glass" href="/features/search">
     Search the web and get full page content
+  </Card>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
   </Card>
   <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
     Click, fill forms, and extract dynamic content

--- a/quickstarts/sveltekit.mdx
+++ b/quickstarts/sveltekit.mdx
@@ -1,0 +1,116 @@
+---
+title: "SvelteKit"
+description: "Use Firecrawl with SvelteKit to scrape, search, and interact with web data in your Svelte application."
+og:title: "SvelteKit Quickstart | Firecrawl"
+og:description: "Use Firecrawl with SvelteKit to scrape, search, and interact with web data in your Svelte application."
+---
+
+## Prerequisites
+
+- SvelteKit project
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Install the SDK
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+Add your API key to `.env`:
+
+```bash
+FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+## Server endpoint
+
+Create `src/routes/api/scrape/+server.ts`:
+
+```typescript
+import { json } from "@sveltejs/kit";
+import Firecrawl from "@mendable/firecrawl-js";
+import { FIRECRAWL_API_KEY } from "$env/static/private";
+
+const firecrawl = new Firecrawl({ apiKey: FIRECRAWL_API_KEY });
+
+export async function POST({ request }) {
+  const { url } = await request.json();
+  const result = await firecrawl.scrape(url);
+  return json(result);
+}
+```
+
+## Server load function
+
+Fetch data in a `+page.server.ts` load function:
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+import { FIRECRAWL_API_KEY } from "$env/static/private";
+
+const firecrawl = new Firecrawl({ apiKey: FIRECRAWL_API_KEY });
+
+export async function load({ url }) {
+  const target = url.searchParams.get("url");
+  if (!target) return { markdown: null };
+
+  const result = await firecrawl.scrape(target);
+  return { markdown: result.markdown };
+}
+```
+
+## Form action
+
+Handle scrape requests through SvelteKit form actions:
+
+```typescript
+// src/routes/search/+page.server.ts
+import Firecrawl from "@mendable/firecrawl-js";
+import { FIRECRAWL_API_KEY } from "$env/static/private";
+
+const firecrawl = new Firecrawl({ apiKey: FIRECRAWL_API_KEY });
+
+export const actions = {
+  default: async ({ request }) => {
+    const data = await request.formData();
+    const query = data.get("query") as string;
+    const results = await firecrawl.search(query, { limit: 5 });
+    return { results: results.map((r) => ({ title: r.title, url: r.url })) };
+  },
+};
+```
+
+```svelte
+<!-- src/routes/search/+page.svelte -->
+<script>
+  export let form;
+</script>
+
+<form method="POST">
+  <input name="query" placeholder="Search the web..." />
+  <button>Search</button>
+</form>
+
+{#if form?.results}
+  {#each form.results as result}
+    <div><a href={result.url}>{result.title}</a></div>
+  {/each}
+{/if}
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Node SDK reference" icon="node" href="/sdks/node">
+    Full SDK reference with crawl, map, batch scrape, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/sveltekit.mdx
+++ b/quickstarts/sveltekit.mdx
@@ -22,27 +22,48 @@ Add your API key to `.env`:
 FIRECRAWL_API_KEY=fc-YOUR-API-KEY
 ```
 
-## Server endpoint
+## Search the web
 
-Create `src/routes/api/scrape/+server.ts`:
+Create a form action in `src/routes/search/+page.server.ts`:
 
 ```typescript
-import { json } from "@sveltejs/kit";
 import Firecrawl from "@mendable/firecrawl-js";
 import { FIRECRAWL_API_KEY } from "$env/static/private";
 
 const firecrawl = new Firecrawl({ apiKey: FIRECRAWL_API_KEY });
 
-export async function POST({ request }) {
-  const { url } = await request.json();
-  const result = await firecrawl.scrape(url);
-  return json(result);
-}
+export const actions = {
+  default: async ({ request }) => {
+    const data = await request.formData();
+    const query = data.get("query") as string;
+    const results = await firecrawl.search(query, { limit: 5 });
+    return { results: results.map((r) => ({ title: r.title, url: r.url })) };
+  },
+};
 ```
 
-## Server load function
+Wire it up in `src/routes/search/+page.svelte`:
 
-Fetch data in a `+page.server.ts` load function:
+```svelte
+<script>
+  export let form;
+</script>
+
+<form method="POST">
+  <input name="query" placeholder="Search the web..." />
+  <button>Search</button>
+</form>
+
+{#if form?.results}
+  {#each form.results as result}
+    <div><a href={result.url}>{result.title}</a></div>
+  {/each}
+{/if}
+```
+
+## Scrape a page
+
+Fetch data in a load function at `src/routes/scrape/+page.server.ts`:
 
 ```typescript
 import Firecrawl from "@mendable/firecrawl-js";
@@ -59,43 +80,50 @@ export async function load({ url }) {
 }
 ```
 
-## Form action
+Display it in `src/routes/scrape/+page.svelte`:
 
-Handle scrape requests through SvelteKit form actions:
+```svelte
+<script>
+  export let data;
+</script>
+
+{#if data.markdown}
+  <pre>{data.markdown}</pre>
+{:else}
+  <p>Pass ?url= to scrape a page</p>
+{/if}
+```
+
+## Interact with a page
+
+Create a server endpoint at `src/routes/api/interact/+server.ts`:
 
 ```typescript
-// src/routes/search/+page.server.ts
+import { json } from "@sveltejs/kit";
 import Firecrawl from "@mendable/firecrawl-js";
 import { FIRECRAWL_API_KEY } from "$env/static/private";
 
 const firecrawl = new Firecrawl({ apiKey: FIRECRAWL_API_KEY });
 
-export const actions = {
-  default: async ({ request }) => {
-    const data = await request.formData();
-    const query = data.get("query") as string;
-    const results = await firecrawl.search(query, { limit: 5 });
-    return { results: results.map((r) => ({ title: r.title, url: r.url })) };
-  },
-};
-```
+export async function POST() {
+  const result = await firecrawl.scrape("https://www.amazon.com", {
+    formats: ["markdown"],
+  });
 
-```svelte
-<!-- src/routes/search/+page.svelte -->
-<script>
-  export let form;
-</script>
+  const scrapeId = result.metadata?.scrapeId;
 
-<form method="POST">
-  <input name="query" placeholder="Search the web..." />
-  <button>Search</button>
-</form>
+  await firecrawl.interact(scrapeId, {
+    prompt: "Search for iPhone 16 Pro Max",
+  });
 
-{#if form?.results}
-  {#each form.results as result}
-    <div><a href={result.url}>{result.title}</a></div>
-  {/each}
-{/if}
+  const response = await firecrawl.interact(scrapeId, {
+    prompt: "Click on the first result and tell me the price",
+  });
+
+  await firecrawl.stopInteraction(scrapeId);
+
+  return json({ output: response.output });
+}
 ```
 
 ## Next steps

--- a/quickstarts/sveltekit.mdx
+++ b/quickstarts/sveltekit.mdx
@@ -37,7 +37,7 @@ export const actions = {
     const data = await request.formData();
     const query = data.get("query") as string;
     const results = await firecrawl.search(query, { limit: 5 });
-    return { results: results.map((r) => ({ title: r.title, url: r.url })) };
+    return { results: (results.web || []).map((r) => ({ title: r.title, url: r.url })) };
   },
 };
 ```

--- a/quickstarts/vercel-functions.mdx
+++ b/quickstarts/vercel-functions.mdx
@@ -1,0 +1,94 @@
+---
+title: "Vercel Functions"
+description: "Use Firecrawl with Vercel Functions to scrape, search, and interact with web data in serverless deployments."
+og:title: "Vercel Functions Quickstart | Firecrawl"
+og:description: "Use Firecrawl with Vercel Functions to scrape, search, and interact with web data in serverless deployments."
+---
+
+## Prerequisites
+
+- Vercel project (Next.js, SvelteKit, Nuxt, or standalone)
+- A Firecrawl API key — [get one free](https://www.firecrawl.dev/app/api-keys)
+
+## Setup
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+Add `FIRECRAWL_API_KEY` as an environment variable in your Vercel project settings, or in `.env.local` for local development:
+
+```bash
+FIRECRAWL_API_KEY=fc-YOUR-API-KEY
+```
+
+## Standalone Vercel Function
+
+Create `api/scrape.ts`:
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+
+export async function POST(request: Request) {
+  const { url } = await request.json();
+  const result = await firecrawl.scrape(url);
+
+  return new Response(JSON.stringify(result), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+```
+
+## With Next.js Route Handler
+
+Create `app/api/scrape/route.ts`:
+
+```typescript
+import { NextResponse } from "next/server";
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+
+export async function POST(request: Request) {
+  const { url } = await request.json();
+  const result = await firecrawl.scrape(url);
+  return NextResponse.json(result);
+}
+```
+
+## Deploy
+
+```bash
+vercel deploy
+```
+
+## Test it
+
+```bash
+curl -X POST https://your-project.vercel.app/api/scrape \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}'
+```
+
+<Note>
+Vercel Functions have a default timeout of 10 seconds on the Hobby plan and 60 seconds on Pro. For large crawl jobs, use the Firecrawl async API with webhooks instead.
+</Note>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
+  </Card>
+  <Card title="Search docs" icon="magnifying-glass" href="/features/search">
+    Search the web and get full page content
+  </Card>
+  <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, and extract dynamic content
+  </Card>
+  <Card title="Node SDK reference" icon="node" href="/sdks/node">
+    Full SDK reference with crawl, map, batch scrape, and more
+  </Card>
+</CardGroup>

--- a/quickstarts/vercel-functions.mdx
+++ b/quickstarts/vercel-functions.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Vercel Functions"
-description: "Use Firecrawl with Vercel Functions to scrape, search, and interact with web data in serverless deployments."
+description: "Use Firecrawl with Vercel Functions to search, scrape, and interact with web data in serverless deployments."
 og:title: "Vercel Functions Quickstart | Firecrawl"
-og:description: "Use Firecrawl with Vercel Functions to scrape, search, and interact with web data in serverless deployments."
+og:description: "Use Firecrawl with Vercel Functions to search, scrape, and interact with web data in serverless deployments."
 ---
 
 ## Prerequisites
@@ -22,9 +22,28 @@ Add `FIRECRAWL_API_KEY` as an environment variable in your Vercel project settin
 FIRECRAWL_API_KEY=fc-YOUR-API-KEY
 ```
 
-## Standalone Vercel Function
+## Search the web
 
-Create `api/scrape.ts`:
+Create `api/search.ts` (or `app/api/search/route.ts` for Next.js):
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+
+export async function POST(request: Request) {
+  const { query } = await request.json();
+  const results = await firecrawl.search(query, { limit: 5 });
+
+  return new Response(JSON.stringify(results), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+```
+
+## Scrape a page
+
+Create `api/scrape.ts` (or `app/api/scrape/route.ts` for Next.js):
 
 ```typescript
 import Firecrawl from "@mendable/firecrawl-js";
@@ -41,20 +60,33 @@ export async function POST(request: Request) {
 }
 ```
 
-## With Next.js Route Handler
+## Interact with a page
 
-Create `app/api/scrape/route.ts`:
+Create `api/interact.ts` (or `app/api/interact/route.ts` for Next.js):
 
 ```typescript
-import { NextResponse } from "next/server";
 import Firecrawl from "@mendable/firecrawl-js";
 
 const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
 
 export async function POST(request: Request) {
-  const { url } = await request.json();
-  const result = await firecrawl.scrape(url);
-  return NextResponse.json(result);
+  const result = await firecrawl.scrape("https://www.amazon.com", {
+    formats: ["markdown"],
+  });
+  const scrapeId = result.metadata?.scrapeId;
+
+  await firecrawl.interact(scrapeId, {
+    prompt: "Search for iPhone 16 Pro Max",
+  });
+  const response = await firecrawl.interact(scrapeId, {
+    prompt: "Click on the first result and tell me the price",
+  });
+
+  await firecrawl.stopInteraction(scrapeId);
+
+  return new Response(JSON.stringify({ output: response.output }), {
+    headers: { "Content-Type": "application/json" },
+  });
 }
 ```
 
@@ -67,9 +99,9 @@ vercel deploy
 ## Test it
 
 ```bash
-curl -X POST https://your-project.vercel.app/api/scrape \
+curl -X POST https://your-project.vercel.app/api/search \
   -H "Content-Type: application/json" \
-  -d '{"url": "https://example.com"}'
+  -d '{"query": "firecrawl web scraping"}'
 ```
 
 <Note>
@@ -79,11 +111,11 @@ Vercel Functions have a default timeout of 10 seconds on the Hobby plan and 60 s
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
-    All scrape options including formats, actions, and proxies
-  </Card>
   <Card title="Search docs" icon="magnifying-glass" href="/features/search">
     Search the web and get full page content
+  </Card>
+  <Card title="Scrape docs" icon="file-lines" href="/features/scrape">
+    All scrape options including formats, actions, and proxies
   </Card>
   <Card title="Interact docs" icon="hand-pointer" href="/features/interact">
     Click, fill forms, and extract dynamic content


### PR DESCRIPTION
## Summary

- Adds a new **Quickstarts** navigation group to the docs (between "Get Started" and "Core Endpoints")
- Creates **7 language intro pages**: Node.js, Python, Go, Rust, PHP, Java, .NET
- Creates **21 framework guide pages**: Next.js, Express, NestJS, Fastify, Hono, Bun, Remix, Nuxt, SvelteKit, Astro, Cloudflare Workers, Vercel Functions, AWS Lambda, Supabase Edge Functions, Deno Deploy, FastAPI, Django, Flask, Laravel, Rails, Spring Boot, ASP.NET Core

### Mode decisions

| Mode | Targets | Rationale |
|------|---------|-----------|
| **SDK** | Node.js, Python, Java | Official SDKs with v2 API support |
| **SDK** | Rust | v2 Client available in firecrawl crate |
| **HTTP** | Go | Community SDK is v1-only; quickstart uses v2 REST API with note about community SDK |
| **HTTP** | PHP, .NET | No official or community SDK; direct REST API calls |
| **Inherited** | All 21 frameworks | Each framework inherits its parent language mode |

### Page structure

- **Language intros**: prerequisites, install, scrape example, search example, env var setup, next steps
- **Framework guides**: prerequisites, install, framework-specific config/wiring, idiomatic examples showing where code belongs in the app, next steps

### Source verification

- All SDK usage verified against source in firecrawl/apps/{js,python,rust,java}-sdk/
- HTTP examples verified against v2-openapi.json (base URL, auth, request schemas)
- No invented SDK methods, packages, or parameters

## Test plan

- [ ] Verify docs.json is valid and Mintlify builds successfully
- [ ] Check navigation: Quickstarts group appears between Get Started and Core Endpoints
- [ ] Spot-check language pages: code examples are copy-paste runnable
- [ ] Spot-check framework pages: file paths match framework conventions
- [ ] Verify links in Next steps cards resolve correctly
