### PR TITLE
Fix missing blank line in extract.mdx

### DIFF
--- a/features/extract.mdx
+++ b/features/extract.mdx
@@ -30,6 +30,7 @@ import ExtractStatusDone from "/snippets/v2/extract/status/completed.mdx";
 import ExtractWithoutURLsPython from "/snippets/v2/extract/without-urls/python.mdx";
 import ExtractWithoutURLsJS from "/snippets/v2/extract/without-urls/js.mdx";
 import ExtractWithoutURLsCURL from "/snippets/v2/extract/without-urls/curl.mdx";
+
 <Note>
   **Introducing Agent: The Next Evolution of Extract**  
   We're launching [`/agent`](/features/agent) — the successor to `/extract`. It's faster, more reliable, and doesn't require URLs. Just describe what you need and let the AI agent find and extract the data for you. [Try Agent now →](/features/agent)


### PR DESCRIPTION
## Summary
- Adds missing blank line before `<Note>` component in `features/extract.mdx` for proper MDX rendering to fix this Mintify issue

<img width="1143" height="79" alt="Screenshot 2026-05-06 at 21 39 54" src="https://github.com/user-attachments/assets/2fddbaf6-4ccb-4844-819a-9d090a91b2f9" />