### PR TITLE
docs: exclude /support/ask and /support/docs-search from Elixir source-of-truth

### DIFF
--- a/agent-source-of-truth/elixir.mdx
+++ b/agent-source-of-truth/elixir.mdx
@@ -28,8 +28,6 @@ config :firecrawl, api_key: System.get_env("FIRECRAWL_API_KEY")
 - `search`: use when you start with a query and need discovery.
 - `scrape`: use when you already have a URL and want page content.
 - `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
-- `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
-- `support/docs-search`: use when you need to look up Firecrawl documentation.
 
 ## Search
 


### PR DESCRIPTION
## Summary

Follow-up to [#909](https://github.com/firecrawl/firecrawl-docs/pull/909) (already merged).

The Elixir SDK is auto-generated from `agent-source-of-truth/elixir.mdx` and the OpenAPI spec. The pattern is: only endpoints listed in the **"When To Use What"** section get a generated client function. Other endpoints — notably `/extract` — are excluded by simply *not being listed* in this file, and the generator skips them.

PR #909 added two bullets to the Elixir source-of-truth:

- `support/ask`
- `support/docs-search`

…but the Elixir SDK doesn't ship clients for these endpoints. An agent reading this source-of-truth would be told to call `support/ask`, find no `Firecrawl.support_ask` function, and `NimbleOptions` would reject the call before any HTTP request was made.

Drop the two bullets so the file reads like the pre-#909 version for these endpoints — same exclusion pattern `/extract` uses.

## Other SDKs unchanged

- `curl.mdx` — kept (universal HTTP, has full endpoint sections)
- `python.mdx`, `node.mdx` — kept (SDKs support these)
- `java.mdx`, `rust.mdx` — only have the bullets, not full endpoint sections; left alone since the user only flagged Elixir
- `elixir.mdx` — **fix in this PR**

If `/support/ask` clients land in any of those SDKs later, the bullets are still correct. The Elixir SDK doesn't and (per the user) should not auto-generate them.

## Diff

```diff
- `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
- `support/docs-search`: use when you need to look up Firecrawl documentation.
```

Two-line deletion. No other files changed.

## Test plan

- [ ] After merge, regenerate the Elixir SDK from this source-of-truth and verify no `support_ask` / `support_docs_search` functions are generated.
- [ ] Confirm `/extract` is similarly absent (sanity check that the pattern still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/firecrawl/firecrawl-docs/pull/917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->