### PR TITLE
docs: fix Claude Code MCP remote URL command

### DIFF
--- a/es/mcp-server.mdx
+++ b/es/mcp-server.mdx
@@ -264,7 +264,7 @@ Agrega el servidor MCP de Firecrawl usando la CLI de Claude Code. Puedes usar la
 
 ```bash
 # URL alojada remotamente (recomendado)
-claude mcp add firecrawl --url https://mcp.firecrawl.dev/your-api-key/v2/mcp
+claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/your-api-key/v2/mcp
 
 # O ejecutarlo localmente mediante npx
 claude mcp add firecrawl -e FIRECRAWL_API_KEY=your-api-key -- npx -y firecrawl-mcp

--- a/es/quickstarts/claude-code.mdx
+++ b/es/quickstarts/claude-code.mdx
@@ -22,7 +22,7 @@ Crea una cuenta en [firecrawl.dev/app](https://firecrawl.dev/app) y copia tu cla
 **Opción A: URL alojada en remoto (recomendada)**
 
 ```bash
-claude mcp add firecrawl --url https://mcp.firecrawl.dev/your-api-key/v2/mcp
+claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/your-api-key/v2/mcp
 ```
 
 **Opción B: Local (npx)**

--- a/fr/mcp-server.mdx
+++ b/fr/mcp-server.mdx
@@ -264,7 +264,7 @@ Ajoutez le serveur MCP Firecrawl à l&#39;aide de la CLI Claude Code. Vous pouve
 
 ```bash
 # URL hébergée à distance (recommandé)
-claude mcp add firecrawl --url https://mcp.firecrawl.dev/your-api-key/v2/mcp
+claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/your-api-key/v2/mcp
 
 # Ou exécuter localement via npx
 claude mcp add firecrawl -e FIRECRAWL_API_KEY=your-api-key -- npx -y firecrawl-mcp

--- a/fr/quickstarts/claude-code.mdx
+++ b/fr/quickstarts/claude-code.mdx
@@ -22,7 +22,7 @@ Inscrivez-vous sur [firecrawl.dev/app](https://firecrawl.dev/app) et copiez votr
 **Option A : URL hébergée sur un serveur distant (recommandée)**
 
 ```bash
-claude mcp add firecrawl --url https://mcp.firecrawl.dev/your-api-key/v2/mcp
+claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/your-api-key/v2/mcp
 ```
 
 **Option B : En local (npx)**

--- a/ja/mcp-server.mdx
+++ b/ja/mcp-server.mdx
@@ -264,7 +264,7 @@ Claude Code の CLI を使って Firecrawl MCP サーバーを追加します。
 
 ```bash
 # Remote hosted URL (recommended)
-claude mcp add firecrawl --url https://mcp.firecrawl.dev/your-api-key/v2/mcp
+claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/your-api-key/v2/mcp
 
 # Or run locally via npx
 claude mcp add firecrawl -e FIRECRAWL_API_KEY=your-api-key -- npx -y firecrawl-mcp

--- a/ja/quickstarts/claude-code.mdx
+++ b/ja/quickstarts/claude-code.mdx
@@ -22,7 +22,7 @@ Firecrawl の MCP を使って、Claude Code にウェブ検索とスクレイ�
 **オプション A: リモートでホストされた URL (推奨)&#x20;**
 
 ```bash
-claude mcp add firecrawl --url https://mcp.firecrawl.dev/your-api-key/v2/mcp
+claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/your-api-key/v2/mcp
 ```
 
 **オプション B: ローカル (npx)**

--- a/mcp-server.mdx
+++ b/mcp-server.mdx
@@ -234,7 +234,7 @@ Add the Firecrawl MCP server using the Claude Code CLI. You can use the remote h
 
 ```bash
 # Remote hosted URL (recommended)
-claude mcp add firecrawl --url https://mcp.firecrawl.dev/your-api-key/v2/mcp
+claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/your-api-key/v2/mcp
 
 # Or run locally via npx
 claude mcp add firecrawl -e FIRECRAWL_API_KEY=your-api-key -- npx -y firecrawl-mcp

--- a/pt-BR/mcp-server.mdx
+++ b/pt-BR/mcp-server.mdx
@@ -264,7 +264,7 @@ Adicione o servidor MCP do Firecrawl usando a CLI do Claude Code. Você pode usa
 
 ```bash
 # URL hospedada remotamente (recomendado)
-claude mcp add firecrawl --url https://mcp.firecrawl.dev/your-api-key/v2/mcp
+claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/your-api-key/v2/mcp
 
 # Ou execute localmente via npx
 claude mcp add firecrawl -e FIRECRAWL_API_KEY=your-api-key -- npx -y firecrawl-mcp

--- a/pt-BR/quickstarts/claude-code.mdx
+++ b/pt-BR/quickstarts/claude-code.mdx
@@ -22,7 +22,7 @@ Inscreva-se em [firecrawl.dev/app](https://firecrawl.dev/app) e copie sua chave 
 **Opção A: URL hospedada remotamente (recomendada)**
 
 ```bash
-claude mcp add firecrawl --url https://mcp.firecrawl.dev/your-api-key/v2/mcp
+claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/your-api-key/v2/mcp
 ```
 
 **Opção B: Local (npx)**

--- a/quickstarts/claude-code.mdx
+++ b/quickstarts/claude-code.mdx
@@ -15,7 +15,7 @@ Sign up at [firecrawl.dev/app](https://firecrawl.dev/app) and copy your API key.
 **Option A: Remote hosted URL (recommended)**
 
 ```bash
-claude mcp add firecrawl --url https://mcp.firecrawl.dev/your-api-key/v2/mcp
+claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/your-api-key/v2/mcp
 ```
 
 **Option B: Local (npx)**

--- a/zh/mcp-server.mdx
+++ b/zh/mcp-server.mdx
@@ -264,7 +264,7 @@ npx -y @smithery/cli install @mendableai/mcp-server-firecrawl --client claude
 
 ```bash
 # 远程托管 URL（推荐）
-claude mcp add firecrawl --url https://mcp.firecrawl.dev/your-api-key/v2/mcp
+claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/your-api-key/v2/mcp
 
 # 或通过 npx 在本地运行
 claude mcp add firecrawl -e FIRECRAWL_API_KEY=your-api-key -- npx -y firecrawl-mcp

--- a/zh/quickstarts/claude-code.mdx
+++ b/zh/quickstarts/claude-code.mdx
@@ -22,7 +22,7 @@ description: "两分钟内为 Claude Code 添加网页抓取和搜索功能"
 **选项 A：远程托管 URL (推荐)&#x20;**
 
 ```bash
-claude mcp add firecrawl --url https://mcp.firecrawl.dev/your-api-key/v2/mcp
+claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/your-api-key/v2/mcp
 ```
 
 **选项 B：本地 (npx)&#x20;**


### PR DESCRIPTION
## Summary

- Fix the Claude Code remote MCP command reported in #862.
- Replace the removed `--url` form with `--transport http` for Firecrawl's hosted MCP endpoint.
- Update the same command in the English pages and localized copies so users don't hit the stale CLI option from another entry point.

Fixes #862.

## Tests

- `git diff --check`
- Static grep confirmed the stale `claude mcp add firecrawl --url https://mcp.firecrawl.dev/your-api-key/v2/mcp` snippet was replaced.

Docs-only command snippet update; no docs build run locally.
