### PR TITLE
Link e-commerce use case from scrape JSON format section

### DIFF
--- a/features/scrape.mdx
+++ b/features/scrape.mdx
@@ -167,6 +167,10 @@ When using the `json` format, pass an object inside `formats` with the following
 - `schema`: JSON Schema for the structured output.
 - `prompt`: Optional prompt to help guide extraction when a schema is present or when you prefer light guidance.
 
+<Note>
+  Looking for a real-world example? See how to use JSON extraction for [product and e-commerce data](/use-cases/product-ecommerce) like pricing, inventory, and product details.
+</Note>
+
 ## Extract brand identity
 
 ### /scrape (with branding) endpoint


### PR DESCRIPTION
## Summary
- Adds a callout in the scrape page's JSON extraction section linking to the product & e-commerce use case page (`/use-cases/product-ecommerce`)

## Why
The scrape page explains JSON structured extraction but doesn't point readers to a practical example. The dedicated e-commerce use case page shows exactly how to use this feature for pricing, inventory, and product data — cross-linking helps users discover it in context.

<img width="913" height="630" alt="Screenshot 2026-05-08 at 10 11 33" src="https://github.com/user-attachments/assets/fbd40dd7-b412-41f4-ab07-6e024b381769" />


## Test plan
- [ ] Verify the Note renders correctly on the scrape page
- [ ] Verify the link navigates to the e-commerce use case page

🤖 Generated with [Claude Code](https://claude.com/claude-code)