### PR TITLE
Fix JSON mode credit cost discrepancy in extraction comparison guide

### DIFF
--- a/developer-guides/usage-guides/choosing-the-data-extractor.mdx
+++ b/developer-guides/usage-guides/choosing-the-data-extractor.mdx
@@ -28,7 +28,7 @@ Firecrawl offers three approaches for extracting structured data from web pages.
 | **URL Discovery** | Autonomous web search | Crawls from given URLs | None |
 | **Processing** | Asynchronous | Asynchronous | Synchronous |
 | **Schema Required** | No (prompt or schema) | No (prompt or schema) | No (prompt or schema) |
-| **Pricing** | Dynamic (5 free runs/day) | Token-based (1 credit = 15 tokens) | 1 credit/page |
+| **Pricing** | Dynamic (5 free runs/day) | Token-based (1 credit = 15 tokens) | 5 credits/page (1 base + 4 for JSON mode) |
 | **Best For** | Research, discovery, complex gathering | Multi-page extraction (when you know URLs) | Known single-page extraction |
 
 ## 1. `/agent` Endpoint
@@ -165,7 +165,7 @@ For more details, see the [JSON mode documentation](/features/llm-extract).
 
 | Endpoint | Cost | Notes |
 |----------|------|-------|
-| `/scrape` (JSON mode) | 1 credit/page | Fixed, predictable |
+| `/scrape` (JSON mode) | 5 credits/page (1 base + 4 for JSON mode) | Fixed, predictable |
 | `/extract` | Token-based (1 credit = 15 tokens) | Variable based on content |
 | `/agent` | Dynamic | 5 free runs/day; varies by complexity |
 
@@ -214,7 +214,7 @@ The key advantage: with `/agent`, you can drop the URLs entirely and just descri
 
 ## Key Takeaways
 
-1. **Know the exact URL?** Use `/scrape` with JSON mode—it's the cheapest (1 credit/page), fastest (synchronous), and most predictable option.
+1. **Know the exact URL?** Use `/scrape` with JSON mode—it's the cheapest (5 credits/page), fastest (synchronous), and most predictable option.
 
 2. **Need autonomous research?** Use `/agent`—it handles discovery automatically with 5 free runs/day, then dynamic pricing based on complexity.
 


### PR DESCRIPTION
## Summary
- Fixed incorrect JSON mode credit cost in `choosing-the-data-extractor.mdx` — was listed as 1 credit/page, corrected to 5 credits/page (1 base + 4 additional for JSON mode)
- Updated 3 occurrences: comparison table, pricing table, and key takeaways section

## What was wrong
The file `developer-guides/usage-guides/choosing-the-data-extractor.mdx` listed JSON mode (`/scrape`) as costing **1 credit/page** in three places. The correct cost is **5 credits/page** (1 base + 4 additional for JSON mode).

<img width="893" height="923" alt="Screenshot 2026-05-08 at 10 16 42" src="https://github.com/user-attachments/assets/aa2b6c45-282d-4084-9efc-da207240512a" />


## How the correct cost was determined
The authoritative source is [`features/scrape.mdx` (line 101)](https://github.com/firecrawl/firecrawl-docs/blob/main/features/scrape.mdx#L101), which states:

> "Each scrape consumes 1 credit. Additional credits apply for certain options: JSON mode costs 4 additional credits per page"

This gives a total of 5 credits/page for JSON mode (1 base + 4 additional).

## Test plan
- [ ] Verify the pricing table renders correctly
- [ ] Confirm values match `features/scrape.mdx` (line 101)

🤖 Generated with [Claude Code](https://claude.com/claude-code)