### PR TITLE
Hide v1 and deprecated pages from navigation and search indexing

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -503,6 +503,7 @@
           },
           {
             "version": "v1",
+            "hidden": true,
             "tabs": [
               {
                 "tab": "Documentation",

--- a/features/extract-beta.mdx
+++ b/features/extract-beta.mdx
@@ -1,4 +1,6 @@
 ---
+hidden: true
+noindex: true
 title: 'Extract'
 description: 'Extract structured data from pages using LLMs'
 og:title: "Extract | Firecrawl"

--- a/v1-welcome.mdx
+++ b/v1-welcome.mdx
@@ -1,4 +1,6 @@
 ---
+hidden: true
+noindex: true
 title: Welcome to V1
 description: "Firecrawl allows you to turn entire websites into LLM-ready markdown"
 og:title: "Welcome to V1 | Firecrawl"


### PR DESCRIPTION
## Summary
Reduces v1 SDK code leaking to AI agents that consume our docs (via llms.txt and site navigation). By hiding deprecated v1 content, agents will default to current v2 APIs instead of outdated v1 patterns.

- Added `"hidden": true` to the v1 version section in `docs.json` to prevent v1 pages from appearing in nav and llms.txt generation
- Added `hidden: true` and `noindex: true` frontmatter to `v1-welcome.mdx`
- Added `hidden: true` and `noindex: true` frontmatter to `features/extract-beta.mdx`
- Confirmed `features/extract.mdx` already has `hidden: true` and `noindex: true`

## Test plan
- [x] Verify v1 pages no longer appear in site navigation
- [x] Verify v1 pages are excluded from llms.txt generation
- [ ] Verify v1-welcome and extract-beta pages are not indexed by search engines
- [ ] Confirm v2/current docs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)