### PR TITLE
docs: use jobId in scrape interact reference

### DIFF
--- a/api-reference/endpoint/scrape.mdx
+++ b/api-reference/endpoint/scrape.mdx
@@ -5,7 +5,7 @@ openapi: '/api-reference/v2-openapi.json POST /scrape'
 
 ## Interactions
 
-For browser interactions (clicking, typing, navigating, extracting dynamic content), use the [Interact endpoint](/features/interact). Scrape a page first, then call `POST /v2/scrape/{scrapeId}/interact` with a natural-language prompt or Playwright code to take actions on the page.
+For browser interactions (clicking, typing, navigating, extracting dynamic content), use the [Interact endpoint](/features/interact). Scrape a page first, then call `POST /v2/scrape/{jobId}/interact` with a natural-language prompt or Playwright code to take actions on the page.
 
 See the [Interact documentation](/features/interact) for full details and examples.
 


### PR DESCRIPTION
## Summary
- update the scrape endpoint page to use `POST /v2/scrape/{jobId}/interact`
- align the copy with the generated OpenAPI route and the dedicated interact endpoint docs

## Why
`api-reference/v2-openapi.json` and the dedicated interact pages already document `/scrape/{jobId}/interact`. The scrape page still used `scrapeId` in the copy-paste route, which can confuse users reading the public API reference.

## Validation
- `git diff --check`
- checked `api-reference/v2-openapi.json`, `api-reference/endpoint/scrape-execute.mdx`, and `api-reference/endpoint/scrape-browser-delete.mdx` for the canonical `jobId` path.