### PR TITLE
Update CLI skills docs

### DIFF
--- a/ai-onboarding.mdx
+++ b/ai-onboarding.mdx
@@ -31,7 +31,7 @@ Currently, we require a human to create a Firecrawl account. Once you have an ac
 
 ## Skills + CLI
 
-The [Firecrawl CLI](/sdks/cli) lets your agent search, scrape, crawl, extract, and drive a browser from the terminal. It's built for humans, AI agents, and CI/CD pipelines.
+The [Firecrawl CLI](/sdks/cli) lets your agent search, scrape, interact, crawl, map, extract, and run agent jobs from the terminal. It's built for humans, AI agents, and CI/CD pipelines.
 
 The Firecrawl **skills** are self-contained knowledge packs that AI coding agents like Claude Code, Antigravity, and OpenCode discover and use automatically. A single install command sets up everything — the CLI tools for live web work and the build skills for integrating Firecrawl into application code:
 
@@ -40,7 +40,7 @@ npx -y firecrawl-cli@latest init --all --browser
 ```
 
 - `--all` installs the Firecrawl skills to every detected AI coding agent on the machine
-- `--browser` opens the browser so the human can sign in or create an account
+- `--browser` opens the browser for Firecrawl authentication automatically
 
 After install, verify everything is working:
 
@@ -55,14 +55,15 @@ The install sets up two categories of skills that cover every way an agent uses 
 
 **CLI skills** — for live web work during an agent session:
 
-| Skill                | Purpose                                  |
-| -------------------- | ---------------------------------------- |
-| `firecrawl/cli`      | Overall CLI command workflow             |
-| `firecrawl-search`   | Search the web and discover pages        |
-| `firecrawl-scrape`   | Extract clean content from a known URL   |
-| `firecrawl-interact` | Drive a live page — clicks, forms, login |
-| `firecrawl-crawl`    | Bulk-extract content from an entire site |
-| `firecrawl-map`      | Discover all URLs on a domain            |
+| Skill              | Purpose                                      |
+| ------------------ | -------------------------------------------- |
+| `firecrawl/cli`    | Overall CLI command workflow                 |
+| `firecrawl-search` | Search the web and discover pages            |
+| `firecrawl-scrape` | Extract clean content from a known URL       |
+| `firecrawl-interact` | Interact with scraped pages using prompts or code |
+| `firecrawl-crawl`  | Bulk-extract content from an entire site     |
+| `firecrawl-map`    | Discover all URLs on a domain                |
+| `firecrawl-agent`  | Run autonomous web data gathering with a job |
 
 **Build skills** — for integrating Firecrawl into application code:
 
@@ -72,7 +73,7 @@ The install sets up two categories of skills that cover every way an agent uses 
 | `firecrawl-build-onboarding` | Auth and project setup                               |
 | `firecrawl-build-scrape`     | Implement scraping in app code                       |
 | `firecrawl-build-search`     | Implement search in app code                         |
-| `firecrawl-build-interact`   | Implement browser interaction in app code            |
+| `firecrawl-build-interact`   | Implement page interaction in app code               |
 | `firecrawl-build-crawl`      | Implement crawling in app code                       |
 | `firecrawl-build-map`        | Implement URL discovery in app code                  |
 
@@ -82,12 +83,14 @@ Both skill categories use the same install. The difference is what happens next:
 
 <Steps>
   <Step title="Live web tools (CLI skills)">
-    Use this when you need web data during your current session — searching the web, scraping known URLs, interacting with live pages, crawling docs, or mapping a site.
+    Use this when you need web data during your current session — searching the web, scraping known URLs, interacting with scraped pages, crawling docs, mapping a site, or running an agent job.
 
     The default flow:
     1. Start with **search** when you need discovery
     2. Move to **scrape** when you have a URL
-    3. Use **interact** only when the page needs clicks, forms, or login
+    3. Use **interact** when the scraped page needs follow-up actions
+    4. Use **map** or **crawl** when you need many URLs or pages
+    5. Use **agent** when the task is open-ended and needs autonomous discovery
 
     ```bash
     # Search the web
@@ -104,7 +107,7 @@ Both skill categories use the same install. The difference is what happens next:
   <Step title="App integration (Build skills)">
     Use this when you're building an application, agent, or workflow that calls the Firecrawl API from code. The build skills help with picking the right endpoint, wiring up the SDK, and running a smoke test.
 
-    The agent answers one key question — *what should Firecrawl do in the product?* — and the build skills route to `/search`, `/scrape`, `/interact`, `/crawl`, or `/map` accordingly.
+    The agent answers one key question — *what should Firecrawl do in the product?* — and the build skills route to `/search`, `/scrape`, `/interact`, `/crawl`, `/map`, or `/agent` accordingly.
 
   </Step>
   <Step title="REST API (no install needed)">
@@ -112,7 +115,10 @@ Both skill categories use the same install. The difference is what happens next:
 
     - `POST https://api.firecrawl.dev/v2/search` — discover pages by query
     - `POST https://api.firecrawl.dev/v2/scrape` — extract clean markdown from a URL
-    - `POST https://api.firecrawl.dev/v2/interact` — browser actions on live pages
+    - `POST https://api.firecrawl.dev/v2/interact` — interact with a scraped page
+    - `POST https://api.firecrawl.dev/v2/crawl` — bulk-extract an entire site
+    - `POST https://api.firecrawl.dev/v2/map` — discover URLs on a domain
+    - `POST https://api.firecrawl.dev/v2/agent` — run autonomous web data gathering
 
     Auth header: `Authorization: Bearer fc-YOUR_API_KEY`
 
@@ -123,7 +129,7 @@ The full onboarding definition is available at [`firecrawl.dev/agent-onboarding/
 
 <Card title="Skills + CLI" icon="terminal" href="/sdks/cli">
   Install the CLI and skills, authenticate, and run scrape, search, crawl,
-  extract, and browser commands from the terminal.
+  interact, map, extract, and agent commands from the terminal.
 </Card>
 
 ## Using Firecrawl as a Tool
@@ -211,12 +217,13 @@ Firecrawl gives agents five core tools for working with the web. Each tool maps 
 
   </Accordion>
 
-  <Accordion title="Interact — drive a live browser" icon="hand-pointer">
-    Interact gives agents control of a remote browser session. Use it when a page requires clicks, form fills, login, or any action beyond passive reading.
+  <Accordion title="Interact — work with a scraped page" icon="hand-pointer">
+    Interact lets agents continue from a scrape using prompts or code. Use it when a scraped page requires clicks, form fills, navigation, or follow-up extraction.
 
     ```bash
     # CLI
-    firecrawl interact https://example.com --instruction "Click the login button, fill in the email field"
+    firecrawl scrape https://example.com
+    firecrawl interact "Click the pricing tab and extract the plan names"
     ```
 
     ```bash
@@ -224,10 +231,10 @@ Firecrawl gives agents five core tools for working with the web. Each tool maps 
     curl -X POST https://api.firecrawl.dev/v2/interact \
       -H "Authorization: Bearer fc-YOUR_API_KEY" \
       -H "Content-Type: application/json" \
-      -d '{"url": "https://example.com", "instruction": "Click the login button"}'
+      -d '{"scrapeId": "scrape-id-from-scrape", "prompt": "Click the pricing tab and extract the plan names"}'
     ```
 
-    **When to use:** Pages behind login walls, filling out forms, navigating multi-step flows, interacting with dynamic SPAs.
+    **When to use:** Continuing from a scrape, navigating dynamic pages, filling forms, and extracting data after page actions.
 
   </Accordion>
 </AccordionGroup>
@@ -238,13 +245,14 @@ Most agent workflows combine multiple tools. A typical pattern:
 
 1. **Search** to find relevant pages → get a list of URLs
 2. **Scrape** the most relevant URLs → get clean content
-3. **Interact** only if a page needs clicks or login → handle dynamic content
+3. **Interact** when the scraped page needs follow-up actions
+4. **Agent** when the task needs autonomous discovery or structured multi-page extraction
 
 For bulk work, agents use **Map** to discover URLs first, then **Crawl** or selectively **Scrape** the pages they need.
 
 ## Firecrawl MCP Server
 
-MCP is an open protocol that standardizes how applications provide context to LLMs. Among other benefits, it gives LLMs tools to act on your behalf. Our [MCP server](https://github.com/firecrawl/firecrawl-mcp-server) is open-source and covers our full API surface — search, scrape, crawl, map, extract, agent, and browser sessions.
+MCP is an open protocol that standardizes how applications provide context to LLMs. Among other benefits, it gives LLMs tools to act on your behalf. Our [MCP server](https://github.com/firecrawl/firecrawl-mcp-server) is open-source and covers our full API surface — search, scrape, interact, crawl, map, extract, and agent.
 
 Use the remote hosted URL:
 
@@ -373,12 +381,9 @@ See the full list of quickstarts (Express, NestJS, Fastify, Hono, Bun, Remix, Nu
 
 ## Agent Harnesses
 
-Firecrawl works with the runtimes and frameworks agents actually live inside — coding agents, browser agents, agent SDKs, and model aggregators. Most coding harnesses can auto-discover the Firecrawl skills via `npx -y firecrawl-cli@latest init --all`; the rest call Firecrawl as a tool over MCP or the REST API.
+Firecrawl works with the runtimes and frameworks agents actually live inside — coding agents, agent SDKs, and model aggregators. Most coding harnesses can auto-discover the Firecrawl skills via `npx -y firecrawl-cli@latest init --all --browser`; the rest call Firecrawl as a tool over MCP or the REST API.
 
 <CardGroup cols={3}>
-  <Card title="OpenClaw" icon="lobster" href="/quickstarts/openclaw">
-    Open spec for agentic browser control with sandboxed sessions.
-  </Card>
   <Card title="Claude Code" icon="terminal" href="/quickstarts/claude-code">
     Anthropic's CLI — set up Firecrawl MCP in Claude Code.
   </Card>

--- a/ai-onboarding.mdx
+++ b/ai-onboarding.mdx
@@ -9,7 +9,7 @@ sidebarTitle: "Build with AI"
 If you're developing with AI, Firecrawl offers several resources to improve your experience. Firecrawl ships with **skills** — self-contained knowledge packs that AI coding agents discover and use automatically. One install command gives agents CLI tools for live web work and build skills for integrating Firecrawl into application code. Agents like Claude Code, Cursor, Antigravity, and OpenCode can self-onboard with a single command — no human setup required after the API key exists.
 
 - [Prerequisite: Create an API Key](#prerequisite-create-an-api-key)
-- [Skill + CLI](#skill-cli)
+- [Skills + CLI](#skills-cli)
 - [Using Firecrawl as a Tool](#using-firecrawl-as-a-tool)
 - [Firecrawl MCP Server](#firecrawl-mcp-server)
 - [Firecrawl Docs for Agents](#firecrawl-docs-for-agents)
@@ -19,23 +19,27 @@ If you're developing with AI, Firecrawl offers several resources to improve your
 
 ## Prerequisite: Create an API Key
 
-Currently, we require a human to create a Firecrawl account. Once you have an account, you'll need to [create an API key](https://www.firecrawl.dev/app/api-keys). With an API key, your agent can handle the rest — installing the skill, authenticating the CLI, wiring up MCP, and making calls on your behalf.
+Currently, we require a human to create a Firecrawl account. Once you have an account, you'll need to [create an API key](https://www.firecrawl.dev/app/api-keys). With an API key, your agent can handle the rest — installing the skills, authenticating the CLI, wiring up MCP, and making calls on your behalf.
 
-<Card title="Get your API key" icon="key" href="https://www.firecrawl.dev/app/api-keys">
+<Card
+  title="Get your API key"
+  icon="key"
+  href="https://www.firecrawl.dev/app/api-keys"
+>
   Sign up and grab an API key to start using Firecrawl.
 </Card>
 
-## Skill + CLI
+## Skills + CLI
 
 The [Firecrawl CLI](/sdks/cli) lets your agent search, scrape, crawl, extract, and drive a browser from the terminal. It's built for humans, AI agents, and CI/CD pipelines.
 
-The Firecrawl **Skill** is a self-contained knowledge pack that AI coding agents like Claude Code, Antigravity, and OpenCode discover and use automatically. A single install command sets up everything — the CLI tools for live web work and the build skills for integrating Firecrawl into application code:
+The Firecrawl **skills** are self-contained knowledge packs that AI coding agents like Claude Code, Antigravity, and OpenCode discover and use automatically. A single install command sets up everything — the CLI tools for live web work and the build skills for integrating Firecrawl into application code:
 
 ```bash
 npx -y firecrawl-cli@latest init --all --browser
 ```
 
-- `--all` installs the Firecrawl skill to every detected AI coding agent on the machine
+- `--all` installs the Firecrawl skills to every detected AI coding agent on the machine
 - `--browser` opens the browser so the human can sign in or create an account
 
 After install, verify everything is working:
@@ -51,26 +55,26 @@ The install sets up two categories of skills that cover every way an agent uses 
 
 **CLI skills** — for live web work during an agent session:
 
-| Skill | Purpose |
-|-------|---------|
-| `firecrawl/cli` | Overall CLI command workflow |
-| `firecrawl-search` | Search the web and discover pages |
-| `firecrawl-scrape` | Extract clean content from a known URL |
+| Skill                | Purpose                                  |
+| -------------------- | ---------------------------------------- |
+| `firecrawl/cli`      | Overall CLI command workflow             |
+| `firecrawl-search`   | Search the web and discover pages        |
+| `firecrawl-scrape`   | Extract clean content from a known URL   |
 | `firecrawl-interact` | Drive a live page — clicks, forms, login |
-| `firecrawl-crawl` | Bulk-extract content from an entire site |
-| `firecrawl-map` | Discover all URLs on a domain |
+| `firecrawl-crawl`    | Bulk-extract content from an entire site |
+| `firecrawl-map`      | Discover all URLs on a domain            |
 
 **Build skills** — for integrating Firecrawl into application code:
 
-| Skill | Purpose |
-|-------|---------|
-| `firecrawl-build` | Choose the right Firecrawl endpoint for your product |
-| `firecrawl-build-onboarding` | Auth and project setup |
-| `firecrawl-build-scrape` | Implement scraping in app code |
-| `firecrawl-build-search` | Implement search in app code |
-| `firecrawl-build-interact` | Implement browser interaction in app code |
-| `firecrawl-build-crawl` | Implement crawling in app code |
-| `firecrawl-build-map` | Implement URL discovery in app code |
+| Skill                        | Purpose                                              |
+| ---------------------------- | ---------------------------------------------------- |
+| `firecrawl-build`            | Choose the right Firecrawl endpoint for your product |
+| `firecrawl-build-onboarding` | Auth and project setup                               |
+| `firecrawl-build-scrape`     | Implement scraping in app code                       |
+| `firecrawl-build-search`     | Implement search in app code                         |
+| `firecrawl-build-interact`   | Implement browser interaction in app code            |
+| `firecrawl-build-crawl`      | Implement crawling in app code                       |
+| `firecrawl-build-map`        | Implement URL discovery in app code                  |
 
 ### Choose your path
 
@@ -95,11 +99,13 @@ Both skill categories use the same install. The difference is what happens next:
     # Crawl a whole site
     firecrawl crawl https://docs.firecrawl.dev
     ```
+
   </Step>
   <Step title="App integration (Build skills)">
     Use this when you're building an application, agent, or workflow that calls the Firecrawl API from code. The build skills help with picking the right endpoint, wiring up the SDK, and running a smoke test.
 
-    The agent answers one key question — *what should Firecrawl do in the product?* — and the build skill routes to `/search`, `/scrape`, `/interact`, `/crawl`, or `/map` accordingly.
+    The agent answers one key question — *what should Firecrawl do in the product?* — and the build skills route to `/search`, `/scrape`, `/interact`, `/crawl`, or `/map` accordingly.
+
   </Step>
   <Step title="REST API (no install needed)">
     If you prefer not to install anything, agents can call the Firecrawl REST API directly. Set the API key and hit the endpoints:
@@ -109,13 +115,15 @@ Both skill categories use the same install. The difference is what happens next:
     - `POST https://api.firecrawl.dev/v2/interact` — browser actions on live pages
 
     Auth header: `Authorization: Bearer fc-YOUR_API_KEY`
+
   </Step>
 </Steps>
 
-The full skill definition is available at [`firecrawl.dev/agent-onboarding/SKILL.md`](https://www.firecrawl.dev/agent-onboarding/SKILL.md) — agents can fetch it directly for self-onboarding.
+The full onboarding definition is available at [`firecrawl.dev/agent-onboarding/SKILL.md`](https://www.firecrawl.dev/agent-onboarding/SKILL.md) — agents can fetch it directly for self-onboarding.
 
-<Card title="Skill + CLI" icon="terminal" href="/sdks/cli">
-  Install the CLI and skill, authenticate, and run scrape, search, crawl, extract, and browser commands from the terminal.
+<Card title="Skills + CLI" icon="terminal" href="/sdks/cli">
+  Install the CLI and skills, authenticate, and run scrape, search, crawl,
+  extract, and browser commands from the terminal.
 </Card>
 
 ## Using Firecrawl as a Tool
@@ -140,6 +148,7 @@ Firecrawl gives agents five core tools for working with the web. Each tool maps 
     ```
 
     **When to use:** Research tasks, finding documentation, competitive analysis, answering questions that require up-to-date web information.
+
   </Accordion>
 
   <Accordion title="Scrape — extract content from a URL" icon="file-lines">
@@ -159,6 +168,7 @@ Firecrawl gives agents five core tools for working with the web. Each tool maps 
     ```
 
     **When to use:** Reading documentation, extracting article content, pulling data from a known page, converting web pages to context for LLMs.
+
   </Accordion>
 
   <Accordion title="Crawl — bulk-extract an entire site" icon="spider">
@@ -178,6 +188,7 @@ Firecrawl gives agents five core tools for working with the web. Each tool maps 
     ```
 
     **When to use:** Ingesting full documentation sites, building knowledge bases, migrating content, training data collection.
+
   </Accordion>
 
   <Accordion title="Map — discover all URLs on a domain" icon="sitemap">
@@ -197,6 +208,7 @@ Firecrawl gives agents five core tools for working with the web. Each tool maps 
     ```
 
     **When to use:** Site audits, finding specific pages on a large site, understanding site structure before a targeted crawl.
+
   </Accordion>
 
   <Accordion title="Interact — drive a live browser" icon="hand-pointer">
@@ -216,6 +228,7 @@ Firecrawl gives agents five core tools for working with the web. Each tool maps 
     ```
 
     **When to use:** Pages behind login walls, filling out forms, navigating multi-step flows, interacting with dynamic SPAs.
+
   </Accordion>
 </AccordionGroup>
 
@@ -256,7 +269,8 @@ Or add the local server to any MCP client:
 ```
 
 <Card title="MCP Server" icon="plug" href="/mcp-server">
-  View installation instructions for Cursor, Claude Desktop, Windsurf, VS Code, and more.
+  View installation instructions for Cursor, Claude Desktop, Windsurf, VS Code,
+  and more.
 </Card>
 
 ## Firecrawl Docs for Agents
@@ -270,6 +284,7 @@ You can give your agent current Firecrawl docs in a context-aware way. Agents ca
     ```
     Docs for this page: https://docs.firecrawl.dev/ai-onboarding.md
     ```
+
   </Step>
   <Step title="Full llms.txt">
     Give your agent all of our docs in a single file.
@@ -279,6 +294,7 @@ You can give your agent current Firecrawl docs in a context-aware way. Agents ca
     ```
 
     A shorter index is also available at `https://docs.firecrawl.dev/llms.txt`.
+
   </Step>
   <Step title="MCP docs server">
     For a structured approach using MCP tools, connect the Firecrawl MCP server in any MCP client (Cursor, Claude Code, Claude Desktop, Windsurf). See the [MCP Server](/mcp-server) page for install commands.
@@ -294,10 +310,10 @@ Drop-in quickstarts for the stacks agents build on most often. Point your agent 
 
 Prefer to let Cursor drive? One-click install the Firecrawl MCP server and start prompting in Cursor:
 
-<a href='cursor://anysphere.cursor-deeplink/mcp/install?name=firecrawl&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsImZpcmVjcmF3bC1tY3AiXSwiZW52Ijp7IkZJUkVDUkFXTF9BUElfS0VZIjoiWU9VUi1BUEktS0VZIn19'>
+<a href="cursor://anysphere.cursor-deeplink/mcp/install?name=firecrawl&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsImZpcmVjcmF3bC1tY3AiXSwiZW52Ijp7IkZJUkVDUkFXTF9BUElfS0VZIjoiWU9VUi1BUEktS0VZIn19">
   <img
-    src='https://cursor.com/deeplink/mcp-install-dark.png'
-    alt='Open in Cursor — Add Firecrawl MCP server'
+    src="https://cursor.com/deeplink/mcp-install-dark.png"
+    alt="Open in Cursor — Add Firecrawl MCP server"
     style={{ maxHeight: 32 }}
   />
 </a>
@@ -315,16 +331,28 @@ Prefer to let Cursor drive? One-click install the Firecrawl MCP server and start
   <Card title="FastAPI" icon="bolt" href="/quickstarts/fastapi">
     Build async Python APIs that search, scrape, and extract.
   </Card>
-  <Card title="Cloudflare Workers" icon="cloudflare" href="/quickstarts/cloudflare-workers">
+  <Card
+    title="Cloudflare Workers"
+    icon="cloudflare"
+    href="/quickstarts/cloudflare-workers"
+  >
     Run Firecrawl at the edge with Workers.
   </Card>
-  <Card title="Vercel Functions" icon="triangle" href="/quickstarts/vercel-functions">
+  <Card
+    title="Vercel Functions"
+    icon="triangle"
+    href="/quickstarts/vercel-functions"
+  >
     Call Firecrawl from Vercel serverless functions.
   </Card>
   <Card title="AWS Lambda" icon="aws" href="/quickstarts/aws-lambda">
     Invoke Firecrawl from Lambda handlers.
   </Card>
-  <Card title="Supabase Edge Functions" icon="database" href="/quickstarts/supabase-edge-functions">
+  <Card
+    title="Supabase Edge Functions"
+    icon="database"
+    href="/quickstarts/supabase-edge-functions"
+  >
     Use Firecrawl inside Supabase Deno runtime.
   </Card>
   <Card title="Go" icon="golang" href="/quickstarts/go">
@@ -345,7 +373,7 @@ See the full list of quickstarts (Express, NestJS, Fastify, Hono, Bun, Remix, Nu
 
 ## Agent Harnesses
 
-Firecrawl works with the runtimes and frameworks agents actually live inside — coding agents, browser agents, agent SDKs, and model aggregators. Most coding harnesses can auto-discover the Firecrawl skill via `npx -y firecrawl-cli@latest init --all`; the rest call Firecrawl as a tool over MCP or the REST API.
+Firecrawl works with the runtimes and frameworks agents actually live inside — coding agents, browser agents, agent SDKs, and model aggregators. Most coding harnesses can auto-discover the Firecrawl skills via `npx -y firecrawl-cli@latest init --all`; the rest call Firecrawl as a tool over MCP or the REST API.
 
 <CardGroup cols={3}>
   <Card title="OpenClaw" icon="lobster" href="/quickstarts/openclaw">

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -6,7 +6,8 @@ og:description: "Search the web, scrape any page, and interact with it — all t
 ---
 
 <Note>
-  **For AI agents:** Append `.md` to any docs URL for markdown, e.g. [introduction.md](/introduction.md).
+  **For AI agents:** Append `.md` to any docs URL for markdown, e.g.
+  [introduction.md](/introduction.md).
 </Note>
 
 import SearchPython from "/snippets/v2/search/base/python.mdx";
@@ -28,24 +29,33 @@ import InteractResponse from "/snippets/v2/interact/response/output.mdx";
 ## Get started
 
 <CardGroup cols={2}>
-  <Card title="Get your API key" icon="key" href="https://www.firecrawl.dev/app/api-keys">
+  <Card
+    title="Get your API key"
+    icon="key"
+    href="https://www.firecrawl.dev/app/api-keys"
+  >
     Sign up and get your API key to start using Firecrawl
   </Card>
-  <Card title="Try it in the Playground" icon="play" href="https://www.firecrawl.dev/playground">
+  <Card
+    title="Try it in the Playground"
+    icon="play"
+    href="https://www.firecrawl.dev/playground"
+  >
     Test the API instantly without writing any code
   </Card>
 </CardGroup>
 
 ### Use Firecrawl with AI agents (recommended)
 
-The Firecrawl skill is the fastest way for agents to discover and use Firecrawl. Without it, your agent will not know Firecrawl is available.
+The Firecrawl skills are the fastest way for agents to discover and use Firecrawl. Without them, your agent will not know Firecrawl is available.
 
 ```bash
 npx -y firecrawl-cli@latest init --all --browser
 ```
 
 <Note>
-Restart your agent after installing the skill. See [Skill + CLI](/sdks/cli) for the full setup.
+  Restart your agent after installing the skills. See [Skills + CLI](/sdks/cli)
+  for the full setup.
 </Note>
 
 Or use the [MCP Server](/mcp-server) to connect Firecrawl directly to Claude, Cursor, Windsurf, VS Code, and other AI tools.
@@ -62,7 +72,8 @@ Or use the [MCP Server](/mcp-server) to connect Firecrawl directly to Claude, Cu
     Extract content from any URL as markdown, HTML, or structured JSON
   </Card>
   <Card title="Interact" icon="hand-pointer" href="#interact">
-    Continue working with any scraped page — click, fill forms, extract dynamic content
+    Continue working with any scraped page — click, fill forms, extract dynamic
+    content
   </Card>
 </CardGroup>
 
@@ -167,10 +178,18 @@ Scrape a page, then keep working with it — click buttons, fill forms, extract 
   <Card title="SDKs" icon="boxes-stacked" href="/sdks/overview">
     Python, Node.js, CLI, and community SDKs
   </Card>
-  <Card title="Open Source" icon="github" href="/contributing/open-source-or-cloud">
+  <Card
+    title="Open Source"
+    icon="github"
+    href="/contributing/open-source-or-cloud"
+  >
     Self-host Firecrawl or contribute to the project
   </Card>
-  <Card title="Integrations" icon="puzzle-piece" href="/developer-guides/llm-sdks-and-frameworks/openai">
+  <Card
+    title="Integrations"
+    icon="puzzle-piece"
+    href="/developer-guides/llm-sdks-and-frameworks/openai"
+  >
     LangChain, LlamaIndex, OpenAI, and more
   </Card>
 </CardGroup>

--- a/sdks/cli.mdx
+++ b/sdks/cli.mdx
@@ -22,10 +22,9 @@ import SearchBasic from "/snippets/v2/cli/search/basic.mdx";
 import SearchOptions from "/snippets/v2/cli/search/options.mdx";
 import AgentBasic from "/snippets/v2/cli/agent/basic.mdx";
 import AgentOptions from "/snippets/v2/cli/agent/options.mdx";
-import BrowserBasic from "/snippets/v2/browser/cli/basic.mdx";
-import BrowserOptions from "/snippets/v2/browser/cli/options.mdx";
+import InteractCLI from "/snippets/v2/interact/quickstart/cli.mdx";
 
-Search, scrape, and interact with the web directly from the terminal. The Firecrawl CLI works standalone or with skills that AI coding agents like Claude Code, Antigravity, and OpenCode can discover and use automatically.
+Search, scrape, interact, crawl, map, and run agent jobs directly from the terminal. The Firecrawl CLI works standalone or with skills that AI coding agents like Claude Code, Antigravity, and OpenCode can discover and use automatically.
 
 ## Installation
 
@@ -197,52 +196,25 @@ Discover all URLs on a website quickly.
 
 ---
 
-### Browser
+### Interact
 
-Have your agents interact with the web using a secure browser sandbox.
+Scrape a page, then interact with it using natural language or code. Interact uses the most recent scrape by default, or you can pass a specific scrape ID.
 
-Launch cloud browser sessions and execute Python, JavaScript, or bash code remotely. Each session runs a full Chromium instance — no local browser install required. Code runs server-side with a pre-configured [Playwright](https://playwright.dev/) `page` object ready to use.
+<InteractCLI />
 
-<BrowserBasic />
+**Available Options:**
 
-#### Browser Options
-
-<BrowserOptions />
-
-**Subcommands:**
-
-| Subcommand       | Description                                                                         |
-| ---------------- | ----------------------------------------------------------------------------------- |
-| `launch-session` | Launch a new cloud browser session (returns session ID, CDP URL, and live view URL) |
-| `execute <code>` | Execute Playwright Python/JS code or bash commands in a session                     |
-| `list [status]`  | List browser sessions (filter by `active` or `destroyed`)                           |
-| `close`          | Close a browser session                                                             |
-
-**Execute Options:**
-
-| Option           | Description                                                                                                                                                                                                                                                                                |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--bash`         | Execute bash commands remotely in the sandbox (default). [agent-browser](https://github.com/vercel-labs/agent-browser) (40+ commands) is pre-installed and auto-prefixed. `CDP_URL` is auto-injected so agent-browser connects to your session automatically. Best approach for AI agents. |
-| `--python`       | Execute as Playwright Python code. A Playwright `page` object is available — use `await page.goto()`, `await page.title()`, etc.                                                                                                                                                           |
-| `--node`         | Execute as Playwright JavaScript code. Same `page` object available.                                                                                                                                                                                                                       |
-| `--session <id>` | Target a specific session (default: active session)                                                                                                                                                                                                                                        |
-
-**Launch Options:**
-
-| Option                       | Description                                                         |
-| ---------------------------- | ------------------------------------------------------------------- |
-| `--ttl <seconds>`            | Total session TTL (default: 600, range: 30–3600)                    |
-| `--ttl-inactivity <seconds>` | Auto-close after inactivity (range: 10–3600)                        |
-| `--profile <name>`           | Name for a profile (saves and reuses browser state across sessions) |
-| `--no-save-changes`          | Load existing profile data without saving changes back              |
-| `--stream`                   | Enable live view streaming                                          |
-
-**Common Options:**
-
-| Option            | Description           |
-| ----------------- | --------------------- |
-| `--output <path>` | Save output to file   |
-| `--json`          | Output as JSON format |
+| Option                 | Description                                    |
+| ---------------------- | ---------------------------------------------- |
+| `-p, --prompt <text>`  | AI prompt (alternative to positional argument) |
+| `-c, --code <code>`    | Code to execute in the live page session       |
+| `-s, --scrape-id <id>` | Scrape job ID (default: last scrape)           |
+| `--python`             | Execute code as Python/Playwright              |
+| `--node`               | Execute code as Node.js/Playwright (default)   |
+| `--bash`               | Execute code as Bash                           |
+| `--timeout <seconds>`  | Timeout in seconds (1-300, default: 30)        |
+| `--output <path>`      | Save output to file                            |
+| `--json`               | Output as JSON format                          |
 
 ---
 
@@ -425,29 +397,6 @@ firecrawl agent "Find the top 5 AI startups and their funding amounts" --wait
 
 # Focus on specific URLs
 firecrawl agent "Compare pricing plans" --urls https://slack.com/pricing,https://teams.microsoft.com/pricing --wait
-```
-
-### Browser Automation
-
-```bash CLI
-# Launch a session, scrape a page, and close
-firecrawl browser launch-session
-firecrawl browser execute "open https://news.ycombinator.com"
-firecrawl browser execute "snapshot"
-firecrawl browser execute "scrape"
-firecrawl browser close
-
-# Use agent-browser via bash mode (default — recommended for AI agents)
-firecrawl browser launch-session
-firecrawl browser execute "open https://example.com"
-firecrawl browser execute "snapshot"
-# snapshot returns @ref IDs — use them to interact
-firecrawl browser execute "click @e5"
-firecrawl browser execute "fill @e3 'search query'"
-firecrawl browser execute "scrape"
-# Run --help to see all 40+ commands
-firecrawl browser execute --bash "agent-browser --help"
-firecrawl browser close
 ```
 
 ### Combine with Other Tools

--- a/sdks/cli.mdx
+++ b/sdks/cli.mdx
@@ -1,53 +1,50 @@
 ---
-title: 'Skill + CLI'
-description: 'Firecrawl Skill is an easy way for AI agents such as Claude Code, Antigravity and  OpenCode to use Firecrawl through the CLI.'
+title: "Skills + CLI"
+description: "Firecrawl skills are an easy way for AI agents such as Claude Code, Antigravity and OpenCode to use Firecrawl through the CLI."
 og:title: "CLI | Firecrawl"
-og:description: "Firecrawl Skills is an easy way for AI agents to use Firecrawl through the CLI. AI agents can get web data through a better and more context efficient interface"
+og:description: "Firecrawl skills are an easy way for AI agents to use Firecrawl through the CLI. AI agents can get web data through a better and more context efficient interface"
 ---
 
-import InstallationCLI from '/snippets/v2/cli/installation/bash.mdx'
-import AuthLogin from '/snippets/v2/cli/auth/login.mdx'
-import AuthLogout from '/snippets/v2/cli/auth/logout.mdx'
-import AuthConfig from '/snippets/v2/cli/auth/config.mdx'
-import AuthSelfHosted from '/snippets/v2/cli/auth/self-hosted.mdx'
-import ScrapeBasic from '/snippets/v2/cli/scrape/basic.mdx'
-import ScrapeFormats from '/snippets/v2/cli/scrape/formats.mdx'
-import ScrapeOptions from '/snippets/v2/cli/scrape/options.mdx'
-import CrawlBasic from '/snippets/v2/cli/crawl/basic.mdx'
-import CrawlStatus from '/snippets/v2/cli/crawl/status.mdx'
-import CrawlOptions from '/snippets/v2/cli/crawl/options.mdx'
-import MapBasic from '/snippets/v2/cli/map/basic.mdx'
-import MapOptions from '/snippets/v2/cli/map/options.mdx'
-import SearchBasic from '/snippets/v2/cli/search/basic.mdx'
-import SearchOptions from '/snippets/v2/cli/search/options.mdx'
-import AgentBasic from '/snippets/v2/cli/agent/basic.mdx'
-import AgentOptions from '/snippets/v2/cli/agent/options.mdx'
-import BrowserBasic from '/snippets/v2/browser/cli/basic.mdx'
-import BrowserOptions from '/snippets/v2/browser/cli/options.mdx'
+import InstallationCLI from "/snippets/v2/cli/installation/bash.mdx";
+import AuthLogin from "/snippets/v2/cli/auth/login.mdx";
+import AuthLogout from "/snippets/v2/cli/auth/logout.mdx";
+import AuthConfig from "/snippets/v2/cli/auth/config.mdx";
+import AuthSelfHosted from "/snippets/v2/cli/auth/self-hosted.mdx";
+import ScrapeBasic from "/snippets/v2/cli/scrape/basic.mdx";
+import ScrapeFormats from "/snippets/v2/cli/scrape/formats.mdx";
+import ScrapeOptions from "/snippets/v2/cli/scrape/options.mdx";
+import CrawlBasic from "/snippets/v2/cli/crawl/basic.mdx";
+import CrawlStatus from "/snippets/v2/cli/crawl/status.mdx";
+import CrawlOptions from "/snippets/v2/cli/crawl/options.mdx";
+import MapBasic from "/snippets/v2/cli/map/basic.mdx";
+import MapOptions from "/snippets/v2/cli/map/options.mdx";
+import SearchBasic from "/snippets/v2/cli/search/basic.mdx";
+import SearchOptions from "/snippets/v2/cli/search/options.mdx";
+import AgentBasic from "/snippets/v2/cli/agent/basic.mdx";
+import AgentOptions from "/snippets/v2/cli/agent/options.mdx";
+import BrowserBasic from "/snippets/v2/browser/cli/basic.mdx";
+import BrowserOptions from "/snippets/v2/browser/cli/options.mdx";
 
-Search, scrape, and interact with the web directly from the terminal. The Firecrawl CLI works standalone or as a skill that AI coding agents like Claude Code, Antigravity, and OpenCode can discover and use automatically.
+Search, scrape, and interact with the web directly from the terminal. The Firecrawl CLI works standalone or with skills that AI coding agents like Claude Code, Antigravity, and OpenCode can discover and use automatically.
 
 ## Installation
 
-If you are using an AI agent like Claude Code, you can install the Firecrawl skill below and the agent will set it up for you.
+If you are using an AI agent like Claude Code, you can install the Firecrawl skills below and the agent will set them up for you.
 
 ```bash
 npx -y firecrawl-cli@latest init --all --browser
 ```
-- `--all` installs the Firecrawl skill to every detected AI coding agent
+
+- `--all` installs the Firecrawl skills to every detected AI coding agent
 - `--browser` opens the browser for Firecrawl authentication automatically
 
 <Note>
-After installing the skill, restart your agent for it to discover the new skill.
+  After installing the skills, restart your agent for it to discover them.
 </Note>
-
 
 You can also manually install the Firecrawl CLI globally using npm:
 
 <InstallationCLI />
-
-
-
 
 ## Authentication
 
@@ -84,7 +81,7 @@ firecrawl --status
 Output when ready:
 
 ```
-  🔥 firecrawl cli v1.1.1
+  🔥 firecrawl cli v1.16.2
 
   ● Authenticated via FIRECRAWL_API_KEY
   Concurrency: 0/100 jobs (parallel scrape limit)
@@ -94,10 +91,6 @@ Output when ready:
 - **Concurrency**: Maximum parallel jobs. Run parallel operations close to this limit but not above.
 - **Credits**: Remaining API credits. Each scrape/crawl consumes credits.
 
-
-
-
-
 ## Commands
 
 ### Scrape
@@ -105,7 +98,9 @@ Output when ready:
 Scrape a single URL and extract its content in various formats.
 
 <Tip>
-Use `--only-main-content` to get clean output without navigation, footers, and ads. This is recommended for most use cases where you want just the article or main page content.
+  Use `--only-main-content` to get clean output without navigation, footers, and
+  ads. This is recommended for most use cases where you want just the article or
+  main page content.
 </Tip>
 
 <ScrapeBasic />
@@ -120,23 +115,28 @@ Use `--only-main-content` to get clean output without navigation, footers, and a
 
 **Available Options:**
 
-| Option | Short | Description |
-|--------|-------|-------------|
-| `--url <url>` | `-u` | URL to scrape (alternative to positional argument) |
-| `--format <formats>` | `-f` | Output formats (comma-separated): `markdown`, `html`, `rawHtml`, `links`, `screenshot`, `json`, `images`, `summary`, `changeTracking`, `attributes`, `branding` |
-| `--html` | `-H` | Shortcut for `--format html` |
-| `--only-main-content` | | Extract only main content |
-| `--wait-for <ms>` | | Wait time in milliseconds for JS rendering |
-| `--screenshot` | | Take a screenshot |
-| `--include-tags <tags>` | | HTML tags to include (comma-separated) |
-| `--exclude-tags <tags>` | | HTML tags to exclude (comma-separated) |
-| `--output <path>` | `-o` | Save output to file |
-| `--json` | | Force JSON output even with single format |
-| `--pretty` | | Pretty print JSON output |
-| `--timing` | | Show request timing and other useful information |
+| Option                   | Short | Description                                                                                                                                                     |
+| ------------------------ | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--url <url>`            | `-u`  | URL to scrape (alternative to positional argument)                                                                                                              |
+| `--format <formats>`     | `-f`  | Output formats (comma-separated): `markdown`, `html`, `rawHtml`, `links`, `screenshot`, `json`, `images`, `summary`, `changeTracking`, `attributes`, `branding` |
+| `--html`                 | `-H`  | Shortcut for `--format html`                                                                                                                                    |
+| `--only-main-content`    |       | Extract only main content                                                                                                                                       |
+| `--wait-for <ms>`        |       | Wait time in milliseconds for JS rendering                                                                                                                      |
+| `--screenshot`           |       | Take a screenshot                                                                                                                                               |
+| `--full-page-screenshot` |       | Take a full page screenshot                                                                                                                                     |
+| `--include-tags <tags>`  |       | HTML tags to include (comma-separated)                                                                                                                          |
+| `--exclude-tags <tags>`  |       | HTML tags to exclude (comma-separated)                                                                                                                          |
+| `--schema <json>`        |       | JSON schema for structured extraction                                                                                                                           |
+| `--schema-file <path>`   |       | Path to JSON schema file                                                                                                                                        |
+| `--actions <json>`       |       | JSON actions array to run during scrape                                                                                                                         |
+| `--actions-file <path>`  |       | Path to JSON actions file                                                                                                                                       |
+| `--proxy <proxy>`        |       | Proxy mode for scraping (for example, `auto` or `basic`)                                                                                                        |
+| `--output <path>`        | `-o`  | Save output to file                                                                                                                                             |
+| `--json`                 |       | Force JSON output even with single format                                                                                                                       |
+| `--pretty`               |       | Pretty print JSON output                                                                                                                                        |
+| `--timing`               |       | Show request timing and other useful information                                                                                                                |
 
 ---
-
 
 ### Search
 
@@ -150,25 +150,24 @@ Search the web and optionally scrape the results.
 
 **Available Options:**
 
-| Option | Description |
-|--------|-------------|
-| `--limit <number>` | Maximum results (default: 5, max: 100) |
-| `--sources <sources>` | Sources to search: `web`, `images`, `news` (comma-separated) |
-| `--categories <categories>` | Filter by category: `github`, `research`, `pdf` (comma-separated) |
-| `--tbs <value>` | Time filter: `qdr:h` (hour), `qdr:d` (day), `qdr:w` (week), `qdr:m` (month), `qdr:y` (year) |
-| `--location <location>` | Geo-targeting (e.g., "Berlin,Germany") |
-| `--country <code>` | ISO country code (default: US) |
-| `--timeout <ms>` | Timeout in milliseconds (default: 60000) |
-| `--ignore-invalid-urls` | Exclude URLs invalid for other Firecrawl endpoints |
-| `--scrape` | Scrape search results |
-| `--scrape-formats <formats>` | Formats for scraped content (default: markdown) |
-| `--only-main-content` | Include only main content when scraping (default: true) |
-| `--json` | Output as JSON |
-| `--output <path>` | Save output to file |
-| `--pretty` | Pretty print JSON output |
+| Option                       | Description                                                                                 |
+| ---------------------------- | ------------------------------------------------------------------------------------------- |
+| `--limit <number>`           | Maximum results (default: 5, max: 100)                                                      |
+| `--sources <sources>`        | Sources to search: `web`, `images`, `news` (comma-separated)                                |
+| `--categories <categories>`  | Filter by category: `github`, `research`, `pdf` (comma-separated)                           |
+| `--tbs <value>`              | Time filter: `qdr:h` (hour), `qdr:d` (day), `qdr:w` (week), `qdr:m` (month), `qdr:y` (year) |
+| `--location <location>`      | Geo-targeting (e.g., "Berlin,Germany")                                                      |
+| `--country <code>`           | ISO country code (default: US)                                                              |
+| `--timeout <ms>`             | Timeout in milliseconds (default: 60000)                                                    |
+| `--ignore-invalid-urls`      | Exclude URLs invalid for other Firecrawl endpoints                                          |
+| `--scrape`                   | Scrape search results                                                                       |
+| `--scrape-formats <formats>` | Formats for scraped content (default: markdown)                                             |
+| `--only-main-content`        | Include only main content when scraping (default: true)                                     |
+| `--json`                     | Output as JSON                                                                              |
+| `--output <path>`            | Save output to file                                                                         |
+| `--pretty`                   | Pretty print JSON output                                                                    |
 
 ---
-
 
 ### Map
 
@@ -182,19 +181,19 @@ Discover all URLs on a website quickly.
 
 **Available Options:**
 
-| Option | Description |
-|--------|-------------|
-| `--url <url>` | URL to map (alternative to positional argument) |
-| `--limit <number>` | Maximum URLs to discover |
-| `--search <query>` | Filter URLs by search query |
-| `--sitemap <mode>` | Sitemap handling: `include`, `skip`, `only` |
-| `--include-subdomains` | Include subdomains |
-| `--ignore-query-parameters` | Treat URLs with different params as same |
-| `--wait` | Wait for map to complete |
-| `--timeout <seconds>` | Timeout in seconds |
-| `--json` | Output as JSON |
-| `--output <path>` | Save output to file |
-| `--pretty` | Pretty print JSON output |
+| Option                      | Description                                     |
+| --------------------------- | ----------------------------------------------- |
+| `--url <url>`               | URL to map (alternative to positional argument) |
+| `--limit <number>`          | Maximum URLs to discover                        |
+| `--search <query>`          | Filter URLs by search query                     |
+| `--sitemap <mode>`          | Sitemap handling: `include`, `skip`, `only`     |
+| `--include-subdomains`      | Include subdomains                              |
+| `--ignore-query-parameters` | Treat URLs with different params as same        |
+| `--wait`                    | Wait for map to complete                        |
+| `--timeout <seconds>`       | Timeout in seconds                              |
+| `--json`                    | Output as JSON                                  |
+| `--output <path>`           | Save output to file                             |
+| `--pretty`                  | Pretty print JSON output                        |
 
 ---
 
@@ -212,38 +211,38 @@ Launch cloud browser sessions and execute Python, JavaScript, or bash code remot
 
 **Subcommands:**
 
-| Subcommand | Description |
-|------------|-------------|
+| Subcommand       | Description                                                                         |
+| ---------------- | ----------------------------------------------------------------------------------- |
 | `launch-session` | Launch a new cloud browser session (returns session ID, CDP URL, and live view URL) |
-| `execute <code>` | Execute Playwright Python/JS code or bash commands in a session |
-| `list [status]` | List browser sessions (filter by `active` or `destroyed`) |
-| `close` | Close a browser session |
+| `execute <code>` | Execute Playwright Python/JS code or bash commands in a session                     |
+| `list [status]`  | List browser sessions (filter by `active` or `destroyed`)                           |
+| `close`          | Close a browser session                                                             |
 
 **Execute Options:**
 
-| Option | Description |
-|--------|-------------|
-| `--bash` | Execute bash commands remotely in the sandbox (default). [agent-browser](https://github.com/vercel-labs/agent-browser) (40+ commands) is pre-installed and auto-prefixed. `CDP_URL` is auto-injected so agent-browser connects to your session automatically. Best approach for AI agents. |
-| `--python` | Execute as Playwright Python code. A Playwright `page` object is available — use `await page.goto()`, `await page.title()`, etc. |
-| `--node` | Execute as Playwright JavaScript code. Same `page` object available. |
-| `--session <id>` | Target a specific session (default: active session) |
+| Option           | Description                                                                                                                                                                                                                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--bash`         | Execute bash commands remotely in the sandbox (default). [agent-browser](https://github.com/vercel-labs/agent-browser) (40+ commands) is pre-installed and auto-prefixed. `CDP_URL` is auto-injected so agent-browser connects to your session automatically. Best approach for AI agents. |
+| `--python`       | Execute as Playwright Python code. A Playwright `page` object is available — use `await page.goto()`, `await page.title()`, etc.                                                                                                                                                           |
+| `--node`         | Execute as Playwright JavaScript code. Same `page` object available.                                                                                                                                                                                                                       |
+| `--session <id>` | Target a specific session (default: active session)                                                                                                                                                                                                                                        |
 
 **Launch Options:**
 
-| Option | Description |
-|--------|-------------|
-| `--ttl <seconds>` | Total session TTL (default: 600, range: 30–3600) |
-| `--ttl-inactivity <seconds>` | Auto-close after inactivity (range: 10–3600) |
-| `--profile <name>` | Name for a profile (saves and reuses browser state across sessions) |
-| `--no-save-changes` | Load existing profile data without saving changes back |
-| `--stream` | Enable live view streaming |
+| Option                       | Description                                                         |
+| ---------------------------- | ------------------------------------------------------------------- |
+| `--ttl <seconds>`            | Total session TTL (default: 600, range: 30–3600)                    |
+| `--ttl-inactivity <seconds>` | Auto-close after inactivity (range: 10–3600)                        |
+| `--profile <name>`           | Name for a profile (saves and reuses browser state across sessions) |
+| `--no-save-changes`          | Load existing profile data without saving changes back              |
+| `--stream`                   | Enable live view streaming                                          |
 
 **Common Options:**
 
-| Option | Description |
-|--------|-------------|
-| `--output <path>` | Save output to file |
-| `--json` | Output as JSON format |
+| Option            | Description           |
+| ----------------- | --------------------- |
+| `--output <path>` | Save output to file   |
+| `--json`          | Output as JSON format |
 
 ---
 
@@ -263,27 +262,31 @@ Crawl an entire website starting from a URL.
 
 **Available Options:**
 
-| Option | Description |
-|--------|-------------|
-| `--url <url>` | URL to crawl (alternative to positional argument) |
-| `--wait` | Wait for crawl to complete |
-| `--progress` | Show progress indicator while waiting |
-| `--poll-interval <seconds>` | Polling interval (default: 5) |
-| `--timeout <seconds>` | Timeout when waiting |
-| `--status` | Check status of existing crawl job |
-| `--limit <number>` | Maximum pages to crawl |
-| `--max-depth <number>` | Maximum crawl depth |
-| `--include-paths <paths>` | Paths to include (comma-separated) |
-| `--exclude-paths <paths>` | Paths to exclude (comma-separated) |
-| `--sitemap <mode>` | Sitemap handling: `include`, `skip`, `only` |
-| `--allow-subdomains` | Include subdomains |
-| `--allow-external-links` | Follow external links |
-| `--crawl-entire-domain` | Crawl entire domain |
-| `--ignore-query-parameters` | Treat URLs with different params as same |
-| `--delay <ms>` | Delay between requests |
-| `--max-concurrency <n>` | Maximum concurrent requests |
-| `--output <path>` | Save output to file |
-| `--pretty` | Pretty print JSON output |
+| Option                         | Description                                       |
+| ------------------------------ | ------------------------------------------------- |
+| `--url <url>`                  | URL to crawl (alternative to positional argument) |
+| `--wait`                       | Wait for crawl to complete                        |
+| `--progress`                   | Show progress indicator while waiting             |
+| `--poll-interval <seconds>`    | Polling interval (default: 5)                     |
+| `--timeout <seconds>`          | Timeout when waiting                              |
+| `--status`                     | Check status of existing crawl job                |
+| `--limit <number>`             | Maximum pages to crawl                            |
+| `--max-depth <number>`         | Maximum crawl depth                               |
+| `--include-paths <paths>`      | Paths to include (comma-separated)                |
+| `--exclude-paths <paths>`      | Paths to exclude (comma-separated)                |
+| `--sitemap <mode>`             | Sitemap handling: `include`, `skip`, `only`       |
+| `--allow-subdomains`           | Include subdomains                                |
+| `--allow-external-links`       | Follow external links                             |
+| `--crawl-entire-domain`        | Crawl entire domain                               |
+| `--ignore-query-parameters`    | Treat URLs with different params as same          |
+| `--delay <ms>`                 | Delay between requests                            |
+| `--max-concurrency <n>`        | Maximum concurrent requests                       |
+| `--scrape-options <json>`      | JSON scrape options passed to each page           |
+| `--scrape-options-file <path>` | Path to scrape options JSON file                  |
+| `--webhook <url-or-json>`      | Webhook URL or configuration                      |
+| `--cancel`                     | Cancel an active crawl job by job ID              |
+| `--output <path>`              | Save output to file                               |
+| `--pretty`                     | Pretty print JSON output                          |
 
 ---
 
@@ -299,19 +302,21 @@ Search and gather data from the web using natural language prompts.
 
 **Available Options:**
 
-| Option | Description |
-|--------|-------------|
-| `--urls <urls>` | Optional list of URLs to focus the agent on (comma-separated) |
-| `--model <model>` | Model to use: `spark-1-mini` (default, 60% cheaper) or `spark-1-pro` (higher accuracy) |
-| `--schema <json>` | JSON schema for structured output (inline JSON string) |
-| `--schema-file <path>` | Path to JSON schema file for structured output |
-| `--max-credits <number>` | Maximum credits to spend (job fails if limit reached) |
-| `--status` | Check status of existing agent job |
-| `--wait` | Wait for agent to complete before returning results |
-| `--poll-interval <seconds>` | Polling interval when waiting (default: 5) |
-| `--timeout <seconds>` | Timeout when waiting (default: no timeout) |
-| `--output <path>` | Save output to file |
-| `--json` | Output as JSON format |
+| Option                      | Description                                                                            |
+| --------------------------- | -------------------------------------------------------------------------------------- |
+| `--urls <urls>`             | Optional list of URLs to focus the agent on (comma-separated)                          |
+| `--model <model>`           | Model to use: `spark-1-mini` (default, 60% cheaper) or `spark-1-pro` (higher accuracy) |
+| `--schema <json>`           | JSON schema for structured output (inline JSON string)                                 |
+| `--schema-file <path>`      | Path to JSON schema file for structured output                                         |
+| `--max-credits <number>`    | Maximum credits to spend (job fails if limit reached)                                  |
+| `--webhook <url-or-json>`   | Webhook URL or configuration                                                           |
+| `--status`                  | Check status of existing agent job                                                     |
+| `--cancel`                  | Cancel an active agent job by job ID                                                   |
+| `--wait`                    | Wait for agent to complete before returning results                                    |
+| `--poll-interval <seconds>` | Polling interval when waiting (default: 5)                                             |
+| `--timeout <seconds>`       | Timeout when waiting (default: no timeout)                                             |
+| `--output <path>`           | Save output to file                                                                    |
+| `--json`                    | Output as JSON format                                                                  |
 
 ---
 
@@ -343,13 +348,13 @@ firecrawl --version
 
 These options are available for all commands:
 
-| Option | Short | Description |
-|--------|-------|-------------|
-| `--status` | | Show version, auth, concurrency, and credits |
-| `--api-key <key>` | `-k` | Override stored API key for this command |
-| `--api-url <url>` | | Use custom API URL (for self-hosted/local development) |
-| `--help` | `-h` | Show help for a command |
-| `--version` | `-V` | Show CLI version |
+| Option            | Short | Description                                            |
+| ----------------- | ----- | ------------------------------------------------------ |
+| `--status`        |       | Show version, auth, concurrency, and credits           |
+| `--api-key <key>` | `-k`  | Override stored API key for this command               |
+| `--api-url <url>` |       | Use custom API URL (for self-hosted/local development) |
+| `--help`          | `-h`  | Show help for a command                                |
+| `--version`       | `-V`  | Show CLI version                                       |
 
 ## Output Handling
 
@@ -478,6 +483,6 @@ export FIRECRAWL_NO_TELEMETRY=1
 
 ## Open Source
 
-The Firecrawl CLI and Skill are open source and available on GitHub: [firecrawl/cli](https://github.com/firecrawl/cli)
+The Firecrawl CLI and skills are open source and available on GitHub: [firecrawl/cli](https://github.com/firecrawl/cli)
 
 > Are you an AI agent that needs a Firecrawl API key? See [firecrawl.dev/agent-onboarding/SKILL.md](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for automated onboarding instructions.

--- a/snippets/v2/cli/agent/basic.mdx
+++ b/snippets/v2/cli/agent/basic.mdx
@@ -6,7 +6,7 @@ firecrawl agent "Find the top 5 AI startups and their funding amounts" --wait
 firecrawl agent "Compare pricing plans" --urls https://slack.com/pricing,https://teams.microsoft.com/pricing --wait
 
 # Use a schema for structured output
-firecrawl agent "Get company information" --urls https://example.com --schema '{"name": "string", "founded": "number"}' --wait
+firecrawl agent "Get company information" --urls https://example.com --schema '{"type":"object","properties":{"name":{"type":"string"},"founded":{"type":"number"}}}' --wait
 
 # Use schema from a file
 firecrawl agent "Get product details" --urls https://example.com --schema-file schema.json --wait

--- a/snippets/v2/cli/agent/options.mdx
+++ b/snippets/v2/cli/agent/options.mdx
@@ -8,6 +8,12 @@ firecrawl agent "Gather contact information from company websites" --max-credits
 # Check status of an existing job
 firecrawl agent <job-id> --status
 
+# Send agent events to a webhook
+firecrawl agent "Extract product details" --urls https://example.com --webhook '{"url":"https://example.com/webhook","events":["completed","failed"]}'
+
+# Cancel an active agent job
+firecrawl agent <job-id> --cancel
+
 # Custom polling interval and timeout
 firecrawl agent "Summarize recent blog posts" --wait --poll-interval 10 --timeout 300
 

--- a/snippets/v2/cli/crawl/options.mdx
+++ b/snippets/v2/cli/crawl/options.mdx
@@ -17,6 +17,15 @@ firecrawl crawl https://example.com --crawl-entire-domain --wait
 # Rate limiting
 firecrawl crawl https://example.com --delay 1000 --max-concurrency 2 --wait
 
+# Pass scrape options to each crawled page
+firecrawl crawl https://example.com --scrape-options '{"formats":["markdown"],"onlyMainContent":true}'
+
+# Send crawl completion events to a webhook
+firecrawl crawl https://example.com --webhook '{"url":"https://example.com/webhook","events":["completed"]}'
+
+# Cancel an active crawl
+firecrawl crawl <job-id> --cancel
+
 # Custom polling interval and timeout
 firecrawl crawl https://example.com --wait --poll-interval 10 --timeout 300
 

--- a/snippets/v2/cli/scrape/options.mdx
+++ b/snippets/v2/cli/scrape/options.mdx
@@ -8,6 +8,15 @@ firecrawl https://example.com --wait-for 3000
 # Take a screenshot
 firecrawl https://example.com --screenshot
 
+# Extract structured JSON with a schema
+firecrawl https://example.com --format json --schema '{"type":"object","properties":{"title":{"type":"string"}}}'
+
+# Run lightweight scrape actions before extraction
+firecrawl https://example.com --actions '[{"type":"wait","milliseconds":1000}]'
+
+# Select proxy mode
+firecrawl https://example.com --proxy basic
+
 # Include/exclude specific HTML tags
 firecrawl https://example.com --include-tags article,main
 firecrawl https://example.com --exclude-tags nav,footer


### PR DESCRIPTION
## Summary
- rename Skill + CLI wording to Skills + CLI in the English source docs
- document the new CLI scrape/crawl/agent flags from firecrawl-cli 1.16.2
- update CLI snippets for schema, proxy/actions, crawl scrape options/webhooks/cancel, and agent webhook/cancel

## Testing
- npx --yes prettier@latest --check sdks/cli.mdx ai-onboarding.mdx introduction.mdx snippets/v2/cli/scrape/options.mdx snippets/v2/cli/crawl/options.mdx snippets/v2/cli/agent/basic.mdx snippets/v2/cli/agent/options.mdx
- git diff --check

## Notes
- `mintlify broken-links` is blocked by an unrelated existing parse error in `features/extract.mdx`: `Unexpected ExpressionStatement in code: only import/exports are supported`
