### PR TITLE
Optimize homepage and API reference for AI agent navigation

### DIFF
--- a/api-reference/v2-introduction.mdx
+++ b/api-reference/v2-introduction.mdx
@@ -3,6 +3,10 @@ title: 'Introduction'
 description: 'Firecrawl API Reference (v2)'
 ---
 
+<Note>
+  **For AI agents:** Use [llms.txt](/llms.txt) for a full index of all documentation.
+</Note>
+
 The Firecrawl API gives you programmatic access to web data. All endpoints share a common base URL, authentication scheme, and response format described on this page.
 
 ## Features

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -25,13 +25,6 @@ import InteractCURL from "/snippets/v2/interact/quickstart/curl.mdx";
 import InteractCLI from "/snippets/v2/interact/quickstart/cli.mdx";
 import InteractResponse from "/snippets/v2/interact/response/output.mdx";
 
-### Quick links for API integration
-
-- [API Reference (v2)](/api-reference/v2-introduction) — base URL, auth, and all endpoints
-- [Agent endpoint](/features/agent) — autonomous web data gathering
-- [Interact endpoint](/features/interact) — click, fill forms, extract dynamic content
-- [Webhooks](/webhooks) — async event delivery
-
 ## Get started
 
 <CardGroup cols={2}>
@@ -175,11 +168,20 @@ Scrape a page, then keep working with it — click buttons, fill forms, extract 
 
 ---
 
-## Resources
+## Quick links for API integration
 
 <CardGroup cols={2}>
-  <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
-    Complete API documentation with interactive examples
+  <Card title="API Reference (v2)" icon="code" href="/api-reference/v2-introduction">
+    Base URL, auth, and all endpoints
+  </Card>
+  <Card title="Agent" icon="robot" href="/features/agent">
+    Autonomous web data gathering
+  </Card>
+  <Card title="Interact" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, extract dynamic content
+  </Card>
+  <Card title="Webhooks" icon="webhook" href="/webhooks">
+    Async event delivery
   </Card>
   <Card title="SDKs" icon="boxes-stacked" href="/sdks/overview">
     Python, Node.js, CLI, and community SDKs
@@ -190,12 +192,5 @@ Scrape a page, then keep working with it — click buttons, fill forms, extract 
     href="/contributing/open-source-or-cloud"
   >
     Self-host Firecrawl or contribute to the project
-  </Card>
-  <Card
-    title="Integrations"
-    icon="puzzle-piece"
-    href="/developer-guides/llm-sdks-and-frameworks/openai"
-  >
-    LangChain, LlamaIndex, OpenAI, and more
   </Card>
 </CardGroup>

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -25,13 +25,6 @@ import InteractCURL from "/snippets/v2/interact/quickstart/curl.mdx";
 import InteractCLI from "/snippets/v2/interact/quickstart/cli.mdx";
 import InteractResponse from "/snippets/v2/interact/response/output.mdx";
 
-### Quick links for API integration
-
-- [API Reference (v2)](/api-reference/v2-introduction) — base URL, auth, and all endpoints
-- [Agent endpoint](/features/agent) — autonomous web data gathering
-- [Interact endpoint](/features/interact) — click, fill forms, extract dynamic content
-- [Webhooks](/webhooks) — async event delivery
-
 ## Get started
 
 <CardGroup cols={2}>
@@ -158,9 +151,18 @@ Scrape a page, then keep working with it — click buttons, fill forms, extract 
 
 ## More capabilities
 
-<CardGroup cols={4}>
+<CardGroup cols={2}>
+  <Card title="API Reference (v2)" icon="code" href="/api-reference/v2-introduction">
+    Base URL, auth, and all endpoints
+  </Card>
   <Card title="Agent" icon="robot" href="/features/agent">
     Autonomous web data gathering powered by AI
+  </Card>
+  <Card title="Interact" icon="hand-pointer" href="/features/interact">
+    Click, fill forms, extract dynamic content
+  </Card>
+  <Card title="Webhooks" icon="webhook" href="/webhooks">
+    Async event delivery
   </Card>
   <Card title="Browser Sandbox" icon="browser" href="/features/browser">
     Managed browser sessions for interactive workflows

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -6,7 +6,7 @@ og:description: "Search the web, scrape any page, and interact with it — all t
 ---
 
 <Note>
-  **For AI agents:** Use [llms.txt](/llms.txt) for a full index, or append `.md` to any docs URL for markdown.
+  **For AI agents:** Use [llms.txt](/llms.txt) for a full index of all documentation.
 </Note>
 
 import SearchPython from "/snippets/v2/search/base/python.mdx";

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -25,6 +25,13 @@ import InteractCURL from "/snippets/v2/interact/quickstart/curl.mdx";
 import InteractCLI from "/snippets/v2/interact/quickstart/cli.mdx";
 import InteractResponse from "/snippets/v2/interact/response/output.mdx";
 
+### Quick links for API integration
+
+- [API Reference (v2)](/api-reference/v2-introduction) — base URL, auth, and all endpoints
+- [Agent endpoint](/features/agent) — autonomous web data gathering
+- [Interact endpoint](/features/interact) — click, fill forms, extract dynamic content
+- [Webhooks](/webhooks) — async event delivery
+
 ## Get started
 
 <CardGroup cols={2}>
@@ -168,20 +175,11 @@ Scrape a page, then keep working with it — click buttons, fill forms, extract 
 
 ---
 
-## Quick links for API integration
+## Resources
 
 <CardGroup cols={2}>
-  <Card title="API Reference (v2)" icon="code" href="/api-reference/v2-introduction">
-    Base URL, auth, and all endpoints
-  </Card>
-  <Card title="Agent" icon="robot" href="/features/agent">
-    Autonomous web data gathering
-  </Card>
-  <Card title="Interact" icon="hand-pointer" href="/features/interact">
-    Click, fill forms, extract dynamic content
-  </Card>
-  <Card title="Webhooks" icon="webhook" href="/webhooks">
-    Async event delivery
+  <Card title="API Reference" icon="code" href="/api-reference/v2-introduction">
+    Complete API documentation with interactive examples
   </Card>
   <Card title="SDKs" icon="boxes-stacked" href="/sdks/overview">
     Python, Node.js, CLI, and community SDKs
@@ -192,5 +190,12 @@ Scrape a page, then keep working with it — click buttons, fill forms, extract 
     href="/contributing/open-source-or-cloud"
   >
     Self-host Firecrawl or contribute to the project
+  </Card>
+  <Card
+    title="Integrations"
+    icon="puzzle-piece"
+    href="/developer-guides/llm-sdks-and-frameworks/openai"
+  >
+    LangChain, LlamaIndex, OpenAI, and more
   </Card>
 </CardGroup>

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -6,8 +6,7 @@ og:description: "Search the web, scrape any page, and interact with it — all t
 ---
 
 <Note>
-  **For AI agents:** Append `.md` to any docs URL for markdown, e.g.
-  [introduction.md](/introduction.md).
+  **For AI agents:** Use [llms.txt](/llms.txt) for a full index, or append `.md` to any docs URL for markdown.
 </Note>
 
 import SearchPython from "/snippets/v2/search/base/python.mdx";
@@ -25,6 +24,13 @@ import InteractNode from "/snippets/v2/interact/quickstart/js.mdx";
 import InteractCURL from "/snippets/v2/interact/quickstart/curl.mdx";
 import InteractCLI from "/snippets/v2/interact/quickstart/cli.mdx";
 import InteractResponse from "/snippets/v2/interact/response/output.mdx";
+
+### Quick links for API integration
+
+- [API Reference (v2)](/api-reference/v2-introduction) — base URL, auth, and all endpoints
+- [Agent endpoint](/features/agent) — autonomous web data gathering
+- [Interact endpoint](/features/interact) — click, fill forms, extract dynamic content
+- [Webhooks](/webhooks) — async event delivery
 
 ## Get started
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -152,9 +152,6 @@ Scrape a page, then keep working with it — click buttons, fill forms, extract 
 ## More capabilities
 
 <CardGroup cols={2}>
-  <Card title="API Reference (v2)" icon="code" href="/api-reference/v2-introduction">
-    Base URL, auth, and all endpoints
-  </Card>
   <Card title="Agent" icon="robot" href="/features/agent">
     Autonomous web data gathering powered by AI
   </Card>


### PR DESCRIPTION
## Summary
- Add llms.txt pointer to homepage and API reference intro so AI agents find the machine-readable index faster
- Remove .md suffix tip (redundant when llms.txt is available)

The text I added before helped a bit but agents still seem to go to the /api-reference/... before going to llms.txt

- Add Interact, Webhooks, and other high-traffic endpoint cards to "More capabilities" section (2-column layout)

Based on agent traffic analysis showing agents navigate `/ → /api-reference/v2-intro → /llms.txt → specific endpoints`. These changes reduce hops by surfacing llms.txt earlier and adding commonly visited destinations to the homepage.

<img width="1767" height="912" alt="Screenshot 2026-05-06 at 11 23 38" src="https://github.com/user-attachments/assets/13080cdf-027b-42e7-9580-4993d18be96d" />
