### PR TITLE
docs(search): clarify SDK search results live under .web

### DIFF
--- a/agent-source-of-truth/node.mdx
+++ b/agent-source-of-truth/node.mdx
@@ -79,6 +79,8 @@ const results = await client.search("site:docs.firecrawl.dev crawl webhooks", {
 - `news`: news hits
 - `images`: image hits
 
+**Wrong turn to avoid:** `search()` does not return `{ data: [...] }`. Do not access `result.data`. Web results are in `result.web`, news in `result.news`, images in `result.images`.
+
 ### Parameters
 
 - `query`

--- a/agent-source-of-truth/python.mdx
+++ b/agent-source-of-truth/python.mdx
@@ -49,6 +49,8 @@ Returns a `SearchData` model with optional lists:
 
 Omitted buckets are `None` when the API did not return that key.
 
+**Wrong turn to avoid:** `search()` does not return `{ data: [...] }`. Do not access `result.data`. Web results are in `result.web`, news in `result.news`, images in `result.images`.
+
 ### Simple Example
 
 ```py

--- a/features/search.mdx
+++ b/features/search.mdx
@@ -68,6 +68,23 @@ SDKs will return the data object directly. cURL will return the complete payload
 
 <SearchResponse />
 
+<Note>
+**SDK users:** search results are grouped by source type, not under a generic `.data` array. Access web results with `result.web`, news with `result.news`, and images with `result.images`.
+
+```python Python
+result = firecrawl.search("query")
+for item in result.web or []:
+    print(item.url, item.title)
+```
+
+```js JavaScript
+const result = await firecrawl.search("query");
+for (const item of result.web ?? []) {
+  console.log(item.url, item.title);
+}
+```
+</Note>
+
 ## Search result types
 
 In addition to regular web results, Search supports specialized result types via the `sources` parameter:


### PR DESCRIPTION
## Summary
- Agents commonly try `result.data` on search responses and get `undefined` (JS) or `AttributeError` (Python)
- Firecrawl search returns results grouped by source type: `.web`, `.news`, `.images` - the SDKs unwrap the outer `data` envelope
- Added a `<Note>` callout with code examples in `features/search.mdx` after the Response section
- Added "wrong turn to avoid" warnings in `agent-source-of-truth/python.mdx` and `agent-source-of-truth/node.mdx`

## Test plan
- [ ] Docs preview renders the Note callout correctly
- [ ] No localized files edited
- [ ] `rg "result.web"` confirms new callout appears in search docs