### PR TITLE
Update installation command for firecrawl-cli

### DIFF
--- a/snippets/v2/installation/cli.mdx
+++ b/snippets/v2/installation/cli.mdx
@@ -1,6 +1,6 @@
 ```bash CLI
 # Install globally with npm
-npm install -g firecrawl
+npm install -g firecrawl-cli
 
 # Authenticate (one-time setup)
 firecrawl login


### PR DESCRIPTION
Made this change because by default it only installs the SDK (no firecrawl binary) due to that firecrawl command doesn't work in the terminal.