### PR TITLE
docs: add search-then-scrape pattern and PDF scrape tips

### DIFF
--- a/features/parse.mdx
+++ b/features/parse.mdx
@@ -22,7 +22,15 @@ Use `/parse` when the source document is **a local file** or **not publicly acce
 | Source | Endpoint |
 |---|---|
 | Public URL to a document (e.g. `https://example.com/report.pdf`) | [`POST /scrape`](/api-reference/endpoint/scrape) |
-| Local file or non-public bytes (PDF, DOCX, XLSX, HTML, …) | [`POST /parse`](/api-reference/endpoint/parse) |
+| Local file or non-public bytes (PDF, DOCX, XLSX, HTML, ...) | [`POST /parse`](/api-reference/endpoint/parse) |
+
+<Tip>
+**Have a public PDF URL?** Use `/scrape` instead -- it auto-detects document types and returns clean markdown. No need for a separate PDF library.
+
+```python Python
+doc = firecrawl.scrape_url("https://example.com/report.pdf", formats=["markdown"])
+```
+</Tip>
 
 ## Parsing
 

--- a/features/parse.mdx
+++ b/features/parse.mdx
@@ -28,7 +28,7 @@ Use `/parse` when the source document is **a local file** or **not publicly acce
 **Have a public PDF URL?** Use `/scrape` instead -- it auto-detects document types and returns clean markdown. No need for a separate PDF library.
 
 ```python Python
-doc = firecrawl.scrape_url("https://example.com/report.pdf", formats=["markdown"])
+doc = firecrawl.scrape("https://example.com/report.pdf", formats=["markdown"])
 ```
 </Tip>
 

--- a/features/scrape.mdx
+++ b/features/scrape.mdx
@@ -104,7 +104,7 @@ For more details about the parameters, refer to the [API Reference](https://docs
 **PDFs and documents:** `/scrape` auto-detects PDFs, DOCX, and other document types from URLs. Pass a PDF URL the same way you would any webpage -- Firecrawl parses it and returns clean markdown. For local files that are not accessible by URL, use [`/parse`](/features/parse) instead.
 
 ```python Python
-doc = firecrawl.scrape_url("https://example.com/report.pdf", formats=["markdown"])
+doc = firecrawl.scrape("https://example.com/report.pdf", formats=["markdown"])
 print(doc.markdown)
 ```
 </Tip>

--- a/features/scrape.mdx
+++ b/features/scrape.mdx
@@ -100,6 +100,15 @@ Used to scrape a URL and get its content.
 
 For more details about the parameters, refer to the [API Reference](https://docs.firecrawl.dev/api-reference/endpoint/scrape).
 
+<Tip>
+**PDFs and documents:** `/scrape` auto-detects PDFs, DOCX, and other document types from URLs. Pass a PDF URL the same way you would any webpage -- Firecrawl parses it and returns clean markdown. For local files that are not accessible by URL, use [`/parse`](/features/parse) instead.
+
+```python Python
+doc = firecrawl.scrape_url("https://example.com/report.pdf", formats=["markdown"])
+print(doc.markdown)
+```
+</Tip>
+
 <Info>
   Each scrape consumes 1 credit. Additional credits apply for certain options: JSON mode costs 4 additional credits per page, question and highlights formats cost 4 additional credits per page per format, enhanced proxy costs 4 additional credits per page, PDF parsing costs 1 credit per PDF page, and audio or video extraction costs 4 additional credits per page.
 </Info>

--- a/features/search.mdx
+++ b/features/search.mdx
@@ -310,6 +310,51 @@ Every option in scrape endpoint is supported by this search endpoint through the
 }
 ```
 
+## Search then Scrape (Two-Step Pattern)
+
+If you need to filter or process search results before scraping, use a two-step approach: search first, then scrape the URLs you want.
+
+<CodeGroup>
+
+```python Python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(api_key="fc-YOUR_API_KEY")
+
+# Step 1: Search
+results = firecrawl.search("firecrawl web scraping", limit=5)
+
+# Step 2: Scrape each result URL for full content
+for item in results.web or []:
+    page = firecrawl.scrape_url(item.url, formats=["markdown"])
+    print(page.markdown[:200])
+```
+
+```js JavaScript
+import Firecrawl from '@mendable/firecrawl-js';
+
+const firecrawl = new Firecrawl({ apiKey: "fc-YOUR_API_KEY" });
+
+// Step 1: Search
+const results = await firecrawl.search("firecrawl web scraping", { limit: 5 });
+
+// Step 2: Scrape each result URL for full content
+for (const item of results.web ?? []) {
+  const page = await firecrawl.scrapeUrl(item.url, { formats: ["markdown"] });
+  console.log(page.markdown?.substring(0, 200));
+}
+```
+
+</CodeGroup>
+
+<Tip>
+**When to use which approach:**
+- **One-step** (`scrapeOptions` in search): You want content from all results. Simpler and faster.
+- **Two-step** (search then scrape): You want to filter, rank, or selectively scrape results. More flexible.
+
+Both approaches use Firecrawl for the scrape step. Do not use generic HTTP fetching or summarize from search snippets alone -- the full page content from Firecrawl scrape is what makes results grounded and complete.
+</Tip>
+
 ## Advanced Search Options
 
 Firecrawl's search API supports various parameters to customize your search:

--- a/features/search.mdx
+++ b/features/search.mdx
@@ -326,7 +326,7 @@ results = firecrawl.search("firecrawl web scraping", limit=5)
 
 # Step 2: Scrape each result URL for full content
 for item in results.web or []:
-    page = firecrawl.scrape_url(item.url, formats=["markdown"])
+    page = firecrawl.scrape(item.url, formats=["markdown"])
     print(page.markdown[:200])
 ```
 
@@ -340,7 +340,7 @@ const results = await firecrawl.search("firecrawl web scraping", { limit: 5 });
 
 // Step 2: Scrape each result URL for full content
 for (const item of results.web ?? []) {
-  const page = await firecrawl.scrapeUrl(item.url, { formats: ["markdown"] });
+  const page = await firecrawl.scrape(item.url, { formats: ["markdown"] });
   console.log(page.markdown?.substring(0, 200));
 }
 ```


### PR DESCRIPTION
## Summary
- Adds a **Search then Scrape** two-step pattern section to `/features/search` with Python and JS examples
- Adds a **PDF/document tip** to `/features/scrape` showing that `/scrape` auto-detects PDFs from URLs
- Adds a cross-reference tip to `/features/parse` redirecting public-URL PDF users to `/scrape`

## Why
From 72 Sapient custom eval traces (batch 1, May 25):
- 5 failures (26% of all failures) were caused by agents calling Firecrawl search but then summarizing from memory instead of scraping each result URL
- 6 failures (32%) were wrong-tool substitution, with agents using pdfplumber or generic HTTP instead of Firecrawl for PDFs

These are the two highest-leverage doc gaps identified from trace analysis.

## Test plan
- [ ] Verify search.mdx renders correctly on docs site (new section between "Search with Content Scraping" and "Advanced Search Options")
- [ ] Verify scrape.mdx tip renders between Usage and credit Info sections
- [ ] Verify parse.mdx tip renders after the endpoint routing table
- [ ] No localized files modified