### PR TITLE
docs(ask): drop usage from /support/ask response + neutralize example diagnosis

### DIFF
--- a/api-reference/endpoint/ask.mdx
+++ b/api-reference/endpoint/ask.mdx
@@ -41,7 +41,6 @@ curl -X POST https://api.firecrawl.dev/v2/support/ask \
 | `fixParameters` | object \| null | API parameters to apply the fix (e.g., `{"waitFor": 5000}`) |
 | `validation` | object \| null | Whether the fix was tested: `tested`, `result` (success/failure/skipped), `evidence` |
 | `feedback` | object \| null | Present when the agent gets stuck; `{ blockedBy, attempted }`. Null on success. |
-| `usage` | object | Token consumption (`inputTokens`, `outputTokens`, `totalTokens`) |
 | `durationMs` | integer | Total execution time in milliseconds |
 
 ## Status codes

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -5561,21 +5561,6 @@
               }
             }
           },
-          "usage": {
-            "type": "object",
-            "description": "Token consumption for this request.",
-            "properties": {
-              "inputTokens": {
-                "type": "integer"
-              },
-              "outputTokens": {
-                "type": "integer"
-              },
-              "totalTokens": {
-                "type": "integer"
-              }
-            }
-          },
           "durationMs": {
             "type": "integer",
             "description": "Total execution time in milliseconds."

--- a/features/ask.mdx
+++ b/features/ask.mdx
@@ -170,19 +170,20 @@ if not doc.markdown or len(doc.markdown) < 100:
 ```json
 {
   "requestId": "req_...",
-  "answer": "Your crawl is hitting a robots.txt disallow on /products/*. The fix is to add the allowBackwardCrawling parameter.",
+  "answer": "<2-4 sentence prose diagnosis of the issue plus the recommended fix.>",
   "confidence": "high",
-  "fixParameters": { "allowBackwardCrawling": true },
+  "fixParameters": { "<param>": "<value>" },
   "validation": {
     "tested": true,
     "result": "success",
-    "evidence": "validateScrape with allowBackwardCrawling:true returned 12,403 chars vs 0 baseline."
+    "evidence": "<short summary of the validation tool call the agent ran to confirm the fix>"
   },
   "feedback": null,
-  "usage": { "inputTokens": 12345, "outputTokens": 678, "totalTokens": 13023 },
   "durationMs": 18432
 }
 ```
+
+The actual `answer`, `fixParameters`, and `validation.evidence` are produced per request by the agent based on your specific run; the example above shows the response shape, not a real diagnosis.
 
 ### `/support/docs-search` response
 


### PR DESCRIPTION
## Summary

Two changes on the `/support/ask` docs to keep the published contract honest:

### 1. Drop `usage` from the `/support/ask` response

Token usage is captured server-side for telemetry but **not** returned to callers — companion change in [support-agent](https://github.com/firecrawl/support-agent/pull/4) removes it from the `AnswerEnvelope`. The docs were promising a `usage` object that won't actually be there. Updates:

- `api-reference/v2-openapi.json` — drop `usage` from the `AskResponse` schema.
- `api-reference/endpoint/ask.mdx` — drop the `usage` row from the response fields table.
- `features/ask.mdx` — drop the `usage` line from the `/support/ask` example payload.

`/support/docs-search` keeps its `usage` field — that endpoint still returns it (different envelope shape, different code path).

### 2. Replace the fabricated example diagnosis

The previous example in `features/ask.mdx` looked like real Firecrawl guidance:

```json
{
  "answer": "Your crawl is hitting a robots.txt disallow on /products/*. The fix is to add the allowBackwardCrawling parameter.",
  "fixParameters": { "allowBackwardCrawling": true },
  "validation": {
    "tested": true,
    "result": "success",
    "evidence": "validateScrape with allowBackwardCrawling:true returned 12,403 chars vs 0 baseline."
  }
}
```

The agent generates each `answer` / `fixParameters` / `validation.evidence` per request, from the caller's specific job logs — there's no canonical "robots.txt → allowBackwardCrawling" mapping in the agent. Showing this example invites readers (and downstream LLMs reading the docs) to apply it to unrelated failures even though it's a snapshot from one particular run.

Replaced with neutral `<...>` placeholders and an explicit one-liner clarifying that the example shows the **shape**, not a real diagnosis:

```json
{
  "answer": "<2-4 sentence prose diagnosis of the issue plus the recommended fix.>",
  "confidence": "high",
  "fixParameters": { "<param>": "<value>" },
  "validation": {
    "tested": true,
    "result": "success",
    "evidence": "<short summary of the validation tool call the agent ran to confirm the fix>"
  },
  "feedback": null,
  "durationMs": 18432
}
```

> The actual `answer`, `fixParameters`, and `validation.evidence` are produced per request by the agent based on your specific run; the example above shows the response shape, not a real diagnosis.

## Companion PRs

- [firecrawl/support-agent#4](https://github.com/firecrawl/support-agent/pull/4) — drop `usage` from the `AnswerEnvelope` interface (source of truth).
- [firecrawl/firecrawl-web#2096](https://github.com/firecrawl/firecrawl-web/pull/2096) — drop `usage` from the playground Debug modal's validation schema.
- [firecrawl/cli#108](https://github.com/firecrawl/cli/pull/108) — drop `usage` from the CLI's `AskResponse` type.
- [firecrawl/firecrawl-mcp-server#228](https://github.com/firecrawl/firecrawl-mcp-server/pull/228) — drop `usage` from the `firecrawl_ask` tool's Returns description.

## Test plan

- [ ] Mintlify renders the response example without the `usage` line.
- [ ] OpenAPI-generated reference page no longer shows `usage` under `AskResponse`.
- [ ] The example block in `features/ask.mdx` reads as obviously templated (`<...>` placeholders) rather than as factual guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/firecrawl/firecrawl-docs/pull/920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->