### PR TITLE
docs: add Ask API and Docs Search to reference, agent pages, and OpenAPI spec

### DIFF
--- a/agent-source-of-truth/curl.mdx
+++ b/agent-source-of-truth/curl.mdx
@@ -427,15 +427,13 @@ curl -X POST "https://api.firecrawl.dev/v2/support/ask" \
 
 ### Response
 
-Successful responses include `requestId`, `answer`, `confidence`, `fixParameters`, `validation`, `evidence`, `kbCitations`, `usage`, and `durationMs`.
+Successful responses include `requestId`, `answer`, `confidence`, `fixParameters`, `validation`, `usage`, and `durationMs`.
 
 - `answer`: 2-4 sentence prose covering the diagnosis and fix.
 - `confidence`: `high`, `medium`, or `low`.
 - `fixParameters`: machine-actionable API parameters to apply the fix (null if no fix applies).
 - `validation.tested`: whether the agent tested the fix against the live API.
 - `validation.result`: `success`, `failure`, or `skipped`.
-- `evidence`: array of tool calls made during diagnosis with `tool`, `rationale`, and `summary`.
-- `kbCitations`: documentation page references.
 - `feedback`: present when the agent gets stuck; null on success.
 
 ### Parameters

--- a/agent-source-of-truth/curl.mdx
+++ b/agent-source-of-truth/curl.mdx
@@ -17,7 +17,7 @@ export FIRECRAWL_API_KEY="fc-your-api-key"
 - `scrape`: use when you already have a URL and want page content.
 - `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
 - `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
-- `support/docs-search`: use when you need to look up Firecrawl documentation (no auth required).
+- `support/docs-search`: use when you need to look up Firecrawl documentation.
 
 ## Search
 
@@ -450,11 +450,11 @@ Successful responses include `requestId`, `answer`, `confidence`, `fixParameters
   - Type: object (free-form)
   - Use when: you want to pass metadata from your agent into the debugging prompt.
 
-## Docs Search (Public)
+## Docs Search
 
 ### Why use it
 
-Use docs-search to look up Firecrawl documentation. No authentication required.
+Use docs-search to look up Firecrawl documentation.
 
 ### Endpoint
 
@@ -464,6 +464,7 @@ Use docs-search to look up Firecrawl documentation. No authentication required.
 
 ```bash
 curl -X POST "https://api.firecrawl.dev/v2/support/docs-search" \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "question": "how do I verify webhook signatures?"

--- a/agent-source-of-truth/curl.mdx
+++ b/agent-source-of-truth/curl.mdx
@@ -421,9 +421,6 @@ curl -X POST "https://api.firecrawl.dev/v2/support/ask" \
   -d '{
     "question": "crawl returned 3 pages but I expected 50",
     "rationale": "user is on their third failed crawl attempt today",
-    "jobId": "crawl_abc123",
-    "model": "claude-sonnet-4-6",
-    "maxSteps": 12,
     "context": {"userPlan": "standard", "retryCount": 3}
   }'
 ```
@@ -451,21 +448,9 @@ Successful responses include `requestId`, `answer`, `confidence`, `fixParameters
   - Type: string (1-2000 chars)
   - Use when: you are an AI agent calling on behalf of a user. Describe what the user is trying to accomplish.
 
-- `jobId`
-  - Type: string
-  - Use when: you have a failing job ID for fast-path debugging.
-
 - `context`
   - Type: object (free-form)
-  - Use when: you want to pass metadata from your agent into the diagnostic prompt.
-
-- `model`
-  - Type: string (default `claude-opus-4-7`)
-  - Use when: you want faster (`claude-sonnet-4-6`) or cheaper (`claude-haiku-4-5`) responses.
-
-- `maxSteps`
-  - Type: integer (1-20, default 8)
-  - Use when: you want to cap the number of diagnostic steps.
+  - Use when: you want to pass metadata from your agent into the debugging prompt.
 
 ## Docs Search (Public)
 
@@ -492,14 +477,6 @@ curl -X POST "https://api.firecrawl.dev/v2/support/docs-search" \
 - `question`
   - Type: string (required, 1-8000 chars)
   - Use when: you need a docs-grounded answer.
-
-- `model`
-  - Type: string (default `claude-sonnet-4-6`)
-  - Use when: you want to override the model.
-
-- `maxSteps`
-  - Type: integer (2-4, default 3)
-  - Use when: you want to cap the number of search steps.
 
 ## Notes
 

--- a/agent-source-of-truth/curl.mdx
+++ b/agent-source-of-truth/curl.mdx
@@ -16,6 +16,8 @@ export FIRECRAWL_API_KEY="fc-your-api-key"
 - `search`: use when you start with a query and need discovery.
 - `scrape`: use when you already have a URL and want page content.
 - `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+- `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
+- `support/docs-search`: use when you need to look up Firecrawl documentation (no auth required).
 
 ## Search
 
@@ -388,6 +390,116 @@ curl -X DELETE "https://api.firecrawl.dev/v2/scrape/<jobId>/interact" \
 ```
 
 No JSON body. A successful response includes `success`.
+
+## Ask (Agentic Debugging)
+
+### Why use it
+
+Use ask when a Firecrawl API call fails or returns unexpected results. The AI support agent diagnoses the issue, proposes fix parameters, and optionally validates the fix against the live API. Typical latency: 15-30 seconds.
+
+### Endpoint
+
+`POST /support/ask`
+
+### Simple Example
+
+```bash
+curl -X POST "https://api.firecrawl.dev/v2/support/ask" \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "question": "my scrape returned empty markdown for https://example.com"
+  }'
+```
+
+### Complex Example
+
+```bash
+curl -X POST "https://api.firecrawl.dev/v2/support/ask" \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "question": "crawl returned 3 pages but I expected 50",
+    "rationale": "user is on their third failed crawl attempt today",
+    "jobId": "crawl_abc123",
+    "model": "claude-sonnet-4-6",
+    "maxSteps": 12,
+    "context": {"userPlan": "standard", "retryCount": 3}
+  }'
+```
+
+### Response
+
+Successful responses include `requestId`, `answer`, `confidence`, `fixParameters`, `validation`, `evidence`, `kbCitations`, `usage`, and `durationMs`.
+
+- `answer`: 2-4 sentence prose covering the diagnosis and fix.
+- `confidence`: `high`, `medium`, or `low`.
+- `fixParameters`: machine-actionable API parameters to apply the fix (null if no fix applies).
+- `validation.tested`: whether the agent tested the fix against the live API.
+- `validation.result`: `success`, `failure`, or `skipped`.
+- `evidence`: array of tool calls made during diagnosis with `tool`, `rationale`, and `summary`.
+- `kbCitations`: documentation page references.
+- `feedback`: present when the agent gets stuck; null on success.
+
+### Parameters
+
+- `question`
+  - Type: string (required, 1-8000 chars)
+  - Use when: you need to describe the issue.
+
+- `rationale`
+  - Type: string (1-2000 chars)
+  - Use when: you are an AI agent calling on behalf of a user. Describe what the user is trying to accomplish.
+
+- `jobId`
+  - Type: string
+  - Use when: you have a failing job ID for fast-path debugging.
+
+- `context`
+  - Type: object (free-form)
+  - Use when: you want to pass metadata from your agent into the diagnostic prompt.
+
+- `model`
+  - Type: string (default `claude-opus-4-7`)
+  - Use when: you want faster (`claude-sonnet-4-6`) or cheaper (`claude-haiku-4-5`) responses.
+
+- `maxSteps`
+  - Type: integer (1-20, default 8)
+  - Use when: you want to cap the number of diagnostic steps.
+
+## Docs Search (Public)
+
+### Why use it
+
+Use docs-search to look up Firecrawl documentation. No authentication required.
+
+### Endpoint
+
+`POST /support/docs-search`
+
+### Example
+
+```bash
+curl -X POST "https://api.firecrawl.dev/v2/support/docs-search" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "question": "how do I verify webhook signatures?"
+  }'
+```
+
+### Parameters
+
+- `question`
+  - Type: string (required, 1-8000 chars)
+  - Use when: you need a docs-grounded answer.
+
+- `model`
+  - Type: string (default `claude-sonnet-4-6`)
+  - Use when: you want to override the model.
+
+- `maxSteps`
+  - Type: integer (2-4, default 3)
+  - Use when: you want to cap the number of search steps.
 
 ## Notes
 

--- a/agent-source-of-truth/elixir.mdx
+++ b/agent-source-of-truth/elixir.mdx
@@ -28,6 +28,8 @@ config :firecrawl, api_key: System.get_env("FIRECRAWL_API_KEY")
 - `search`: use when you start with a query and need discovery.
 - `scrape`: use when you already have a URL and want page content.
 - `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+- `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
+- `support/docs-search`: use when you need to look up Firecrawl documentation (no auth required).
 
 ## Search
 

--- a/agent-source-of-truth/elixir.mdx
+++ b/agent-source-of-truth/elixir.mdx
@@ -29,7 +29,7 @@ config :firecrawl, api_key: System.get_env("FIRECRAWL_API_KEY")
 - `scrape`: use when you already have a URL and want page content.
 - `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
 - `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
-- `support/docs-search`: use when you need to look up Firecrawl documentation (no auth required).
+- `support/docs-search`: use when you need to look up Firecrawl documentation.
 
 ## Search
 

--- a/agent-source-of-truth/java.mdx
+++ b/agent-source-of-truth/java.mdx
@@ -38,6 +38,8 @@ FirecrawlClient client = FirecrawlClient.builder()
 - `search`: use when you start with a query and need discovery.
 - `scrape`: use when you already have a URL and want page content.
 - `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+- `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
+- `support/docs-search`: use when you need to look up Firecrawl documentation (no auth required).
 
 ## Search
 

--- a/agent-source-of-truth/java.mdx
+++ b/agent-source-of-truth/java.mdx
@@ -39,7 +39,7 @@ FirecrawlClient client = FirecrawlClient.builder()
 - `scrape`: use when you already have a URL and want page content.
 - `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
 - `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
-- `support/docs-search`: use when you need to look up Firecrawl documentation (no auth required).
+- `support/docs-search`: use when you need to look up Firecrawl documentation.
 
 ## Search
 

--- a/agent-source-of-truth/node.mdx
+++ b/agent-source-of-truth/node.mdx
@@ -432,9 +432,6 @@ const response = await fetch("https://api.firecrawl.dev/v2/support/ask", {
   body: JSON.stringify({
     question: "crawl returned 3 pages but I expected 50",
     rationale: "user is on their third failed crawl attempt today",
-    jobId: "crawl_abc123",
-    model: "claude-sonnet-4-6",
-    maxSteps: 12,
     context: { userPlan: "standard", retryCount: 3 },
   }),
 });
@@ -462,8 +459,7 @@ if (!doc.markdown || doc.markdown.length < 100) {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        question: `scrape returned only ${doc.markdown?.length ?? 0} chars`,
-        jobId: doc.metadata?.scrapeId,
+        question: `scrape returned only ${doc.markdown?.length ?? 0} chars for https://example.com/pricing`,
       }),
     }
   );
@@ -488,21 +484,9 @@ if (!doc.markdown || doc.markdown.length < 100) {
   - Type: string (1-2000 chars)
   - Use when: you are an AI agent calling on behalf of a user.
 
-- `jobId`
-  - Type: string
-  - Use when: you have a failing job ID for fast-path debugging.
-
 - `context`
   - Type: object (free-form)
-  - Use when: you want to pass metadata into the diagnostic prompt.
-
-- `model`
-  - Type: string (default `claude-opus-4-7`)
-  - Use when: you want faster (`claude-sonnet-4-6`) or cheaper (`claude-haiku-4-5`) responses.
-
-- `maxSteps`
-  - Type: number (1-20, default 8)
-  - Use when: you want to cap diagnostic steps.
+  - Use when: you want to pass metadata into the debugging prompt.
 
 ## Docs Search (Public)
 
@@ -532,12 +516,6 @@ console.log(result.answer);
 - `question`
   - Type: string (required, 1-8000 chars)
   - Use when: you need a docs-grounded answer.
-
-- `model`
-  - Type: string (default `claude-sonnet-4-6`)
-
-- `maxSteps`
-  - Type: number (2-4, default 3)
 
 ## Notes
 

--- a/agent-source-of-truth/node.mdx
+++ b/agent-source-of-truth/node.mdx
@@ -28,7 +28,7 @@ const client = new Firecrawl({
 - `scrape`: use when you already have a URL and want page content.
 - `interact`: use when the page needs clicks, forms, or other browser actions after a scrape has created a session. For multi-step interactive flows, prefer `interact` over scrape-time `actions`.
 - `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
-- `support/docs-search`: use when you need to look up Firecrawl documentation (no auth required).
+- `support/docs-search`: use when you need to look up Firecrawl documentation.
 
 ## Search
 
@@ -488,11 +488,11 @@ if (!doc.markdown || doc.markdown.length < 100) {
   - Type: object (free-form)
   - Use when: you want to pass metadata into the debugging prompt.
 
-## Docs Search (Public)
+## Docs Search
 
 ### Why use it
 
-Use docs-search to look up Firecrawl documentation. No authentication required.
+Use docs-search to look up Firecrawl documentation.
 
 ### Simple Example
 
@@ -501,7 +501,10 @@ const response = await fetch(
   "https://api.firecrawl.dev/v2/support/docs-search",
   {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      Authorization: `Bearer ${process.env.FIRECRAWL_API_KEY}`,
+      "Content-Type": "application/json",
+    },
     body: JSON.stringify({
       question: "how do I verify webhook signatures?",
     }),

--- a/agent-source-of-truth/node.mdx
+++ b/agent-source-of-truth/node.mdx
@@ -27,6 +27,8 @@ const client = new Firecrawl({
 - `search`: use when you start with a query and need discovery.
 - `scrape`: use when you already have a URL and want page content.
 - `interact`: use when the page needs clicks, forms, or other browser actions after a scrape has created a session. For multi-step interactive flows, prefer `interact` over scrape-time `actions`.
+- `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
+- `support/docs-search`: use when you need to look up Firecrawl documentation (no auth required).
 
 ## Search
 
@@ -389,6 +391,153 @@ const result = await client.interact("<scrapeJobId>", {
 
 - `jobId`: scrape job id (same id used for `interact`).
 - Response fields in typings include `success`, `sessionDurationMs`, `creditsBilled`, `error`.
+
+## Ask (Agentic Debugging)
+
+### Why use it
+
+Use ask when a Firecrawl API call fails or returns unexpected results. The AI support agent diagnoses the issue, proposes fix parameters, and optionally validates the fix against the live API. Typical latency: 15-30 seconds.
+
+### Preferred SDK method
+
+Not yet available in the Node.js SDK. Use `fetch` directly.
+
+### Simple Example
+
+```ts
+const response = await fetch("https://api.firecrawl.dev/v2/support/ask", {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${process.env.FIRECRAWL_API_KEY}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    question: "my scrape returned empty markdown for https://example.com",
+  }),
+});
+const result = await response.json();
+console.log(result.answer);
+console.log(result.fixParameters);
+```
+
+### Complex Example
+
+```ts
+const response = await fetch("https://api.firecrawl.dev/v2/support/ask", {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${process.env.FIRECRAWL_API_KEY}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    question: "crawl returned 3 pages but I expected 50",
+    rationale: "user is on their third failed crawl attempt today",
+    jobId: "crawl_abc123",
+    model: "claude-sonnet-4-6",
+    maxSteps: 12,
+    context: { userPlan: "standard", retryCount: 3 },
+  }),
+});
+const result = await response.json();
+```
+
+### Agent retry pattern
+
+```ts
+import Firecrawl from "@mendable/firecrawl-js";
+
+const client = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+
+const doc = await client.scrape("https://example.com/pricing", {
+  formats: ["markdown"],
+});
+
+if (!doc.markdown || doc.markdown.length < 100) {
+  const diagResponse = await fetch(
+    "https://api.firecrawl.dev/v2/support/ask",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.FIRECRAWL_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        question: `scrape returned only ${doc.markdown?.length ?? 0} chars`,
+        jobId: doc.metadata?.scrapeId,
+      }),
+    }
+  );
+  const diagnosis = await diagResponse.json();
+
+  if (diagnosis.fixParameters) {
+    const retryDoc = await client.scrape("https://example.com/pricing", {
+      formats: ["markdown"],
+      ...diagnosis.fixParameters,
+    });
+  }
+}
+```
+
+### Parameters
+
+- `question`
+  - Type: string (required, 1-8000 chars)
+  - Use when: you need to describe the issue.
+
+- `rationale`
+  - Type: string (1-2000 chars)
+  - Use when: you are an AI agent calling on behalf of a user.
+
+- `jobId`
+  - Type: string
+  - Use when: you have a failing job ID for fast-path debugging.
+
+- `context`
+  - Type: object (free-form)
+  - Use when: you want to pass metadata into the diagnostic prompt.
+
+- `model`
+  - Type: string (default `claude-opus-4-7`)
+  - Use when: you want faster (`claude-sonnet-4-6`) or cheaper (`claude-haiku-4-5`) responses.
+
+- `maxSteps`
+  - Type: number (1-20, default 8)
+  - Use when: you want to cap diagnostic steps.
+
+## Docs Search (Public)
+
+### Why use it
+
+Use docs-search to look up Firecrawl documentation. No authentication required.
+
+### Simple Example
+
+```ts
+const response = await fetch(
+  "https://api.firecrawl.dev/v2/support/docs-search",
+  {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      question: "how do I verify webhook signatures?",
+    }),
+  }
+);
+const result = await response.json();
+console.log(result.answer);
+```
+
+### Parameters
+
+- `question`
+  - Type: string (required, 1-8000 chars)
+  - Use when: you need a docs-grounded answer.
+
+- `model`
+  - Type: string (default `claude-sonnet-4-6`)
+
+- `maxSteps`
+  - Type: number (2-4, default 3)
 
 ## Notes
 

--- a/agent-source-of-truth/python.mdx
+++ b/agent-source-of-truth/python.mdx
@@ -27,7 +27,7 @@ client = Firecrawl(api_key=os.environ.get("FIRECRAWL_API_KEY"))
 - `scrape`: use when you already have a URL and want page content.
 - `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
 - `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
-- `support/docs-search`: use when you need to look up Firecrawl documentation (no auth required).
+- `support/docs-search`: use when you need to look up Firecrawl documentation.
 
 ## Search
 
@@ -472,19 +472,22 @@ if not doc.markdown or len(doc.markdown) < 100:
   - Type: dict (free-form)
   - Use when: you want to pass metadata into the debugging prompt.
 
-## Docs Search (Public)
+## Docs Search
 
 ### Why use it
 
-Use docs-search to look up Firecrawl documentation. No authentication required.
+Use docs-search to look up Firecrawl documentation.
 
 ### Simple Example
 
 ```py
 import requests
 
+FIRECRAWL_API_KEY = "fc-YOUR_API_KEY"
+
 response = requests.post(
     "https://api.firecrawl.dev/v2/support/docs-search",
+    headers={"Authorization": f"Bearer {FIRECRAWL_API_KEY}"},
     json={"question": "how do I verify webhook signatures?"},
 )
 print(response.json()["answer"])

--- a/agent-source-of-truth/python.mdx
+++ b/agent-source-of-truth/python.mdx
@@ -422,9 +422,6 @@ response = requests.post(
     json={
         "question": "crawl returned 3 pages but I expected 50",
         "rationale": "user is on their third failed crawl attempt today",
-        "jobId": "crawl_abc123",
-        "model": "claude-sonnet-4-6",
-        "maxSteps": 12,
         "context": {"userPlan": "standard", "retryCount": 3},
     },
 )
@@ -449,8 +446,7 @@ if not doc.markdown or len(doc.markdown) < 100:
             "Content-Type": "application/json",
         },
         json={
-            "question": f"scrape returned only {len(doc.markdown or '')} chars",
-            "jobId": doc.metadata.scrape_id if doc.metadata else None,
+            "question": f"scrape returned only {len(doc.markdown or '')} chars for https://example.com/pricing",
         },
     ).json()
 
@@ -472,21 +468,9 @@ if not doc.markdown or len(doc.markdown) < 100:
   - Type: str (1-2000 chars)
   - Use when: you are an AI agent calling on behalf of a user.
 
-- `jobId`
-  - Type: str
-  - Use when: you have a failing job ID for fast-path debugging.
-
 - `context`
   - Type: dict (free-form)
-  - Use when: you want to pass metadata into the diagnostic prompt.
-
-- `model`
-  - Type: str (default `claude-opus-4-7`)
-  - Use when: you want faster (`claude-sonnet-4-6`) or cheaper (`claude-haiku-4-5`) responses.
-
-- `maxSteps`
-  - Type: int (1-20, default 8)
-  - Use when: you want to cap diagnostic steps.
+  - Use when: you want to pass metadata into the debugging prompt.
 
 ## Docs Search (Public)
 
@@ -511,12 +495,6 @@ print(response.json()["answer"])
 - `question`
   - Type: str (required, 1-8000 chars)
   - Use when: you need a docs-grounded answer.
-
-- `model`
-  - Type: str (default `claude-sonnet-4-6`)
-
-- `maxSteps`
-  - Type: int (2-4, default 3)
 
 ## Notes
 

--- a/agent-source-of-truth/python.mdx
+++ b/agent-source-of-truth/python.mdx
@@ -26,6 +26,8 @@ client = Firecrawl(api_key=os.environ.get("FIRECRAWL_API_KEY"))
 - `search`: use when you start with a query and need discovery.
 - `scrape`: use when you already have a URL and want page content.
 - `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+- `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
+- `support/docs-search`: use when you need to look up Firecrawl documentation (no auth required).
 
 ## Search
 
@@ -377,6 +379,144 @@ result = client.interact(
 ### Return value
 
 Returns `BrowserExecuteResponse`: `success`, optional `live_view_url`, `interactive_live_view_url`, `output`, `stdout`, `result`, `stderr`, `exit_code`, `killed`, `error` (API camelCase is normalized to snake_case on the model).
+
+## Ask (Agentic Debugging)
+
+### Why use it
+
+Use ask when a Firecrawl API call fails or returns unexpected results. The AI support agent diagnoses the issue, proposes fix parameters, and optionally validates the fix against the live API. Typical latency: 15-30 seconds.
+
+### Preferred SDK method
+
+Not yet available in the Python SDK. Use `requests` or `httpx` directly.
+
+### Simple Example
+
+```py
+import requests
+
+response = requests.post(
+    "https://api.firecrawl.dev/v2/support/ask",
+    headers={
+        "Authorization": f"Bearer {os.environ['FIRECRAWL_API_KEY']}",
+        "Content-Type": "application/json",
+    },
+    json={"question": "my scrape returned empty markdown for https://example.com"},
+)
+result = response.json()
+print(result["answer"])
+print(result["fixParameters"])
+```
+
+### Complex Example
+
+```py
+import requests
+
+response = requests.post(
+    "https://api.firecrawl.dev/v2/support/ask",
+    headers={
+        "Authorization": f"Bearer {os.environ['FIRECRAWL_API_KEY']}",
+        "Content-Type": "application/json",
+    },
+    json={
+        "question": "crawl returned 3 pages but I expected 50",
+        "rationale": "user is on their third failed crawl attempt today",
+        "jobId": "crawl_abc123",
+        "model": "claude-sonnet-4-6",
+        "maxSteps": 12,
+        "context": {"userPlan": "standard", "retryCount": 3},
+    },
+)
+result = response.json()
+```
+
+### Agent retry pattern
+
+```py
+from firecrawl import Firecrawl
+import requests, os
+
+client = Firecrawl(api_key=os.environ["FIRECRAWL_API_KEY"])
+
+doc = client.scrape("https://example.com/pricing", formats=["markdown"])
+
+if not doc.markdown or len(doc.markdown) < 100:
+    diagnosis = requests.post(
+        "https://api.firecrawl.dev/v2/support/ask",
+        headers={
+            "Authorization": f"Bearer {os.environ['FIRECRAWL_API_KEY']}",
+            "Content-Type": "application/json",
+        },
+        json={
+            "question": f"scrape returned only {len(doc.markdown or '')} chars",
+            "jobId": doc.metadata.scrape_id if doc.metadata else None,
+        },
+    ).json()
+
+    if diagnosis.get("fixParameters"):
+        doc = client.scrape(
+            "https://example.com/pricing",
+            formats=["markdown"],
+            **diagnosis["fixParameters"],
+        )
+```
+
+### Parameters
+
+- `question`
+  - Type: str (required, 1-8000 chars)
+  - Use when: you need to describe the issue.
+
+- `rationale`
+  - Type: str (1-2000 chars)
+  - Use when: you are an AI agent calling on behalf of a user.
+
+- `jobId`
+  - Type: str
+  - Use when: you have a failing job ID for fast-path debugging.
+
+- `context`
+  - Type: dict (free-form)
+  - Use when: you want to pass metadata into the diagnostic prompt.
+
+- `model`
+  - Type: str (default `claude-opus-4-7`)
+  - Use when: you want faster (`claude-sonnet-4-6`) or cheaper (`claude-haiku-4-5`) responses.
+
+- `maxSteps`
+  - Type: int (1-20, default 8)
+  - Use when: you want to cap diagnostic steps.
+
+## Docs Search (Public)
+
+### Why use it
+
+Use docs-search to look up Firecrawl documentation. No authentication required.
+
+### Simple Example
+
+```py
+import requests
+
+response = requests.post(
+    "https://api.firecrawl.dev/v2/support/docs-search",
+    json={"question": "how do I verify webhook signatures?"},
+)
+print(response.json()["answer"])
+```
+
+### Parameters
+
+- `question`
+  - Type: str (required, 1-8000 chars)
+  - Use when: you need a docs-grounded answer.
+
+- `model`
+  - Type: str (default `claude-sonnet-4-6`)
+
+- `maxSteps`
+  - Type: int (2-4, default 3)
 
 ## Notes
 

--- a/agent-source-of-truth/rust.mdx
+++ b/agent-source-of-truth/rust.mdx
@@ -29,7 +29,7 @@ let client = Client::new("fc-your-api-key")?;
 - `scrape`: use when you already have a URL and want page content.
 - `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
 - `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
-- `support/docs-search`: use when you need to look up Firecrawl documentation (no auth required).
+- `support/docs-search`: use when you need to look up Firecrawl documentation.
 
 ## Search
 

--- a/agent-source-of-truth/rust.mdx
+++ b/agent-source-of-truth/rust.mdx
@@ -28,6 +28,8 @@ let client = Client::new("fc-your-api-key")?;
 - `search`: use when you start with a query and need discovery.
 - `scrape`: use when you already have a URL and want page content.
 - `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+- `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
+- `support/docs-search`: use when you need to look up Firecrawl documentation (no auth required).
 
 ## Search
 

--- a/api-reference/endpoint/ask.mdx
+++ b/api-reference/endpoint/ask.mdx
@@ -3,24 +3,24 @@ title: 'Ask'
 openapi: '/api-reference/v2-openapi.json POST /support/ask'
 ---
 
-The `/support/ask` endpoint is an AI support agent that diagnoses issues with your Firecrawl jobs, account, and API usage. Send a question and optionally a failing job ID, and receive a verified diagnosis with actionable fix parameters — typically in 15–30 seconds.
+The `/support/ask` endpoint is an AI support agent that diagnoses issues with your Firecrawl jobs, account, and API usage. Send a question and receive a verified answer with actionable fix parameters — typically in 15–30 seconds.
 
 ## Designed for AI agents
 
 `/support/ask` is built for **agent-to-agent** communication. If you're building an AI agent that uses Firecrawl, wire this endpoint into your error-handling flow so your agent can self-diagnose scraping failures, crawl issues, and configuration problems without human intervention.
 
-Pass a `rationale` field to give the support agent context about what your end user is trying to accomplish. This helps prioritize the diagnostic evidence gathering.
+Pass a `rationale` field to give the support agent context about what your end user is trying to accomplish. This helps prioritize the evidence gathering.
 
 ## How it works
 
-1. **You describe the problem** — a natural-language question, optionally with a `jobId` for fast-path debugging.
-2. **The agent investigates** — it inspects job logs, account state, documentation, and source code across up to `maxSteps` diagnostic steps.
+1. **You describe the problem** — a natural-language question describing the issue.
+2. **The agent investigates** — it inspects job logs, account state, documentation, and source code.
 3. **The agent validates** — when possible, the agent tests a fix against the live Firecrawl API (e.g., retrying a scrape with adjusted parameters).
 4. **You get a verified answer** — the response includes a prose `answer`, machine-readable `fixParameters` you can apply directly, and `validation` results showing whether the fix was tested.
 
 ## Authentication
 
-Uses your Firecrawl API key as the bearer token. The diagnostic is automatically scoped to your team — you can only query your own jobs and account data.
+Uses your Firecrawl API key as the bearer token. The request is automatically scoped to your team — you can only query your own jobs and account data.
 
 ```bash
 curl -X POST https://api.firecrawl.dev/v2/support/ask \
@@ -28,8 +28,7 @@ curl -X POST https://api.firecrawl.dev/v2/support/ask \
   -H "Content-Type: application/json" \
   -d '{
     "question": "my crawl returned 3 pages but I expected 50",
-    "rationale": "user is on their third failed crawl attempt today",
-    "jobId": "crawl_abc123"
+    "rationale": "user is on their third failed crawl attempt today"
   }'
 ```
 
@@ -46,14 +45,6 @@ curl -X POST https://api.firecrawl.dev/v2/support/ask \
 | `feedback` | string \| null | Present when the agent gets stuck; null on success |
 | `usage` | object | Token consumption (`inputTokens`, `outputTokens`, `totalTokens`) |
 | `durationMs` | integer | Total execution time in milliseconds |
-
-## Model selection
-
-| Model | Speed | Cost | Best for |
-|-------|-------|------|----------|
-| `claude-opus-4-7` (default) | ~15-30s | Highest | Complex multi-step diagnosis |
-| `claude-sonnet-4-6` | ~7-15s | Medium | Most issues, good balance |
-| `claude-haiku-4-5` | Fastest | Lowest | Simple questions, high volume |
 
 ## Status codes
 

--- a/api-reference/endpoint/ask.mdx
+++ b/api-reference/endpoint/ask.mdx
@@ -40,8 +40,6 @@ curl -X POST https://api.firecrawl.dev/v2/support/ask \
 | `confidence` | string | `high`, `medium`, or `low` |
 | `fixParameters` | object \| null | API parameters to apply the fix (e.g., `{"waitFor": 5000}`) |
 | `validation` | object \| null | Whether the fix was tested: `tested`, `result` (success/failure/skipped), `evidence` |
-| `evidence` | array | Tool calls made during diagnosis with rationale and summaries |
-| `kbCitations` | array | References to relevant documentation |
 | `feedback` | string \| null | Present when the agent gets stuck; null on success |
 | `usage` | object | Token consumption (`inputTokens`, `outputTokens`, `totalTokens`) |
 | `durationMs` | integer | Total execution time in milliseconds |

--- a/api-reference/endpoint/ask.mdx
+++ b/api-reference/endpoint/ask.mdx
@@ -40,7 +40,7 @@ curl -X POST https://api.firecrawl.dev/v2/support/ask \
 | `confidence` | string | `high`, `medium`, or `low` |
 | `fixParameters` | object \| null | API parameters to apply the fix (e.g., `{"waitFor": 5000}`) |
 | `validation` | object \| null | Whether the fix was tested: `tested`, `result` (success/failure/skipped), `evidence` |
-| `feedback` | string \| null | Present when the agent gets stuck; null on success |
+| `feedback` | object \| null | Present when the agent gets stuck; `{ blockedBy, attempted }`. Null on success. |
 | `usage` | object | Token consumption (`inputTokens`, `outputTokens`, `totalTokens`) |
 | `durationMs` | integer | Total execution time in milliseconds |
 

--- a/api-reference/endpoint/ask.mdx
+++ b/api-reference/endpoint/ask.mdx
@@ -1,0 +1,69 @@
+---
+title: 'Ask'
+openapi: '/api-reference/v2-openapi.json POST /support/ask'
+---
+
+The `/support/ask` endpoint is an AI support agent that diagnoses issues with your Firecrawl jobs, account, and API usage. Send a question and optionally a failing job ID, and receive a verified diagnosis with actionable fix parameters — typically in 15–30 seconds.
+
+## Designed for AI agents
+
+`/support/ask` is built for **agent-to-agent** communication. If you're building an AI agent that uses Firecrawl, wire this endpoint into your error-handling flow so your agent can self-diagnose scraping failures, crawl issues, and configuration problems without human intervention.
+
+Pass a `rationale` field to give the support agent context about what your end user is trying to accomplish. This helps prioritize the diagnostic evidence gathering.
+
+## How it works
+
+1. **You describe the problem** — a natural-language question, optionally with a `jobId` for fast-path debugging.
+2. **The agent investigates** — it inspects job logs, account state, documentation, and source code across up to `maxSteps` diagnostic steps.
+3. **The agent validates** — when possible, the agent tests a fix against the live Firecrawl API (e.g., retrying a scrape with adjusted parameters).
+4. **You get a verified answer** — the response includes a prose `answer`, machine-readable `fixParameters` you can apply directly, and `validation` results showing whether the fix was tested.
+
+## Authentication
+
+Uses your Firecrawl API key as the bearer token. The diagnostic is automatically scoped to your team — you can only query your own jobs and account data.
+
+```bash
+curl -X POST https://api.firecrawl.dev/v2/support/ask \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "question": "my crawl returned 3 pages but I expected 50",
+    "rationale": "user is on their third failed crawl attempt today",
+    "jobId": "crawl_abc123"
+  }'
+```
+
+## Response fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `answer` | string | 2-4 sentence prose covering the diagnosis and fix |
+| `confidence` | string | `high`, `medium`, or `low` |
+| `fixParameters` | object \| null | API parameters to apply the fix (e.g., `{"waitFor": 5000}`) |
+| `validation` | object \| null | Whether the fix was tested: `tested`, `result` (success/failure/skipped), `evidence` |
+| `evidence` | array | Tool calls made during diagnosis with rationale and summaries |
+| `kbCitations` | array | References to relevant documentation |
+| `feedback` | string \| null | Present when the agent gets stuck; null on success |
+| `usage` | object | Token consumption (`inputTokens`, `outputTokens`, `totalTokens`) |
+| `durationMs` | integer | Total execution time in milliseconds |
+
+## Model selection
+
+| Model | Speed | Cost | Best for |
+|-------|-------|------|----------|
+| `claude-opus-4-7` (default) | ~15-30s | Highest | Complex multi-step diagnosis |
+| `claude-sonnet-4-6` | ~7-15s | Medium | Most issues, good balance |
+| `claude-haiku-4-5` | Fastest | Lowest | Simple questions, high volume |
+
+## Status codes
+
+| Code | Meaning |
+|------|---------|
+| `200` | Answered or stuck (envelope always returned) |
+| `400` | Invalid JSON or schema violation |
+| `401` | Missing or invalid bearer token |
+| `504` | Hit 60s hard budget — partial envelope returned |
+
+For the feature guide with integration examples, see the [Ask feature documentation](/features/ask).
+
+> Are you an AI agent that needs a Firecrawl API key? See [firecrawl.dev/agent-onboarding/SKILL.md](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for automated onboarding instructions.

--- a/api-reference/endpoint/docs-search.mdx
+++ b/api-reference/endpoint/docs-search.mdx
@@ -1,0 +1,54 @@
+---
+title: 'Docs Search'
+openapi: '/api-reference/v2-openapi.json POST /support/docs-search'
+---
+
+The `/support/docs-search` endpoint answers questions using Firecrawl's public documentation. No authentication required — anyone can call it. Returns a concise, docs-grounded answer with citations to the relevant documentation pages.
+
+## Use cases
+
+- **AI agents** that need to look up Firecrawl API usage, parameters, or best practices
+- **Support bots** that answer customer questions from the docs
+- **Developer tools** that surface relevant documentation inline
+
+## Example
+
+```bash
+curl -X POST https://api.firecrawl.dev/v2/support/docs-search \
+  -H "Content-Type: application/json" \
+  -d '{
+    "question": "what header carries the webhook signature, and how do I verify it?"
+  }'
+```
+
+### Response
+
+```json
+{
+  "requestId": "req_...",
+  "answer": "The signature is sent in the X-Firecrawl-Signature header...",
+  "evidence": [
+    {
+      "pathOrUrl": "webhooks/security.mdx#L1-L52",
+      "reason": "Documents webhook signature verification"
+    }
+  ],
+  "usage": { "inputTokens": 4356, "outputTokens": 688, "totalTokens": 5044 },
+  "durationMs": 11252,
+  "model": "anthropic:claude-sonnet-4-6"
+}
+```
+
+## Response fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `answer` | string | Concise answer grounded in Firecrawl documentation |
+| `evidence` | array | Documentation pages referenced, with `pathOrUrl` and `reason` |
+| `usage` | object | Token consumption (`inputTokens`, `outputTokens`, `totalTokens`) |
+| `durationMs` | integer | Total execution time in milliseconds |
+| `model` | string | Model used for this run |
+
+For the full feature guide, see the [Ask feature documentation](/features/ask).
+
+> Are you an AI agent that needs a Firecrawl API key? See [firecrawl.dev/agent-onboarding/SKILL.md](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for automated onboarding instructions.

--- a/api-reference/endpoint/docs-search.mdx
+++ b/api-reference/endpoint/docs-search.mdx
@@ -34,8 +34,7 @@ curl -X POST https://api.firecrawl.dev/v2/support/docs-search \
     }
   ],
   "usage": { "inputTokens": 4356, "outputTokens": 688, "totalTokens": 5044 },
-  "durationMs": 11252,
-  "model": "anthropic:claude-sonnet-4-6"
+  "durationMs": 11252
 }
 ```
 
@@ -47,7 +46,6 @@ curl -X POST https://api.firecrawl.dev/v2/support/docs-search \
 | `evidence` | array | Documentation pages referenced, with `pathOrUrl` and `reason` |
 | `usage` | object | Token consumption (`inputTokens`, `outputTokens`, `totalTokens`) |
 | `durationMs` | integer | Total execution time in milliseconds |
-| `model` | string | Model used for this run |
 
 For the full feature guide, see the [Ask feature documentation](/features/ask).
 

--- a/api-reference/endpoint/docs-search.mdx
+++ b/api-reference/endpoint/docs-search.mdx
@@ -3,7 +3,7 @@ title: 'Docs Search'
 openapi: '/api-reference/v2-openapi.json POST /support/docs-search'
 ---
 
-The `/support/docs-search` endpoint answers questions using Firecrawl's public documentation. No authentication required — anyone can call it. Returns a concise, docs-grounded answer with citations to the relevant documentation pages.
+The `/support/docs-search` endpoint answers questions using Firecrawl's public documentation. Requires your Firecrawl API key. Returns a concise, docs-grounded answer with citations to the relevant documentation pages.
 
 ## Use cases
 
@@ -15,6 +15,7 @@ The `/support/docs-search` endpoint answers questions using Firecrawl's public d
 
 ```bash
 curl -X POST https://api.firecrawl.dev/v2/support/docs-search \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "question": "what header carries the webhook signature, and how do I verify it?"

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -3659,8 +3659,13 @@
                   },
                   "rationale": {
                     "type": "string",
+                    "minLength": 1,
                     "maxLength": 2000,
                     "description": "Recommended for AI callers. 1-2 sentences on what the end user is trying to accomplish."
+                  },
+                  "jobId": {
+                    "type": "string",
+                    "description": "Optional Firecrawl job ID the failing call was associated with. Tools like debugJob, searchLogs, and getJob auto-default to this when set, so the agent doesn't need to pull it from the question."
                   },
                   "context": {
                     "type": "object",
@@ -5523,9 +5528,22 @@
             }
           },
           "feedback": {
-            "type": "string",
+            "type": "object",
             "nullable": true,
-            "description": "Stuck signal when the agent cannot help. Null on success."
+            "description": "Present when the agent gets stuck and could not produce a usable answer. Null on success.",
+            "properties": {
+              "blockedBy": {
+                "type": "string",
+                "description": "Short description of what the agent could not do."
+              },
+              "attempted": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Names of the tools the agent tried before giving up."
+              }
+            }
           },
           "usage": {
             "type": "object",

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -5517,31 +5517,6 @@
               }
             }
           },
-          "evidence": {
-            "type": "array",
-            "description": "Tool calls made during diagnosis and their summaries.",
-            "items": {
-              "type": "object",
-              "properties": {
-                "tool": {
-                  "type": "string"
-                },
-                "rationale": {
-                  "type": "string"
-                },
-                "summary": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "kbCitations": {
-            "type": "array",
-            "description": "References to relevant documentation pages.",
-            "items": {
-              "type": "string"
-            }
-          },
           "feedback": {
             "type": "string",
             "nullable": true,

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -3662,25 +3662,9 @@
                     "maxLength": 2000,
                     "description": "Recommended for AI callers. 1-2 sentences on what the end user is trying to accomplish."
                   },
-                  "jobId": {
-                    "type": "string",
-                    "description": "A failing job ID (scrape, crawl, extract, etc.) for fast-path debugging."
-                  },
                   "context": {
                     "type": "object",
                     "description": "Free-form metadata from the calling agent, stringified into the diagnostic prompt."
-                  },
-                  "model": {
-                    "type": "string",
-                    "description": "Override the default model (claude-opus-4-7). Use claude-sonnet-4-6 for faster responses or claude-haiku-4-5 for cheaper.",
-                    "default": "claude-opus-4-7"
-                  },
-                  "maxSteps": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 20,
-                    "default": 8,
-                    "description": "Maximum number of diagnostic steps the agent can take."
                   }
                 }
               }
@@ -3759,18 +3743,6 @@
                     "minLength": 1,
                     "maxLength": 8000,
                     "description": "The question to answer from Firecrawl's public documentation."
-                  },
-                  "model": {
-                    "type": "string",
-                    "description": "Override the default model (claude-sonnet-4-6).",
-                    "default": "claude-sonnet-4-6"
-                  },
-                  "maxSteps": {
-                    "type": "integer",
-                    "minimum": 2,
-                    "maximum": 4,
-                    "default": 3,
-                    "description": "Maximum number of search steps."
                   }
                 }
               }
@@ -5593,10 +5565,6 @@
           "durationMs": {
             "type": "integer",
             "description": "Total execution time in milliseconds."
-          },
-          "model": {
-            "type": "string",
-            "description": "Model used for this run."
           }
         }
       },
@@ -5643,10 +5611,6 @@
           "durationMs": {
             "type": "integer",
             "description": "Total execution time in milliseconds."
-          },
-          "model": {
-            "type": "string",
-            "description": "Model used for this run."
           }
         }
       }

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -3632,6 +3632,179 @@
           }
         }
       }
+    },
+    "/support/ask": {
+      "post": {
+        "summary": "Diagnose Firecrawl issues using an AI support agent",
+        "operationId": "supportAsk",
+        "tags": ["Support"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["question"],
+                "properties": {
+                  "question": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 8000,
+                    "description": "What to diagnose. Describe the issue you're experiencing."
+                  },
+                  "rationale": {
+                    "type": "string",
+                    "maxLength": 2000,
+                    "description": "Recommended for AI callers. 1-2 sentences on what the end user is trying to accomplish."
+                  },
+                  "jobId": {
+                    "type": "string",
+                    "description": "A failing job ID (scrape, crawl, extract, etc.) for fast-path debugging."
+                  },
+                  "context": {
+                    "type": "object",
+                    "description": "Free-form metadata from the calling agent, stringified into the diagnostic prompt."
+                  },
+                  "model": {
+                    "type": "string",
+                    "description": "Override the default model (claude-opus-4-7). Use claude-sonnet-4-6 for faster responses or claude-haiku-4-5 for cheaper.",
+                    "default": "claude-opus-4-7"
+                  },
+                  "maxSteps": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 8,
+                    "description": "Maximum number of diagnostic steps the agent can take."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Diagnosis complete. The envelope is returned whether the agent found an answer or got stuck.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AskResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid JSON or schema violation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid bearer token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "Hit the 60-second hard budget. A partial envelope may be returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AskResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/support/docs-search": {
+      "post": {
+        "summary": "Search Firecrawl documentation using AI",
+        "operationId": "supportDocsSearch",
+        "tags": ["Support"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["question"],
+                "properties": {
+                  "question": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 8000,
+                    "description": "The question to answer from Firecrawl's public documentation."
+                  },
+                  "model": {
+                    "type": "string",
+                    "description": "Override the default model (claude-sonnet-4-6).",
+                    "default": "claude-sonnet-4-6"
+                  },
+                  "maxSteps": {
+                    "type": "integer",
+                    "minimum": 2,
+                    "maximum": 4,
+                    "default": 3,
+                    "description": "Maximum number of search steps."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Docs-grounded answer returned successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocsSearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid JSON or schema violation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -5331,6 +5504,149 @@
           "tokensUsed": {
             "type": "integer",
             "description": "The number of tokens used by the extract job. Only available if the job is completed."
+          }
+        }
+      },
+      "AskResponse": {
+        "type": "object",
+        "properties": {
+          "requestId": {
+            "type": "string",
+            "description": "Unique identifier for this request."
+          },
+          "answer": {
+            "type": "string",
+            "description": "2-4 sentence prose covering what's wrong and the fix."
+          },
+          "confidence": {
+            "type": "string",
+            "enum": ["high", "medium", "low"],
+            "description": "Agent's confidence in the diagnosis."
+          },
+          "fixParameters": {
+            "type": "object",
+            "nullable": true,
+            "description": "Machine-actionable API parameters to apply the recommended fix. Null if no fix applies."
+          },
+          "validation": {
+            "type": "object",
+            "nullable": true,
+            "description": "Whether the agent tested the fix against the live Firecrawl API.",
+            "properties": {
+              "tested": {
+                "type": "boolean"
+              },
+              "result": {
+                "type": "string",
+                "enum": ["success", "failure", "skipped"]
+              },
+              "evidence": {
+                "type": "string"
+              }
+            }
+          },
+          "evidence": {
+            "type": "array",
+            "description": "Tool calls made during diagnosis and their summaries.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tool": {
+                  "type": "string"
+                },
+                "rationale": {
+                  "type": "string"
+                },
+                "summary": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "kbCitations": {
+            "type": "array",
+            "description": "References to relevant documentation pages.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "feedback": {
+            "type": "string",
+            "nullable": true,
+            "description": "Stuck signal when the agent cannot help. Null on success."
+          },
+          "usage": {
+            "type": "object",
+            "description": "Token consumption for this request.",
+            "properties": {
+              "inputTokens": {
+                "type": "integer"
+              },
+              "outputTokens": {
+                "type": "integer"
+              },
+              "totalTokens": {
+                "type": "integer"
+              }
+            }
+          },
+          "durationMs": {
+            "type": "integer",
+            "description": "Total execution time in milliseconds."
+          },
+          "model": {
+            "type": "string",
+            "description": "Model used for this run."
+          }
+        }
+      },
+      "DocsSearchResponse": {
+        "type": "object",
+        "properties": {
+          "requestId": {
+            "type": "string",
+            "description": "Unique identifier for this request."
+          },
+          "answer": {
+            "type": "string",
+            "description": "Concise answer grounded in Firecrawl's public documentation."
+          },
+          "evidence": {
+            "type": "array",
+            "description": "Documentation pages referenced in the answer.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "pathOrUrl": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "usage": {
+            "type": "object",
+            "properties": {
+              "inputTokens": {
+                "type": "integer"
+              },
+              "outputTokens": {
+                "type": "integer"
+              },
+              "totalTokens": {
+                "type": "integer"
+              }
+            }
+          },
+          "durationMs": {
+            "type": "integer",
+            "description": "Total execution time in milliseconds."
+          },
+          "model": {
+            "type": "string",
+            "description": "Model used for this run."
           }
         }
       }

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -3730,6 +3730,11 @@
         "summary": "Search Firecrawl documentation using AI",
         "operationId": "supportDocsSearch",
         "tags": ["Support"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {

--- a/docs.json
+++ b/docs.json
@@ -82,6 +82,7 @@
                       "features/parse",
                       "features/map",
                       "features/crawl",
+                      "features/ask",
                       {
                         "group": "Agent (Research Preview)",
                         "icon": "robot",
@@ -384,6 +385,13 @@
                     "hidden": true
                   },
                   {
+                    "group": "Agentic Debugging Endpoints",
+                    "pages": [
+                      "api-reference/endpoint/ask",
+                      "api-reference/endpoint/docs-search"
+                    ]
+                  },
+                  {
                     "group": "Account Endpoints",
                     "pages": [
                       "api-reference/endpoint/activity",
@@ -488,6 +496,12 @@
                     "pages": [
                       "agents/fire-1",
                       "agents/fire-1-extract"
+                    ]
+                  },
+                  {
+                    "group": "Agentic Debugging",
+                    "pages": [
+                      "features/ask"
                     ]
                   },
                   {

--- a/features/agent.mdx
+++ b/features/agent.mdx
@@ -204,6 +204,22 @@ The [Agent Playground](https://www.firecrawl.dev/app/agent) supports CSV upload 
 
 Upload your CSV, then add output columns using the "+" button in the grid header. Each column has its own prompt — click a column header to describe what the agent should find for that field (e.g., "CEO or founder name", "Total funding raised"). Hit Run, and the agent processes each row in parallel, filling in the results.
 
+## Troubleshooting with Ask
+
+If your agent jobs fail or return unexpected results, use the [Ask API](/features/ask) for agentic debugging. Pass the failing job ID and get back a verified answer with fix parameters you can apply directly:
+
+```bash
+curl -X POST https://api.firecrawl.dev/v2/support/ask \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "question": "my agent returned incomplete results",
+    "jobId": "agent_abc123"
+  }'
+```
+
+See the [Ask documentation](/features/ask) for full details and integration examples.
+
 ## API Reference
 
 Check out the [Agent API Reference](/api-reference/endpoint/agent) for more details.

--- a/features/agent.mdx
+++ b/features/agent.mdx
@@ -206,15 +206,14 @@ Upload your CSV, then add output columns using the "+" button in the grid header
 
 ## Troubleshooting with Ask
 
-If your agent jobs fail or return unexpected results, use the [Ask API](/features/ask) for agentic debugging. Pass the failing job ID and get back a verified answer with fix parameters you can apply directly:
+If your agent jobs fail or return unexpected results, use the [Ask API](/features/ask) for agentic debugging. Describe the issue and get back a verified answer with fix parameters you can apply directly:
 
 ```bash
 curl -X POST https://api.firecrawl.dev/v2/support/ask \
   -H "Authorization: Bearer fc-YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "question": "my agent returned incomplete results",
-    "jobId": "agent_abc123"
+    "question": "my agent returned incomplete results"
   }'
 ```
 

--- a/features/ask.mdx
+++ b/features/ask.mdx
@@ -2,7 +2,7 @@
 title: "Ask"
 description: "Agentic debugging for your Firecrawl integration"
 og:title: "Ask | Firecrawl"
-og:description: "Diagnose scraping issues, debug failing jobs, and get verified fixes — all through a single API call."
+og:description: "Debug scraping issues and get verified fixes — all through a single API call."
 sidebarTitle: "Ask"
 icon: "messages-question"
 ---
@@ -24,15 +24,14 @@ Firecrawl `/support/ask` is an AI support agent exposed as an API. Describe your
 
 ## Quick start
 
-### Diagnose a failing job
+### Debug a failing crawl
 
 ```bash
 curl -X POST https://api.firecrawl.dev/v2/support/ask \
   -H "Authorization: Bearer fc-YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "question": "my crawl returned 3 pages but I expected 50",
-    "jobId": "crawl_abc123"
+    "question": "my crawl returned 3 pages but I expected 50"
   }'
 ```
 
@@ -66,11 +65,9 @@ import requests
 
 FIRECRAWL_API_KEY = "fc-YOUR_API_KEY"
 
-def diagnose_firecrawl_issue(question, job_id=None, rationale=None):
-    """Call the Firecrawl Ask API to diagnose an issue."""
+def diagnose_firecrawl_issue(question, rationale=None):
+    """Call the Firecrawl Ask API to debug an issue."""
     payload = {"question": question}
-    if job_id:
-        payload["jobId"] = job_id
     if rationale:
         payload["rationale"] = rationale
 
@@ -85,10 +82,9 @@ def diagnose_firecrawl_issue(question, job_id=None, rationale=None):
     return response.json()
 
 
-# Example: diagnose a scrape that returned empty content
+# Example: debug a scrape that returned empty content
 result = diagnose_firecrawl_issue(
     question="scrape returned empty markdown for https://example.com",
-    job_id="scrape_xyz789",
     rationale="user needs product pricing data for competitive analysis",
 )
 
@@ -100,7 +96,7 @@ print(result["confidence"])     # "high", "medium", or "low"
 ### Node.js example
 
 ```javascript
-async function diagnoseFirecrawlIssue(question, jobId, rationale) {
+async function diagnoseFirecrawlIssue(question, rationale) {
   const response = await fetch(
     "https://api.firecrawl.dev/v2/support/ask",
     {
@@ -109,16 +105,15 @@ async function diagnoseFirecrawlIssue(question, jobId, rationale) {
         Authorization: `Bearer ${process.env.FIRECRAWL_API_KEY}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ question, jobId, rationale }),
+      body: JSON.stringify({ question, rationale }),
     }
   );
   return response.json();
 }
 
-// Example: diagnose a crawl that stopped early
+// Example: debug a crawl that stopped early
 const result = await diagnoseFirecrawlIssue(
   "my crawl returned 3 pages but I expected 50",
-  "crawl_abc123",
   "user is on their third failed crawl attempt today"
 );
 
@@ -137,10 +132,9 @@ client = Firecrawl(api_key="fc-YOUR_API_KEY")
 doc = client.scrape("https://example.com/pricing", formats=["markdown"])
 
 if not doc.markdown or len(doc.markdown) < 100:
-    # Step 2: Ask for diagnosis
+    # Step 2: Ask for help debugging
     diagnosis = diagnose_firecrawl_issue(
-        question=f"scrape returned only {len(doc.markdown or '')} chars of markdown",
-        job_id=doc.metadata.scrape_id if doc.metadata else None,
+        question=f"scrape returned only {len(doc.markdown or '')} chars of markdown for https://example.com/pricing",
     )
 
     # Step 3: Apply fix parameters and retry
@@ -158,20 +152,15 @@ if not doc.markdown or len(doc.markdown) < 100:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `question` | string | Yes | What to diagnose (1–8,000 characters) |
-| `rationale` | string | No | Recommended for AI callers. What the end user is trying to accomplish. Helps prioritize diagnostic evidence gathering. |
-| `jobId` | string | No | A failing job ID for fast-path debugging |
-| `context` | object | No | Free-form metadata from your agent, included in the diagnostic prompt |
-| `model` | string | No | Override the default model. Options: `claude-opus-4-7` (default), `claude-sonnet-4-6` (~2x faster), `claude-haiku-4-5` (cheapest) |
-| `maxSteps` | integer | No | Step cap (1–20, default 8) |
+| `question` | string | Yes | What to debug (1–8,000 characters) |
+| `rationale` | string | No | Recommended for AI callers. What the end user is trying to accomplish. Helps prioritize evidence gathering. |
+| `context` | object | No | Free-form metadata from your agent, included in the debugging prompt |
 
 ### `/support/docs-search`
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `question` | string | Yes | The question to answer (1–8,000 characters) |
-| `model` | string | No | Override the default model (default: `claude-sonnet-4-6`) |
-| `maxSteps` | integer | No | Step cap (2–4, default 3) |
 
 ## Response
 
@@ -195,8 +184,7 @@ if not doc.markdown or len(doc.markdown) < 100:
   "kbCitations": ["features/crawl.mdx#L40-L80"],
   "feedback": null,
   "usage": { "inputTokens": 12345, "outputTokens": 678, "totalTokens": 13023 },
-  "durationMs": 18432,
-  "model": "anthropic:claude-opus-4-7"
+  "durationMs": 18432
 }
 ```
 
@@ -210,8 +198,7 @@ if not doc.markdown or len(doc.markdown) < 100:
     { "pathOrUrl": "webhooks/security.mdx#L1-L52", "reason": "..." }
   ],
   "usage": { "inputTokens": 4356, "outputTokens": 688, "totalTokens": 5044 },
-  "durationMs": 11252,
-  "model": "anthropic:claude-sonnet-4-6"
+  "durationMs": 11252
 }
 ```
 
@@ -220,19 +207,6 @@ if not doc.markdown or len(doc.markdown) < 100:
 | Metric | Typical | Maximum |
 |--------|---------|---------|
 | Latency | 15–30 seconds | 60 seconds (hard ceiling) |
-| Steps | 2–3 | 20 (configurable via `maxSteps`) |
-
-## Model selection
-
-| Model | Speed | Cost | Best for |
-|-------|-------|------|----------|
-| `claude-opus-4-7` (default) | ~15-30s | Highest | Complex multi-step diagnosis |
-| `claude-sonnet-4-6` | ~7-15s | Medium | Most issues, good speed/quality balance |
-| `claude-haiku-4-5` | Fastest | Lowest | Simple questions, high-volume usage |
-
-<Tip>
-  Start with the default (`claude-opus-4-7`) for diagnostic accuracy. Switch to `claude-sonnet-4-6` if you need faster responses, or `claude-haiku-4-5` for high-volume, simple lookups.
-</Tip>
 
 ## API Reference
 

--- a/features/ask.mdx
+++ b/features/ask.mdx
@@ -1,0 +1,244 @@
+---
+title: "Ask"
+description: "Agentic debugging for your Firecrawl integration"
+og:title: "Ask | Firecrawl"
+og:description: "Diagnose scraping issues, debug failing jobs, and get verified fixes — all through a single API call."
+sidebarTitle: "Ask"
+icon: "messages-question"
+---
+
+Firecrawl `/support/ask` is an AI support agent exposed as an API. Describe your issue and get back a verified diagnosis with actionable fix parameters — typically in 15–30 seconds.
+
+**Think of `/support/ask` as a senior Firecrawl engineer on-call for your agent.**
+
+<Info>
+  The Ask API is designed primarily for **AI agent callers**. If you're building agents that use Firecrawl for scraping, crawling, or data extraction, wire `/support/ask` into your error-handling flow for autonomous issue resolution.
+</Info>
+
+## Two endpoints
+
+| Endpoint | Auth | Who it's for | What it does |
+|----------|------|--------------|--------------|
+| `POST /support/ask` | Your Firecrawl API key | Your agents and apps | Full diagnostic loop scoped to your team |
+| `POST /support/docs-search` | None (public) | Anyone | Docs-grounded answers from Firecrawl's public documentation |
+
+## Quick start
+
+### Diagnose a failing job
+
+```bash
+curl -X POST https://api.firecrawl.dev/v2/support/ask \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "question": "my crawl returned 3 pages but I expected 50",
+    "jobId": "crawl_abc123"
+  }'
+```
+
+### Search the docs (no auth)
+
+```bash
+curl -X POST https://api.firecrawl.dev/v2/support/docs-search \
+  -H "Content-Type: application/json" \
+  -d '{
+    "question": "how do I set up webhook signature verification?"
+  }'
+```
+
+## How it works
+
+When you call `/support/ask`, the AI agent:
+
+1. **Gathers evidence** — inspects your job logs, account state, credit usage, and relevant documentation in parallel
+2. **Diagnoses the issue** — reasons across all evidence to identify the root cause
+3. **Proposes a fix** — generates machine-actionable `fixParameters` you can apply directly to your next API call
+4. **Validates the fix** — when possible, tests the fix against the live Firecrawl API (e.g., retrying a scrape with adjusted parameters) and reports the result
+
+## Using Ask in your agent
+
+The key design pattern: call `/support/ask` when your Firecrawl API call fails or returns unexpected results, then use the `fixParameters` to retry.
+
+### Python example
+
+```python
+import requests
+
+FIRECRAWL_API_KEY = "fc-YOUR_API_KEY"
+
+def diagnose_firecrawl_issue(question, job_id=None, rationale=None):
+    """Call the Firecrawl Ask API to diagnose an issue."""
+    payload = {"question": question}
+    if job_id:
+        payload["jobId"] = job_id
+    if rationale:
+        payload["rationale"] = rationale
+
+    response = requests.post(
+        "https://api.firecrawl.dev/v2/support/ask",
+        headers={
+            "Authorization": f"Bearer {FIRECRAWL_API_KEY}",
+            "Content-Type": "application/json",
+        },
+        json=payload,
+    )
+    return response.json()
+
+
+# Example: diagnose a scrape that returned empty content
+result = diagnose_firecrawl_issue(
+    question="scrape returned empty markdown for https://example.com",
+    job_id="scrape_xyz789",
+    rationale="user needs product pricing data for competitive analysis",
+)
+
+print(result["answer"])
+print(result["fixParameters"])  # e.g., {"waitFor": 5000, "actions": [...]}
+print(result["confidence"])     # "high", "medium", or "low"
+```
+
+### Node.js example
+
+```javascript
+async function diagnoseFirecrawlIssue(question, jobId, rationale) {
+  const response = await fetch(
+    "https://api.firecrawl.dev/v2/support/ask",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.FIRECRAWL_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ question, jobId, rationale }),
+    }
+  );
+  return response.json();
+}
+
+// Example: diagnose a crawl that stopped early
+const result = await diagnoseFirecrawlIssue(
+  "my crawl returned 3 pages but I expected 50",
+  "crawl_abc123",
+  "user is on their third failed crawl attempt today"
+);
+
+console.log(result.answer);
+console.log(result.fixParameters);
+```
+
+### Agent retry pattern
+
+```python
+from firecrawl import Firecrawl
+
+client = Firecrawl(api_key="fc-YOUR_API_KEY")
+
+# Step 1: Try the scrape
+doc = client.scrape("https://example.com/pricing", formats=["markdown"])
+
+if not doc.markdown or len(doc.markdown) < 100:
+    # Step 2: Ask for diagnosis
+    diagnosis = diagnose_firecrawl_issue(
+        question=f"scrape returned only {len(doc.markdown or '')} chars of markdown",
+        job_id=doc.metadata.scrape_id if doc.metadata else None,
+    )
+
+    # Step 3: Apply fix parameters and retry
+    if diagnosis.get("fixParameters"):
+        doc = client.scrape(
+            "https://example.com/pricing",
+            formats=["markdown"],
+            **diagnosis["fixParameters"],
+        )
+```
+
+## Parameters
+
+### `/support/ask`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `question` | string | Yes | What to diagnose (1–8,000 characters) |
+| `rationale` | string | No | Recommended for AI callers. What the end user is trying to accomplish. Helps prioritize diagnostic evidence gathering. |
+| `jobId` | string | No | A failing job ID for fast-path debugging |
+| `context` | object | No | Free-form metadata from your agent, included in the diagnostic prompt |
+| `model` | string | No | Override the default model. Options: `claude-opus-4-7` (default), `claude-sonnet-4-6` (~2x faster), `claude-haiku-4-5` (cheapest) |
+| `maxSteps` | integer | No | Step cap (1–20, default 8) |
+
+### `/support/docs-search`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `question` | string | Yes | The question to answer (1–8,000 characters) |
+| `model` | string | No | Override the default model (default: `claude-sonnet-4-6`) |
+| `maxSteps` | integer | No | Step cap (2–4, default 3) |
+
+## Response
+
+### `/support/ask` response
+
+```json
+{
+  "requestId": "req_...",
+  "answer": "Your crawl is hitting a robots.txt disallow on /products/*. The fix is to add the allowBackwardCrawling parameter.",
+  "confidence": "high",
+  "fixParameters": { "allowBackwardCrawling": true },
+  "validation": {
+    "tested": true,
+    "result": "success",
+    "evidence": "validateScrape with allowBackwardCrawling:true returned 12,403 chars vs 0 baseline."
+  },
+  "evidence": [
+    { "tool": "debugJob", "rationale": "...", "summary": "..." },
+    { "tool": "searchKnowledgeBase", "rationale": "...", "summary": "..." }
+  ],
+  "kbCitations": ["features/crawl.mdx#L40-L80"],
+  "feedback": null,
+  "usage": { "inputTokens": 12345, "outputTokens": 678, "totalTokens": 13023 },
+  "durationMs": 18432,
+  "model": "anthropic:claude-opus-4-7"
+}
+```
+
+### `/support/docs-search` response
+
+```json
+{
+  "requestId": "req_...",
+  "answer": "The signature is sent in the X-Firecrawl-Signature header...",
+  "evidence": [
+    { "pathOrUrl": "webhooks/security.mdx#L1-L52", "reason": "..." }
+  ],
+  "usage": { "inputTokens": 4356, "outputTokens": 688, "totalTokens": 5044 },
+  "durationMs": 11252,
+  "model": "anthropic:claude-sonnet-4-6"
+}
+```
+
+## Performance
+
+| Metric | Typical | Maximum |
+|--------|---------|---------|
+| Latency | 15–30 seconds | 60 seconds (hard ceiling) |
+| Steps | 2–3 | 20 (configurable via `maxSteps`) |
+
+## Model selection
+
+| Model | Speed | Cost | Best for |
+|-------|-------|------|----------|
+| `claude-opus-4-7` (default) | ~15-30s | Highest | Complex multi-step diagnosis |
+| `claude-sonnet-4-6` | ~7-15s | Medium | Most issues, good speed/quality balance |
+| `claude-haiku-4-5` | Fastest | Lowest | Simple questions, high-volume usage |
+
+<Tip>
+  Start with the default (`claude-opus-4-7`) for diagnostic accuracy. Switch to `claude-sonnet-4-6` if you need faster responses, or `claude-haiku-4-5` for high-volume, simple lookups.
+</Tip>
+
+## API Reference
+
+- [Ask endpoint API Reference](/api-reference/endpoint/ask)
+- [Docs Search endpoint API Reference](/api-reference/endpoint/docs-search)
+
+Have feedback or need help? Email [help@firecrawl.com](mailto:help@firecrawl.com).
+
+> Are you an AI agent that needs a Firecrawl API key? See [firecrawl.dev/agent-onboarding/SKILL.md](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for automated onboarding instructions.

--- a/features/ask.mdx
+++ b/features/ask.mdx
@@ -20,7 +20,7 @@ Firecrawl `/support/ask` is an AI support agent exposed as an API. Describe your
 | Endpoint | Auth | Who it's for | What it does |
 |----------|------|--------------|--------------|
 | `POST /support/ask` | Your Firecrawl API key | Your agents and apps | Full diagnostic loop scoped to your team |
-| `POST /support/docs-search` | None (public) | Anyone | Docs-grounded answers from Firecrawl's public documentation |
+| `POST /support/docs-search` | Your Firecrawl API key | Your agents and apps | Docs-grounded answers from Firecrawl's public documentation |
 
 ## Quick start
 
@@ -35,10 +35,11 @@ curl -X POST https://api.firecrawl.dev/v2/support/ask \
   }'
 ```
 
-### Search the docs (no auth)
+### Search the docs
 
 ```bash
 curl -X POST https://api.firecrawl.dev/v2/support/docs-search \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "question": "how do I set up webhook signature verification?"

--- a/features/ask.mdx
+++ b/features/ask.mdx
@@ -177,11 +177,6 @@ if not doc.markdown or len(doc.markdown) < 100:
     "result": "success",
     "evidence": "validateScrape with allowBackwardCrawling:true returned 12,403 chars vs 0 baseline."
   },
-  "evidence": [
-    { "tool": "debugJob", "rationale": "...", "summary": "..." },
-    { "tool": "searchKnowledgeBase", "rationale": "...", "summary": "..." }
-  ],
-  "kbCitations": ["features/crawl.mdx#L40-L80"],
   "feedback": null,
   "usage": { "inputTokens": 12345, "outputTokens": 678, "totalTokens": 13023 },
   "durationMs": 18432


### PR DESCRIPTION
Adds agentic debugging endpoints (/support/ask, /support/docs-search) from the support-agent service into the public documentation — API reference pages, a feature guide with integration examples, OpenAPI schema entries, navigation updates, and cross-references across all agent source-of-truth pages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/firecrawl/firecrawl-docs/pull/909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->