### PR TITLE
fix(webhooks): convert OpenAPI spec to paths for SSR compatibility

### DIFF
--- a/api-reference/endpoint/webhook-agent-action.mdx
+++ b/api-reference/endpoint/webhook-agent-action.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent Action"
-openapi: "/api-reference/webhooks-openapi.json webhook agentAction"
+openapi: "/api-reference/webhooks-openapi.json POST /webhooks/agent.action"
 hidden: true
 noindex: true
 

--- a/api-reference/endpoint/webhook-agent-action.mdx
+++ b/api-reference/endpoint/webhook-agent-action.mdx
@@ -5,3 +5,5 @@ hidden: true
 noindex: true
 
 ---
+
+This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when an agent executes a tool. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.

--- a/api-reference/endpoint/webhook-agent-action.mdx
+++ b/api-reference/endpoint/webhook-agent-action.mdx
@@ -6,4 +6,6 @@ noindex: true
 
 ---
 
-This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when an agent executes a tool. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.
+import WebhookPayloadNote from "/snippets/shared/webhook-payload-note.mdx";
+
+<WebhookPayloadNote />

--- a/api-reference/endpoint/webhook-agent-cancelled.mdx
+++ b/api-reference/endpoint/webhook-agent-cancelled.mdx
@@ -6,4 +6,6 @@ noindex: true
 
 ---
 
-This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when an agent job is cancelled. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.
+import WebhookPayloadNote from "/snippets/shared/webhook-payload-note.mdx";
+
+<WebhookPayloadNote />

--- a/api-reference/endpoint/webhook-agent-cancelled.mdx
+++ b/api-reference/endpoint/webhook-agent-cancelled.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent Cancelled"
-openapi: "/api-reference/webhooks-openapi.json webhook agentCancelled"
+openapi: "/api-reference/webhooks-openapi.json POST /webhooks/agent.cancelled"
 hidden: true
 noindex: true
 

--- a/api-reference/endpoint/webhook-agent-cancelled.mdx
+++ b/api-reference/endpoint/webhook-agent-cancelled.mdx
@@ -5,3 +5,5 @@ hidden: true
 noindex: true
 
 ---
+
+This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when an agent job is cancelled. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.

--- a/api-reference/endpoint/webhook-agent-completed.mdx
+++ b/api-reference/endpoint/webhook-agent-completed.mdx
@@ -6,4 +6,6 @@ noindex: true
 
 ---
 
-This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when an agent finishes successfully. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.
+import WebhookPayloadNote from "/snippets/shared/webhook-payload-note.mdx";
+
+<WebhookPayloadNote />

--- a/api-reference/endpoint/webhook-agent-completed.mdx
+++ b/api-reference/endpoint/webhook-agent-completed.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent Completed"
-openapi: "/api-reference/webhooks-openapi.json webhook agentCompleted"
+openapi: "/api-reference/webhooks-openapi.json POST /webhooks/agent.completed"
 hidden: true
 noindex: true
 

--- a/api-reference/endpoint/webhook-agent-completed.mdx
+++ b/api-reference/endpoint/webhook-agent-completed.mdx
@@ -5,3 +5,5 @@ hidden: true
 noindex: true
 
 ---
+
+This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when an agent finishes successfully. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.

--- a/api-reference/endpoint/webhook-agent-failed.mdx
+++ b/api-reference/endpoint/webhook-agent-failed.mdx
@@ -6,4 +6,6 @@ noindex: true
 
 ---
 
-This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when an agent encounters an error. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.
+import WebhookPayloadNote from "/snippets/shared/webhook-payload-note.mdx";
+
+<WebhookPayloadNote />

--- a/api-reference/endpoint/webhook-agent-failed.mdx
+++ b/api-reference/endpoint/webhook-agent-failed.mdx
@@ -5,3 +5,5 @@ hidden: true
 noindex: true
 
 ---
+
+This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when an agent encounters an error. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.

--- a/api-reference/endpoint/webhook-agent-failed.mdx
+++ b/api-reference/endpoint/webhook-agent-failed.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent Failed"
-openapi: "/api-reference/webhooks-openapi.json webhook agentFailed"
+openapi: "/api-reference/webhooks-openapi.json POST /webhooks/agent.failed"
 hidden: true
 noindex: true
 

--- a/api-reference/endpoint/webhook-agent-started.mdx
+++ b/api-reference/endpoint/webhook-agent-started.mdx
@@ -5,3 +5,5 @@ hidden: true
 noindex: true
 
 ---
+
+This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when an agent job starts. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.

--- a/api-reference/endpoint/webhook-agent-started.mdx
+++ b/api-reference/endpoint/webhook-agent-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent Started"
-openapi: "/api-reference/webhooks-openapi.json webhook agentStarted"
+openapi: "/api-reference/webhooks-openapi.json POST /webhooks/agent.started"
 hidden: true
 noindex: true
 

--- a/api-reference/endpoint/webhook-agent-started.mdx
+++ b/api-reference/endpoint/webhook-agent-started.mdx
@@ -6,4 +6,6 @@ noindex: true
 
 ---
 
-This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when an agent job starts. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.
+import WebhookPayloadNote from "/snippets/shared/webhook-payload-note.mdx";
+
+<WebhookPayloadNote />

--- a/api-reference/endpoint/webhook-batch-scrape-completed.mdx
+++ b/api-reference/endpoint/webhook-batch-scrape-completed.mdx
@@ -3,4 +3,6 @@ title: "Batch Scrape Completed"
 openapi: "/api-reference/webhooks-openapi.json POST /webhooks/batch_scrape.completed"
 ---
 
-This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when all URLs in a batch scrape have been processed. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.
+import WebhookPayloadNote from "/snippets/shared/webhook-payload-note.mdx";
+
+<WebhookPayloadNote />

--- a/api-reference/endpoint/webhook-batch-scrape-completed.mdx
+++ b/api-reference/endpoint/webhook-batch-scrape-completed.mdx
@@ -2,3 +2,5 @@
 title: "Batch Scrape Completed"
 openapi: "/api-reference/webhooks-openapi.json POST /webhooks/batch_scrape.completed"
 ---
+
+This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when all URLs in a batch scrape have been processed. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.

--- a/api-reference/endpoint/webhook-batch-scrape-completed.mdx
+++ b/api-reference/endpoint/webhook-batch-scrape-completed.mdx
@@ -1,4 +1,4 @@
 ---
 title: "Batch Scrape Completed"
-openapi: "/api-reference/webhooks-openapi.json webhook batchScrapeCompleted"
+openapi: "/api-reference/webhooks-openapi.json POST /webhooks/batch_scrape.completed"
 ---

--- a/api-reference/endpoint/webhook-batch-scrape-page.mdx
+++ b/api-reference/endpoint/webhook-batch-scrape-page.mdx
@@ -1,4 +1,4 @@
 ---
 title: "Batch Scrape Page"
-openapi: "/api-reference/webhooks-openapi.json webhook batchScrapePage"
+openapi: "/api-reference/webhooks-openapi.json POST /webhooks/batch_scrape.page"
 ---

--- a/api-reference/endpoint/webhook-batch-scrape-page.mdx
+++ b/api-reference/endpoint/webhook-batch-scrape-page.mdx
@@ -3,4 +3,6 @@ title: "Batch Scrape Page"
 openapi: "/api-reference/webhooks-openapi.json POST /webhooks/batch_scrape.page"
 ---
 
-This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when a URL is scraped during a batch scrape. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.
+import WebhookPayloadNote from "/snippets/shared/webhook-payload-note.mdx";
+
+<WebhookPayloadNote />

--- a/api-reference/endpoint/webhook-batch-scrape-page.mdx
+++ b/api-reference/endpoint/webhook-batch-scrape-page.mdx
@@ -2,3 +2,5 @@
 title: "Batch Scrape Page"
 openapi: "/api-reference/webhooks-openapi.json POST /webhooks/batch_scrape.page"
 ---
+
+This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when a URL is scraped during a batch scrape. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.

--- a/api-reference/endpoint/webhook-batch-scrape-started.mdx
+++ b/api-reference/endpoint/webhook-batch-scrape-started.mdx
@@ -3,4 +3,6 @@ title: "Batch Scrape Started"
 openapi: "/api-reference/webhooks-openapi.json POST /webhooks/batch_scrape.started"
 ---
 
-This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when a batch scrape job starts. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.
+import WebhookPayloadNote from "/snippets/shared/webhook-payload-note.mdx";
+
+<WebhookPayloadNote />

--- a/api-reference/endpoint/webhook-batch-scrape-started.mdx
+++ b/api-reference/endpoint/webhook-batch-scrape-started.mdx
@@ -1,4 +1,4 @@
 ---
 title: "Batch Scrape Started"
-openapi: "/api-reference/webhooks-openapi.json webhook batchScrapeStarted"
+openapi: "/api-reference/webhooks-openapi.json POST /webhooks/batch_scrape.started"
 ---

--- a/api-reference/endpoint/webhook-batch-scrape-started.mdx
+++ b/api-reference/endpoint/webhook-batch-scrape-started.mdx
@@ -2,3 +2,5 @@
 title: "Batch Scrape Started"
 openapi: "/api-reference/webhooks-openapi.json POST /webhooks/batch_scrape.started"
 ---
+
+This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when a batch scrape job starts. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.

--- a/api-reference/endpoint/webhook-crawl-completed.mdx
+++ b/api-reference/endpoint/webhook-crawl-completed.mdx
@@ -2,3 +2,5 @@
 title: "Crawl Completed"
 openapi: "/api-reference/webhooks-openapi.json POST /webhooks/crawl.completed"
 ---
+
+This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when a crawl job finishes. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.

--- a/api-reference/endpoint/webhook-crawl-completed.mdx
+++ b/api-reference/endpoint/webhook-crawl-completed.mdx
@@ -3,4 +3,6 @@ title: "Crawl Completed"
 openapi: "/api-reference/webhooks-openapi.json POST /webhooks/crawl.completed"
 ---
 
-This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when a crawl job finishes. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.
+import WebhookPayloadNote from "/snippets/shared/webhook-payload-note.mdx";
+
+<WebhookPayloadNote />

--- a/api-reference/endpoint/webhook-crawl-completed.mdx
+++ b/api-reference/endpoint/webhook-crawl-completed.mdx
@@ -1,4 +1,4 @@
 ---
 title: "Crawl Completed"
-openapi: "/api-reference/webhooks-openapi.json webhook crawlCompleted"
+openapi: "/api-reference/webhooks-openapi.json POST /webhooks/crawl.completed"
 ---

--- a/api-reference/endpoint/webhook-crawl-page.mdx
+++ b/api-reference/endpoint/webhook-crawl-page.mdx
@@ -3,4 +3,6 @@ title: "Crawl Page"
 openapi: "/api-reference/webhooks-openapi.json POST /webhooks/crawl.page"
 ---
 
-This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when a page is scraped during a crawl. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.
+import WebhookPayloadNote from "/snippets/shared/webhook-payload-note.mdx";
+
+<WebhookPayloadNote />

--- a/api-reference/endpoint/webhook-crawl-page.mdx
+++ b/api-reference/endpoint/webhook-crawl-page.mdx
@@ -2,3 +2,5 @@
 title: "Crawl Page"
 openapi: "/api-reference/webhooks-openapi.json POST /webhooks/crawl.page"
 ---
+
+This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when a page is scraped during a crawl. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.

--- a/api-reference/endpoint/webhook-crawl-page.mdx
+++ b/api-reference/endpoint/webhook-crawl-page.mdx
@@ -1,4 +1,4 @@
 ---
 title: "Crawl Page"
-openapi: "/api-reference/webhooks-openapi.json webhook crawlPage"
+openapi: "/api-reference/webhooks-openapi.json POST /webhooks/crawl.page"
 ---

--- a/api-reference/endpoint/webhook-crawl-started.mdx
+++ b/api-reference/endpoint/webhook-crawl-started.mdx
@@ -1,4 +1,4 @@
 ---
 title: "Crawl Started"
-openapi: "/api-reference/webhooks-openapi.json webhook crawlStarted"
+openapi: "/api-reference/webhooks-openapi.json POST /webhooks/crawl.started"
 ---

--- a/api-reference/endpoint/webhook-crawl-started.mdx
+++ b/api-reference/endpoint/webhook-crawl-started.mdx
@@ -2,3 +2,5 @@
 title: "Crawl Started"
 openapi: "/api-reference/webhooks-openapi.json POST /webhooks/crawl.started"
 ---
+
+This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when a crawl job starts. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.

--- a/api-reference/endpoint/webhook-crawl-started.mdx
+++ b/api-reference/endpoint/webhook-crawl-started.mdx
@@ -3,4 +3,6 @@ title: "Crawl Started"
 openapi: "/api-reference/webhooks-openapi.json POST /webhooks/crawl.started"
 ---
 
-This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL when a crawl job starts. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.
+import WebhookPayloadNote from "/snippets/shared/webhook-payload-note.mdx";
+
+<WebhookPayloadNote />

--- a/api-reference/webhooks-openapi.json
+++ b/api-reference/webhooks-openapi.json
@@ -1,11 +1,16 @@
 {
-  "openapi": "3.1.0",
+  "openapi": "3.0.0",
   "info": {
     "title": "Firecrawl Webhooks",
     "version": "v2"
   },
-  "webhooks": {
-    "crawlStarted": {
+  "servers": [
+    {
+      "url": "https://your-server.com"
+    }
+  ],
+  "paths": {
+    "/webhooks/crawl.started": {
       "post": {
         "summary": "Crawl Started",
         "operationId": "crawlStarted",
@@ -34,12 +39,12 @@
                   "success": {
                     "type": "boolean",
                     "description": "Always `true` for this event.",
-                    "const": true
+                    "enum": [true]
                   },
                   "type": {
                     "type": "string",
                     "description": "The event type.",
-                    "const": "crawl.started"
+                    "enum": ["crawl.started"]
                   },
                   "id": {
                     "type": "string",
@@ -80,7 +85,7 @@
         }
       }
     },
-    "crawlPage": {
+    "/webhooks/crawl.page": {
       "post": {
         "summary": "Crawl Page",
         "operationId": "crawlPage",
@@ -113,7 +118,7 @@
                   "type": {
                     "type": "string",
                     "description": "The event type.",
-                    "const": "crawl.page"
+                    "enum": ["crawl.page"]
                   },
                   "id": {
                     "type": "string",
@@ -169,7 +174,7 @@
         }
       }
     },
-    "crawlCompleted": {
+    "/webhooks/crawl.completed": {
       "post": {
         "summary": "Crawl Completed",
         "operationId": "crawlCompleted",
@@ -198,12 +203,12 @@
                   "success": {
                     "type": "boolean",
                     "description": "Always `true` for this event.",
-                    "const": true
+                    "enum": [true]
                   },
                   "type": {
                     "type": "string",
                     "description": "The event type.",
-                    "const": "crawl.completed"
+                    "enum": ["crawl.completed"]
                   },
                   "id": {
                     "type": "string",
@@ -244,7 +249,7 @@
         }
       }
     },
-    "batchScrapeStarted": {
+    "/webhooks/batch_scrape.started": {
       "post": {
         "summary": "Batch Scrape Started",
         "operationId": "batchScrapeStarted",
@@ -272,11 +277,11 @@
                 "properties": {
                   "success": {
                     "type": "boolean",
-                    "const": true
+                    "enum": [true]
                   },
                   "type": {
                     "type": "string",
-                    "const": "batch_scrape.started"
+                    "enum": ["batch_scrape.started"]
                   },
                   "id": {
                     "type": "string",
@@ -316,7 +321,7 @@
         }
       }
     },
-    "batchScrapePage": {
+    "/webhooks/batch_scrape.page": {
       "post": {
         "summary": "Batch Scrape Page",
         "operationId": "batchScrapePage",
@@ -348,7 +353,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "const": "batch_scrape.page"
+                    "enum": ["batch_scrape.page"]
                   },
                   "id": {
                     "type": "string",
@@ -404,7 +409,7 @@
         }
       }
     },
-    "batchScrapeCompleted": {
+    "/webhooks/batch_scrape.completed": {
       "post": {
         "summary": "Batch Scrape Completed",
         "operationId": "batchScrapeCompleted",
@@ -432,11 +437,11 @@
                 "properties": {
                   "success": {
                     "type": "boolean",
-                    "const": true
+                    "enum": [true]
                   },
                   "type": {
                     "type": "string",
-                    "const": "batch_scrape.completed"
+                    "enum": ["batch_scrape.completed"]
                   },
                   "id": {
                     "type": "string",
@@ -477,7 +482,7 @@
         }
       }
     },
-    "agentStarted": {
+    "/webhooks/agent.started": {
       "post": {
         "summary": "Agent Started",
         "operationId": "agentStarted",
@@ -505,11 +510,11 @@
                 "properties": {
                   "success": {
                     "type": "boolean",
-                    "const": true
+                    "enum": [true]
                   },
                   "type": {
                     "type": "string",
-                    "const": "agent.started"
+                    "enum": ["agent.started"]
                   },
                   "id": {
                     "type": "string",
@@ -549,7 +554,7 @@
         }
       }
     },
-    "agentAction": {
+    "/webhooks/agent.action": {
       "post": {
         "summary": "Agent Action",
         "operationId": "agentAction",
@@ -577,11 +582,11 @@
                 "properties": {
                   "success": {
                     "type": "boolean",
-                    "const": true
+                    "enum": [true]
                   },
                   "type": {
                     "type": "string",
-                    "const": "agent.action"
+                    "enum": ["agent.action"]
                   },
                   "id": {
                     "type": "string",
@@ -646,7 +651,7 @@
         }
       }
     },
-    "agentCompleted": {
+    "/webhooks/agent.completed": {
       "post": {
         "summary": "Agent Completed",
         "operationId": "agentCompleted",
@@ -674,11 +679,11 @@
                 "properties": {
                   "success": {
                     "type": "boolean",
-                    "const": true
+                    "enum": [true]
                   },
                   "type": {
                     "type": "string",
-                    "const": "agent.completed"
+                    "enum": ["agent.completed"]
                   },
                   "id": {
                     "type": "string",
@@ -739,7 +744,7 @@
         }
       }
     },
-    "agentFailed": {
+    "/webhooks/agent.failed": {
       "post": {
         "summary": "Agent Failed",
         "operationId": "agentFailed",
@@ -769,11 +774,11 @@
                   "success": {
                     "type": "boolean",
                     "description": "Always `false` for this event.",
-                    "const": false
+                    "enum": [false]
                   },
                   "type": {
                     "type": "string",
-                    "const": "agent.failed"
+                    "enum": ["agent.failed"]
                   },
                   "id": {
                     "type": "string",
@@ -829,7 +834,7 @@
         }
       }
     },
-    "agentCancelled": {
+    "/webhooks/agent.cancelled": {
       "post": {
         "summary": "Agent Cancelled",
         "operationId": "agentCancelled",
@@ -858,11 +863,11 @@
                   "success": {
                     "type": "boolean",
                     "description": "Always `false` for this event.",
-                    "const": false
+                    "enum": [false]
                   },
                   "type": {
                     "type": "string",
-                    "const": "agent.cancelled"
+                    "enum": ["agent.cancelled"]
                   },
                   "id": {
                     "type": "string",

--- a/snippets/shared/webhook-payload-note.mdx
+++ b/snippets/shared/webhook-payload-note.mdx
@@ -1,0 +1,3 @@
+<Note>
+  This is not an API endpoint you call. It describes the payload Firecrawl sends to your webhook URL. See [Webhook Overview](/webhooks/overview) for configuration and [Event Types](/webhooks/events) for all payloads.
+</Note>


### PR DESCRIPTION
## Problem

Webhook API reference pages (e.g. `/api-reference/endpoint/webhook-crawl-completed`) appear **completely empty** to LLMs and agents. This is because:

1. `webhooks-openapi.json` uses the OpenAPI 3.1.0 `webhooks` key
2. Mintlify only server-side renders the `paths` key — not `webhooks`
3. Agents fetching these pages (or using `Accept: text/markdown` content negotiation) get an empty `paths: {}` object

These pages are linked from the auto-generated `llms.txt`, so agents are actively directed to dead ends.

<img width="994" height="885" alt="Screenshot 2026-05-08 at 12 28 08" src="https://github.com/user-attachments/assets/4708f8c9-109f-471c-b9fa-c2b0e3efd04d" />


**Human visitors are unaffected** — Mintlify renders the spec client-side via JavaScript.


<img width="1128" height="1128" alt="Screenshot 2026-05-08 at 12 29 25" src="https://github.com/user-attachments/assets/70281bdc-f083-4510-a3f7-2dc758bdf2b6" />



### How to reproduce

```bash
# Returns full spec ✅
curl -s -H "Accept: text/markdown" 'https://docs.firecrawl.dev/api-reference/endpoint/map' | head -30

# Returns empty paths: {} ❌
curl -s -H "Accept: text/markdown" 'https://docs.firecrawl.dev/api-reference/endpoint/webhook-crawl-started' | head -30
```

## Fix

- Convert `webhooks-openapi.json` from `webhooks` key → `paths` key
- Downgrade from OpenAPI 3.1.0 → 3.0.0 (`const` → `enum`)
- Update all 11 MDX stubs to reference the new `POST /webhooks/...` path format

## ⚠️ Tradeoff

This is a **workaround**, not a perfect fix. Using `paths` with `POST` makes these pages display as if they're API endpoints you call, when in reality webhooks are payloads Firecrawl sends *to your server*. The semantically correct approach is the OpenAPI 3.1.0 `webhooks` key, but Mintlify doesn't SSR it.

This should be reverted once Mintlify adds server-side rendering support for the `webhooks` key. Filed upstream: https://github.com/mintlify/docs/issues/5712

## Test plan

- [x] Verify webhook API reference pages render correctly in the Mintlify preview
- [ ] Verify `curl -H "Accept: text/markdown"` returns the full spec for a webhook page
- [ ] Verify `llms.txt` descriptions still appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)