### PR TITLE
docs: add /api-reference/errors reference page

### DIFF
--- a/api-reference/errors.mdx
+++ b/api-reference/errors.mdx
@@ -1,0 +1,118 @@
+---
+title: 'Errors'
+description: 'Every API error code, what causes it, how to remedy it, and whether to retry.'
+---
+
+Every Firecrawl error response uses the same JSON shape. Look up the `error` value (or HTTP status) in the table below to find the cause, remedy, and whether the request is safe to retry.
+
+<Note>This catalog covers the errors most agents and clients will encounter. It is non-exhaustive — if you receive an error not listed here, please [open an issue](https://github.com/firecrawl/firecrawl/issues) so we can document it.</Note>
+
+## Error response shape
+
+All non-2xx responses return JSON with a top-level `success: false` and a string `error`. Some endpoints include additional fields (`details`, `code`) when more context is available.
+
+```json
+{
+  "success": false,
+  "error": "Unauthorized: Invalid token",
+  "details": "Optional structured details (only present on some errors)"
+}
+```
+
+| Field      | Type      | Description                                                       |
+|------------|-----------|-------------------------------------------------------------------|
+| `success`  | `boolean` | Always `false` on errors.                                         |
+| `error`    | `string`  | Human-readable error message. Use this to look up the row below.  |
+| `details`  | `any`     | Optional. Structured per-field validation errors when applicable. |
+
+## Errors
+
+| HTTP | `error` (typical message)                          | Cause                                                              | Remedy                                                                              | Retryable        |
+|------|----------------------------------------------------|--------------------------------------------------------------------|-------------------------------------------------------------------------------------|------------------|
+| 400  | `Bad Request` / validation message                 | Request body failed schema validation (missing or invalid fields). | Fix the request payload using the endpoint reference. Check `details` for fields.   | No               |
+| 400  | `Invalid URL`                                      | The `url` field is missing, malformed, or uses an unsupported scheme. | Pass an absolute `http(s)://` URL.                                                  | No               |
+| 401  | `Unauthorized: Invalid token`                      | API key is missing, malformed, or revoked.                         | Send `Authorization: Bearer fc-...` with a valid key from the [dashboard](https://www.firecrawl.dev/app/api-keys). | No               |
+| 402  | `Payment Required: Insufficient credits`           | Plan credits are exhausted or billing is not configured.           | Top up credits, enable auto-recharge, or upgrade your plan.                          | No               |
+| 403  | `Forbidden`                                        | Key lacks permission for this endpoint or feature.                 | Use a key with the required scope, or upgrade the plan that gates this feature.     | No               |
+| 404  | `Not Found`                                        | The job ID, resource, or endpoint path does not exist.             | Verify the resource ID and endpoint URL.                                            | No               |
+| 408  | `Request Timeout`                                  | The page took longer than the request `timeout` to load.           | Increase `timeout`, simplify actions, or use `fastMode`.                            | Yes, with backoff |
+| 409  | `Conflict`                                         | Resource is in a state that prevents the operation (e.g. already deleted). | Re-fetch state and reconcile before retrying.                                       | No               |
+| 413  | `Payload Too Large`                                | Request body exceeded the maximum allowed size.                    | Reduce the payload (e.g. shorter schema, fewer URLs per batch).                     | No               |
+| 422  | `Unprocessable Entity` / extraction schema error   | Schema is invalid JSON Schema, or the model could not produce a conforming result. | Validate the schema; loosen required fields; try a different `model`.                | Sometimes        |
+| 429  | `Rate limit exceeded`                              | Too many requests for your plan's per-minute limit.                | Back off and retry after `Retry-After` seconds. See [Rate Limits](/rate-limits).     | Yes, with backoff |
+| 429  | `Concurrency limit reached`                        | Concurrent browser limit for your plan reached.                    | Wait for in-flight jobs to finish, lower concurrency, or upgrade your plan.         | Yes, with backoff |
+| 500  | `Internal Server Error`                            | Unhandled server-side failure.                                     | Retry with exponential backoff. If it persists, contact support with the request ID. | Yes, with backoff |
+| 502  | `Bad Gateway`                                      | Upstream proxy or worker returned an invalid response.             | Retry with backoff.                                                                 | Yes, with backoff |
+| 503  | `Service Unavailable`                              | Service temporarily unable to handle the request.                  | Retry with backoff.                                                                 | Yes, with backoff |
+| 504  | `Gateway Timeout`                                  | Request exceeded the gateway's timeout (typically long crawls).    | Use the async crawl/batch endpoints and poll status instead.                         | Yes, with backoff |
+
+For 429 responses, Firecrawl includes a `Retry-After` header (in seconds) when available — wait at least that long before retrying.
+
+## Retry guidance
+
+Treat the **Retryable** column as authoritative; do not infer from the HTTP status alone. The pattern below uses exponential backoff with jitter and respects `Retry-After` on 429.
+
+<CodeGroup>
+
+```python Python
+import time
+import random
+import requests
+
+RETRYABLE_STATUSES = {408, 429, 500, 502, 503, 504}
+
+def request_with_retry(method, url, headers=None, json=None, max_attempts=5):
+    for attempt in range(max_attempts):
+        resp = requests.request(method, url, headers=headers, json=json)
+        if resp.status_code < 400 or resp.status_code not in RETRYABLE_STATUSES:
+            return resp
+        # Honor Retry-After when present, otherwise exponential backoff with jitter.
+        retry_after = resp.headers.get("Retry-After")
+        delay = float(retry_after) if retry_after else min(2 ** attempt, 30) + random.random()
+        time.sleep(delay)
+    return resp
+```
+
+```js Node
+const RETRYABLE_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
+
+async function requestWithRetry(url, init = {}, maxAttempts = 5) {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const resp = await fetch(url, init);
+    if (resp.ok || !RETRYABLE_STATUSES.has(resp.status)) return resp;
+    // Honor Retry-After when present, otherwise exponential backoff with jitter.
+    const retryAfter = resp.headers.get('Retry-After');
+    const delayMs = retryAfter
+      ? Number(retryAfter) * 1000
+      : Math.min(2 ** attempt, 30) * 1000 + Math.random() * 1000;
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+}
+```
+
+```bash cURL
+# Simple shell loop with exponential backoff for retryable statuses.
+attempt=0
+max=5
+until response=$(curl -sS -w "\n%{http_code}" -X POST "https://api.firecrawl.dev/v2/scrape" \
+    -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"url":"https://example.com"}'); do
+  status=$(printf '%s' "$response" | tail -n1)
+  case "$status" in
+    408|429|500|502|503|504)
+      attempt=$((attempt+1))
+      [ "$attempt" -ge "$max" ] && break
+      sleep $((2 ** attempt))
+      ;;
+    *) break ;;
+  esac
+done
+echo "$response"
+```
+
+</CodeGroup>
+
+## Rate limits
+
+429 responses are the most common retryable error. Per-plan rate limits and concurrency limits are documented in [Rate Limits](/rate-limits). Always honor the `Retry-After` header when present rather than retrying immediately.

--- a/api-reference/v2-introduction.mdx
+++ b/api-reference/v2-introduction.mdx
@@ -82,17 +82,7 @@ const result = await firecrawl.scrape('https://example.com');
 
 Firecrawl uses conventional HTTP status codes to indicate the outcome of your requests. Codes in the `2xx` range indicate success, `4xx` codes indicate client errors, and `5xx` codes indicate server errors.
 
-| Status | Description |
-|--------|-------------|
-| `200`  | Request was successful. |
-| `400`  | Invalid request parameters. |
-| `401`  | API key is missing or invalid. |
-| `402`  | Payment required. |
-| `404`  | The requested resource was not found. |
-| `429`  | Rate limit exceeded. |
-| `5xx`  | Server error on Firecrawl's side. |
-
-When a `5xx` error occurs, the response body includes a specific error code to help you diagnose the issue.
+See [Errors](/api-reference/errors) for the full reference, including the `error` string returned for each failure mode, retry guidance, and a copy-pasteable backoff snippet.
 
 ## Rate limit
 

--- a/docs.json
+++ b/docs.json
@@ -317,7 +317,8 @@
                   {
                     "group": "Using the API",
                     "pages": [
-                      "api-reference/v2-introduction"
+                      "api-reference/v2-introduction",
+                      "api-reference/errors"
                     ]
                   },
                   {

--- a/features/llm-extract.mdx
+++ b/features/llm-extract.mdx
@@ -23,6 +23,8 @@ import EventExampleOutput from "/snippets/v2/scrape/json/events-example/output.m
 **v2 API Change:** JSON schema extraction is fully supported in v2, but the API format has changed. In v2, the schema is embedded directly inside the format object as `formats: [{type: "json", schema: {...}}]`. The v1 `jsonOptions` parameter no longer exists in v2.
 </Note>
 
+<Note>For schema validation failures and other extraction errors, see [Errors](/api-reference/errors) — extraction-specific issues typically surface as `400` or `422` responses.</Note>
+
 ## Scrape and extract structured data with Firecrawl
 
 Firecrawl uses AI to get structured data from web pages in 3 steps:

--- a/features/scrape.mdx
+++ b/features/scrape.mdx
@@ -55,6 +55,8 @@ For details, see the [Scrape Endpoint API Reference](https://docs.firecrawl.dev/
 
 <PlaygroundCTA />
 
+<Note>If a request fails, see [Errors](/api-reference/errors) for the full catalog of error codes, causes, remedies, and retry guidance.</Note>
+
 ## Scraping a URL with Firecrawl
 
 ### /scrape endpoint

--- a/rate-limits.mdx
+++ b/rate-limits.mdx
@@ -5,6 +5,8 @@ og:title: "Rate Limits | Firecrawl"
 og:description: "Rate limits for different pricing plans and API requests"
 ---
 
+When you exceed a rate or concurrency limit, the API returns a `429` response. See [Errors](/api-reference/errors) for the full error catalog and a retry-with-backoff snippet.
+
 ## Billing Model
 
 Firecrawl uses subscription-based monthly plans. There is no pure pay-as-you-go model, but the **auto-recharge feature** provides flexible scaling. Once you subscribe to a plan, you can automatically purchase additional credits when you dip below a threshold. Larger auto-recharge packs offer better rates. To test before committing to a larger plan, start with the Free or Hobby tier.


### PR DESCRIPTION
## Summary

Adds a dedicated **Errors** page at `/api-reference/errors` that catalogs every API error an agent or client can receive, mapped to its HTTP status, `error` string, cause, remedy, and whether it's retryable. Wires it into the nav and links to it from the pages where errors actually surface.

<img width="1659" height="1348" alt="Screenshot 2026-04-28 at 10 03 03" src="https://github.com/user-attachments/assets/8294cb74-6ef2-4da1-9308-c1640621c1ce" />

## Why

Today the only error coverage in the docs is a 7-row HTTP status table buried in `api-reference/v2-introduction.mdx`. It's a stub, not a reference:

- Tells you what HTTP statuses mean *in general* — universal knowledge, not Firecrawl-specific.
- No error response JSON shape.
- No application-level `error` *strings*. So when a client gets:

  ```json
  { \"success\": false, \"error\": \"Unauthorized: Invalid token\" }
  ```

  there is nowhere in the docs to resolve `\"Unauthorized: Invalid token\"` to a remedy.
- No retryability flag per error, no `Retry-After` header documentation, no backoff snippet.
- Buried on a page titled \"Introduction\" — not URL-guessable as `/api-reference/errors`.

Errors are revisited in every production run; without a catalog, users (and especially LLM agents) fall back to web search and third-party blogs. This is the highest-leverage docs gap to close — bigger payoff than per-language quickstarts because errors have no good fallback surface.

## What changed

**New page — `api-reference/errors.mdx`:**
- One-paragraph intro + non-exhaustive note.
- **Error response shape** — verbatim JSON example with each field typed.
- **Errors table** with columns: HTTP status, `error` string, Cause, Remedy, Retryable. Covers 400, 401, 402, 403, 404, 408, 409, 413, 422, 429 (rate limit *and* concurrency), 500, 502, 503, 504.
- **Retry guidance** — copy-pasteable Python / Node / cURL backoff snippets that honor `Retry-After` and use exponential backoff with jitter for retryable statuses only.
- **Rate-limit pointer** to `/rate-limits`.

**Lifted the existing table out of `api-reference/v2-introduction.mdx`** and replaced it with a one-line link to the new page, so there's a single source of truth.

**Wired entry points:**
- `docs.json` — added `api-reference/errors` under \"Using the API\".
- `rate-limits.mdx`, `features/scrape.mdx`, `features/llm-extract.mdx` — inline `<Note>` callouts pointing to the new page.

## Example: before vs. after

**Before** — agent receives `{ \"error\": \"Rate limit exceeded\" }`. Searches the docs for the string. No match. Has to infer retry policy from status code alone.

**After** — agent fetches `/api-reference/errors`, finds the row:

| 429 | `Rate limit exceeded` | Too many requests for your plan's per-minute limit. | Back off and retry after `Retry-After` seconds. See [Rate Limits](/rate-limits). | Yes, with backoff |

…and a runnable retry snippet directly below it. One fetch, action taken.

## Out of scope (deferred)

- **Per-SDK error class documentation** — different surface, separate page.
- **Webhook delivery errors** — revisit after webhook event-type pages exist.
- **Localization** — per `CLAUDE.md`, source files only; translations are managed separately.
- **Auto-generation from OpenAPI** — long-term the catalog should be generated to prevent drift; v1 is hand-written and labeled non-exhaustive.

## Test plan

- [ ] `mintlify dev` renders `/api-reference/errors` cleanly (table, code group with Python/Node/cURL tabs, Note callouts).
- [ ] Sidebar shows **Errors** under **API Reference → Using the API**.
- [ ] `/api-reference/v2-introduction` no longer shows the old table; the inline link to `/api-reference/errors` works.
- [ ] Inline links from `/rate-limits`, `/features/scrape`, `/features/llm-extract` resolve.
- [ ] No localized files were touched (`git diff` shows only base/source files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)