### PR TITLE
docs(webhooks): add descriptions and cross-links to API reference stubs

### DIFF
--- a/api-reference/endpoint/webhook-batch-scrape-completed.mdx
+++ b/api-reference/endpoint/webhook-batch-scrape-completed.mdx
@@ -1,4 +1,7 @@
 ---
 title: "Batch Scrape Completed"
+description: "Webhook event sent when all URLs in a batch scrape have been processed."
 openapi: "/api-reference/webhooks-openapi.json webhook batchScrapeCompleted"
 ---
+
+For payload examples, configuration, and retry behavior, see [Webhook Event Types](/webhooks/events#batch_scrapecompleted) and [Webhook Overview](/webhooks/overview).

--- a/api-reference/endpoint/webhook-batch-scrape-page.mdx
+++ b/api-reference/endpoint/webhook-batch-scrape-page.mdx
@@ -1,4 +1,7 @@
 ---
 title: "Batch Scrape Page"
+description: "Webhook event sent for each URL scraped during a batch scrape job."
 openapi: "/api-reference/webhooks-openapi.json webhook batchScrapePage"
 ---
+
+For payload examples, configuration, and retry behavior, see [Webhook Event Types](/webhooks/events#batch_scrapepage) and [Webhook Overview](/webhooks/overview).

--- a/api-reference/endpoint/webhook-batch-scrape-started.mdx
+++ b/api-reference/endpoint/webhook-batch-scrape-started.mdx
@@ -1,4 +1,7 @@
 ---
 title: "Batch Scrape Started"
+description: "Webhook event sent when a batch scrape job begins processing."
 openapi: "/api-reference/webhooks-openapi.json webhook batchScrapeStarted"
 ---
+
+For payload examples, configuration, and retry behavior, see [Webhook Event Types](/webhooks/events#batch_scrapestarted) and [Webhook Overview](/webhooks/overview).

--- a/api-reference/endpoint/webhook-crawl-completed.mdx
+++ b/api-reference/endpoint/webhook-crawl-completed.mdx
@@ -1,4 +1,7 @@
 ---
 title: "Crawl Completed"
+description: "Webhook event sent when a crawl job finishes and all pages have been processed."
 openapi: "/api-reference/webhooks-openapi.json webhook crawlCompleted"
 ---
+
+For payload examples, configuration, and retry behavior, see [Webhook Event Types](/webhooks/events#crawlcompleted) and [Webhook Overview](/webhooks/overview).

--- a/api-reference/endpoint/webhook-crawl-page.mdx
+++ b/api-reference/endpoint/webhook-crawl-page.mdx
@@ -1,4 +1,7 @@
 ---
 title: "Crawl Page"
+description: "Webhook event sent for each page scraped during a crawl job."
 openapi: "/api-reference/webhooks-openapi.json webhook crawlPage"
 ---
+
+For payload examples, configuration, and retry behavior, see [Webhook Event Types](/webhooks/events#crawlpage) and [Webhook Overview](/webhooks/overview).

--- a/api-reference/endpoint/webhook-crawl-started.mdx
+++ b/api-reference/endpoint/webhook-crawl-started.mdx
@@ -1,4 +1,7 @@
 ---
 title: "Crawl Started"
+description: "Webhook event sent when a crawl job begins processing."
 openapi: "/api-reference/webhooks-openapi.json webhook crawlStarted"
 ---
+
+For payload examples, configuration, and retry behavior, see [Webhook Event Types](/webhooks/events#crawlstarted) and [Webhook Overview](/webhooks/overview).


### PR DESCRIPTION
## Problem

Webhook API reference pages (e.g. `/api-reference/endpoint/webhook-crawl-completed`) are OpenAPI stub files with no static content. Mintlify renders the OpenAPI spec client-side via JavaScript, which means:

- **LLMs and agents** fetching these pages get empty content (no JS execution)
- **`llms.txt`** links directly to these stubs, actively directing agents to dead ends
- The `description` frontmatter field (used by `llms.txt`) was missing entirely

## Fix

Adds to each of the 6 non-hidden webhook endpoint stubs:
- A `description` in frontmatter — picked up by Mintlify's auto-generated `llms.txt`
- A cross-link to `/webhooks/events` and `/webhooks/overview` — so agents landing on these pages can find the actual documentation

This is a **lightweight, standalone fix** that improves discoverability without changing the OpenAPI spec structure.

<img width="824" height="605" alt="Screenshot 2026-05-08 at 12 07 58" src="https://github.com/user-attachments/assets/a1d32bc9-6d15-4648-aae8-6b5d1a6d48cd" />



## Related

[#929](https://github.com/firecrawl/firecrawl-docs/pull/929) takes a different approach — converting the OpenAPI spec from the `webhooks` key to `paths` so Mintlify can SSR the full schema. That's a more complete fix but involves a semantic tradeoff. These two PRs are independent and complementary.

## Test plan

- [ ] Verify descriptions appear in the auto-generated `llms.txt`
- [ ] Verify cross-links render correctly on the webhook API reference pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)