### PR TITLE
docs: update README for mint CLI rename and Node 25 incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,21 +12,23 @@ To get started with the Firecrawl documentation, follow the steps below:
 
 ### Prerequisites
 
-- Node.js (version 19 or higher)
+- Node.js LTS (version 19 or higher). **Node 25+ is not supported** by the Mintlify CLI — it fails with `TypeError: localStorage.getItem is not a function` (see [mintlify/starter#116](https://github.com/mintlify/starter/issues/116)). If you're on Node 25+, pin an LTS for this repo with a version manager such as [mise](https://mise.jdx.dev/) or [nvm](https://github.com/nvm-sh/nvm):
+
+  ```bash
+  mise use node@24
+  # or
+  nvm install 24 && nvm use 24
+  ```
 
 ### Installation
 
-1. Install Mintlify globally using npm:
+1. Install the Mintlify CLI globally:
 
    ```bash
-   npm install -g mintlify
+   npm install -g mint
    ```
 
-   Or if you prefer yarn:
-
-   ```bash
-   yarn global add mintlify
-   ```
+   Or with your preferred package manager (`bun add -g mint`, `yarn global add mint`, `pnpm add -g mint`).
 
 2. Clone this repository and navigate to the directory:
 
@@ -38,8 +40,10 @@ To get started with the Firecrawl documentation, follow the steps below:
 3. Start the Mintlify development server:
 
    ```bash
-   mintlify dev
+   mint dev
    ```
+
+   > Note: the CLI was renamed from `mintlify` to `mint`. The old `mintlify dev` command is deprecated.
 
 4. Open your web browser and visit [http://localhost:3000](http://localhost:3000) to see a local preview of the documentation.
 

--- a/README.md
+++ b/README.md
@@ -12,23 +12,16 @@ To get started with the Firecrawl documentation, follow the steps below:
 
 ### Prerequisites
 
-- Node.js LTS (version 19 or higher). **Node 25+ is not supported** by the Mintlify CLI — it fails with `TypeError: localStorage.getItem is not a function` (see [mintlify/starter#116](https://github.com/mintlify/starter/issues/116)). If you're on Node 25+, pin an LTS for this repo with a version manager such as [mise](https://mise.jdx.dev/) or [nvm](https://github.com/nvm-sh/nvm):
+- Node.js LTS (version 19 or higher). **Node 25+ is not supported** by the Mintlify CLI (see [mintlify/starter#116](https://github.com/mintlify/starter/issues/116)). If you're on Node 25+, please use an [LTS version](https://nodejs.org/en/about/previous-releases#looking-for-the-latest-release-of-a-version-branch) of Node.js.
 
-  ```bash
-  mise use node@24
-  # or
-  nvm install 24 && nvm use 24
-  ```
 
 ### Installation
 
 1. Install the Mintlify CLI globally:
 
    ```bash
-   npm install -g mint
+   npm i -g mint
    ```
-
-   Or with your preferred package manager (`bun add -g mint`, `yarn global add mint`, `pnpm add -g mint`).
 
 2. Clone this repository and navigate to the directory:
 


### PR DESCRIPTION
## Summary
- Update CLI install/run commands from `mintlify` → `mint` (Mintlify renamed the CLI).
- Document that Node 25+ is not supported by the Mintlify CLI (fails with `TypeError: localStorage.getItem is not a function`, tracked in [mintlify/starter#116](https://github.com/mintlify/starter/issues/116)).
