### PR TITLE
fix(docs): wrap Java generic types in backticks

### DIFF
--- a/agent-source-of-truth/java.mdx
+++ b/agent-source-of-truth/java.mdx
@@ -243,15 +243,15 @@ Document doc = client.scrape("https://example.com/pricing", options);
     - `selectors`: array of `{selector, attribute}` for `type: "attributes"`
 
 - `options.headers`
-  - Type: Map<String, String>
+  - Type: `Map<String, String>`
   - Use when: you need custom request headers.
 
 - `options.includeTags`
-  - Type: List<String>
+  - Type: `List<String>`
   - Use when: you want to include only specific HTML tags.
 
 - `options.excludeTags`
-  - Type: List<String>
+  - Type: `List<String>`
   - Use when: you want to exclude specific HTML tags.
 
 - `options.onlyMainContent`
@@ -271,14 +271,14 @@ Document doc = client.scrape("https://example.com/pricing", options);
   - Use when: you want a mobile viewport.
 
 - `options.parsers`
-  - Type: List<Object>
+  - Type: `List<Object>`
   - Use when: you need file parsing controls.
   - Confirmed values:
     - `"pdf"`
     - `{type: "pdf", maxPages: number}`
 
 - `options.actions`
-  - Type: List<Map<String, Object>>
+  - Type: `List<Map<String, Object>>`
   - Use when: you need lightweight pre-scrape actions.
   - Confirmed action types:
     - `wait`: `milliseconds` or `selector` required


### PR DESCRIPTION
## Summary
- Wrap Java generic types (`Map<String, String>`, `List<String>`, etc.) in backticks in `agent-source-of-truth/java.mdx` so MDX does not try to parse them as JSX tags.

<img width="1466" height="477" alt="Screenshot 2026-04-24 at 09 42 15" src="https://github.com/user-attachments/assets/15d3d9ea-eb7a-4b4a-a89c-7ac4faf2a37b" />


## Test plan
- [ ] Verify the page renders without MDX parse errors