### PR TITLE
Add mobile scraping section to advanced scraping guide

### DIFF
--- a/advanced-scraping-guide.mdx
+++ b/advanced-scraping-guide.mdx
@@ -104,16 +104,17 @@ from firecrawl import Firecrawl
 
 firecrawl = Firecrawl(api_key="fc-YOUR-API-KEY")
 
-doc = firecrawl.scrape("https://example.com", {
-    "mobile": True,
-    "location": {"country": "GB", "languages": ["en-GB"]},
-    "formats": [
+doc = firecrawl.scrape(
+    "https://example.com",
+    mobile=True,
+    location={"country": "GB", "languages": ["en-GB"]},
+    formats=[
         "markdown",
         {"type": "screenshot", "fullPage": True, "viewport": {"width": 390, "height": 844}},
     ],
-    "onlyMainContent": False,
-    "waitFor": 2000,
-})
+    only_main_content=False,
+    wait_for=2000,
+)
 
 print(doc.markdown)
 ```
@@ -168,11 +169,6 @@ If the site still serves a desktop layout despite `mobile: true`, add a mobile U
   }
 }
 ```
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `mobile` | `boolean` | `false` | Emulate a mobile device for scraping and screenshots. |
-
 ### Content filtering
 
 These parameters control which parts of the page appear in the output. When `onlyMainContent` is `true` (the default), boilerplate (nav, footer, etc.) is stripped. `includeTags` and `excludeTags` are applied against the original page DOM, not the post-filtered result, so your selectors should target elements as they appear in the source HTML. Set `onlyMainContent: false` to use the full page as the starting point for tag filtering.

--- a/advanced-scraping-guide.mdx
+++ b/advanced-scraping-guide.mdx
@@ -91,6 +91,88 @@ The `formats` array controls which output types the scraper returns. Default: `[
 | `changeTracking` | `modes?: ("json" \| "git-diff")[]`, `tag?: string`, `schema?: object`, `prompt?: string` | Track changes between scrapes. Requires `"markdown"` to also be in the formats array. |
 | `attributes` | `selectors: [{ selector: string, attribute: string }]` | Extract specific HTML attributes from elements matching CSS selectors. |
 
+### Mobile scraping
+
+Set `mobile: true` to emulate a mobile device. This is useful when a responsive site hides content on desktop or serves a different layout to mobile browsers.
+
+For region-specific sites, combine with `location` and a mobile screenshot to verify the rendered layout:
+
+<CodeGroup>
+
+```python Python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(api_key="fc-YOUR-API-KEY")
+
+doc = firecrawl.scrape("https://example.com", {
+    "mobile": True,
+    "location": {"country": "GB", "languages": ["en-GB"]},
+    "formats": [
+        "markdown",
+        {"type": "screenshot", "fullPage": True, "viewport": {"width": 390, "height": 844}},
+    ],
+    "onlyMainContent": False,
+    "waitFor": 2000,
+})
+
+print(doc.markdown)
+```
+
+```js Node
+import { Firecrawl } from 'firecrawl-js';
+
+const firecrawl = new Firecrawl({ apiKey: 'fc-YOUR-API-KEY' });
+
+const doc = await firecrawl.scrape('https://example.com', {
+  mobile: true,
+  location: { country: 'GB', languages: ['en-GB'] },
+  formats: [
+    'markdown',
+    { type: 'screenshot', fullPage: true, viewport: { width: 390, height: 844 } },
+  ],
+  onlyMainContent: false,
+  waitFor: 2000,
+});
+
+console.log(doc.markdown);
+```
+
+```bash cURL
+curl -X POST https://api.firecrawl.dev/v2/scrape \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer fc-YOUR-API-KEY' \
+  -d '{
+    "url": "https://example.com",
+    "mobile": true,
+    "location": {
+      "country": "GB",
+      "languages": ["en-GB"]
+    },
+    "formats": [
+      "markdown",
+      { "type": "screenshot", "fullPage": true, "viewport": { "width": 390, "height": 844 } }
+    ],
+    "onlyMainContent": false,
+    "waitFor": 2000
+  }'
+```
+
+</CodeGroup>
+
+If the site still serves a desktop layout despite `mobile: true`, add a mobile User-Agent via `headers`:
+
+```json
+{
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+  }
+}
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `mobile` | `boolean` | `false` | Emulate a mobile device for scraping and screenshots. |
+
 ### Content filtering
 
 These parameters control which parts of the page appear in the output. When `onlyMainContent` is `true` (the default), boilerplate (nav, footer, etc.) is stripped. `includeTags` and `excludeTags` are applied against the original page DOM, not the post-filtered result, so your selectors should target elements as they appear in the source HTML. Set `onlyMainContent: false` to use the full page as the starting point for tag filtering.


### PR DESCRIPTION
## Summary

- Adds a "Mobile scraping" section to the advanced scraping guide combining `mobile: true`, `location`, screenshot viewport, and `headers` User-Agent fallback into a single recipe
- Includes Python, Node, and cURL examples
- Addresses a docs gap where these parameters were documented individually but never shown together for the mobile scraping use case

## Preview

<img width="1724" height="1047" alt="Screenshot 2026-05-07 at 12 07 37" src="https://github.com/user-attachments/assets/36031b80-54ff-45df-944f-4986de8626f2" />



## Test plan

- [x] Verify the section renders correctly on the docs site
- [x] Confirm Python, Node, and cURL code examples are syntactically valid
- [x] Check the section appears in the "On this page" sidebar navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)