### PR TITLE
Add redirects for commonly guessed URLs by AI agents

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -4198,6 +4198,34 @@
     {
       "source": "/integrations/ai-sdk",
       "destination": "/developer-guides/llm-sdks-and-frameworks/vercel-ai-sdk"
+    },
+    {
+      "source": "/api-reference/endpoint/crawl-webhooks",
+      "destination": "/api-reference/endpoint/webhook-crawl-started"
+    },
+    {
+      "source": "/api-reference/endpoint/crawl",
+      "destination": "/api-reference/endpoint/crawl-post"
+    },
+    {
+      "source": "/api-reference/endpoint/crawl-with-webhook",
+      "destination": "/webhooks/overview"
+    },
+    {
+      "source": "/features/webhooks",
+      "destination": "/webhooks/overview"
+    },
+    {
+      "source": "/api-reference/endpoint/batch-scrape-with-webhook",
+      "destination": "/webhooks/overview"
+    },
+    {
+      "source": "/api-reference/batch-scrape",
+      "destination": "/api-reference/endpoint/batch-scrape"
+    },
+    {
+      "source": "/api-reference/webhooks",
+      "destination": "/webhooks/overview"
     }
   ]
 }

--- a/docs.json
+++ b/docs.json
@@ -4226,6 +4226,30 @@
     {
       "source": "/api-reference/webhooks",
       "destination": "/webhooks/overview"
+    },
+    {
+      "source": "/api-reference/v2-batch-scrape",
+      "destination": "/api-reference/endpoint/batch-scrape"
+    },
+    {
+      "source": "/api-reference/v2-agent",
+      "destination": "/api-reference/endpoint/agent"
+    },
+    {
+      "source": "/api-reference/agent",
+      "destination": "/api-reference/endpoint/agent"
+    },
+    {
+      "source": "/webhooks/batch-scrape-events",
+      "destination": "/webhooks/events"
+    },
+    {
+      "source": "/features/webhooks/event-types",
+      "destination": "/webhooks/events"
+    },
+    {
+      "source": "/webhooks/event-types",
+      "destination": "/webhooks/events"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds 13 redirects in `docs.json` for URLs that AI agents frequently guess incorrectly
- When agents hit 404 pages, they get stuck because WebFetch and similar tools can't read the suggested links on the 404 page — the HTTP 404 status causes the request to fail before any page content is returned
- Agents guess wrong URLs by combining concepts (`crawl-with-webhook`), omitting path segments (`/api-reference/batch-scrape`), prefixing with `v2-` (`/api-reference/v2-agent`), or inventing paths (`/features/webhooks/event-types`)
- Redirects point to the correct existing pages so agents can continue their workflows without getting blocked
- Agents seem to ignore the links in 404 pages

<img width="1289" height="1372" alt="Screenshot 2026-05-06 at 10 25 30" src="https://github.com/user-attachments/assets/7da07890-1aea-400b-8ffb-fcc74c34c5f9" />


## Redirects added

| Source | Destination |
|---|---|
| `/api-reference/endpoint/crawl-webhooks` | `/api-reference/endpoint/webhook-crawl-started` |
| `/api-reference/endpoint/crawl` | `/api-reference/endpoint/crawl-post` |
| `/api-reference/endpoint/crawl-with-webhook` | `/webhooks/overview` |
| `/features/webhooks` | `/webhooks/overview` |
| `/api-reference/endpoint/batch-scrape-with-webhook` | `/webhooks/overview` |
| `/api-reference/batch-scrape` | `/api-reference/endpoint/batch-scrape` |
| `/api-reference/webhooks` | `/webhooks/overview` |
| `/api-reference/v2-batch-scrape` | `/api-reference/endpoint/batch-scrape` |
| `/api-reference/v2-agent` | `/api-reference/endpoint/agent` |
| `/api-reference/agent` | `/api-reference/endpoint/agent` |
| `/webhooks/batch-scrape-events` | `/webhooks/events` |
| `/features/webhooks/event-types` | `/webhooks/events` |
| `/webhooks/event-types` | `/webhooks/events` |

