### PR TITLE
fix(snippets): use // for JS comment in Node install snippet

### DIFF
--- a/snippets/v2/installation/js.mdx
+++ b/snippets/v2/installation/js.mdx
@@ -1,5 +1,5 @@
 ```js Node
-# npm install @mendable/firecrawl-js
+// npm install @mendable/firecrawl-js
 
 import Firecrawl from '@mendable/firecrawl-js';
 


### PR DESCRIPTION
## Summary
- The Node install snippet at `snippets/v2/installation/js.mdx` used `#` as a comment inside a ` ```js ` code block, which is a syntax error if copy-pasted into Node.
- Replaced `#` with `//`.

Localized copies of the snippet (`ja`, `zh`, `pt-BR`, `fr`, `es`) have the same issue but are left alone per repo guidelines (translations are managed separately).

## Test plan
- [x] Visual check: install snippet renders with `//` and runs cleanly when pasted into Node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)