### PR TITLE
Add scrape status, search feedback, and support endpoints to v2 OpenAPI spec

### DIFF
--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -20,7 +20,9 @@
       "post": {
         "summary": "Create a monitor",
         "operationId": "createMonitor",
-        "tags": ["Monitoring"],
+        "tags": [
+          "Monitoring"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -46,14 +48,18 @@
                     "notification": {
                       "email": {
                         "enabled": true,
-                        "recipients": ["alerts@example.com"],
+                        "recipients": [
+                          "alerts@example.com"
+                        ],
                         "includeDiffs": true
                       }
                     },
                     "targets": [
                       {
                         "type": "scrape",
-                        "urls": ["https://example.com/blog"]
+                        "urls": [
+                          "https://example.com/blog"
+                        ]
                       }
                     ]
                   }
@@ -68,7 +74,10 @@
                     },
                     "webhook": {
                       "url": "https://example.com/webhooks/firecrawl",
-                      "events": ["monitor.page", "monitor.check.completed"]
+                      "events": [
+                        "monitor.page",
+                        "monitor.check.completed"
+                      ]
                     },
                     "goal": "Notify me when docs pages add, remove, or materially change API behavior",
                     "targets": [
@@ -105,7 +114,9 @@
       "get": {
         "summary": "List monitors",
         "operationId": "listMonitors",
-        "tags": ["Monitoring"],
+        "tags": [
+          "Monitoring"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -150,7 +161,9 @@
       "get": {
         "summary": "Get a monitor",
         "operationId": "getMonitor",
-        "tags": ["Monitoring"],
+        "tags": [
+          "Monitoring"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -180,7 +193,9 @@
       "patch": {
         "summary": "Update a monitor",
         "operationId": "updateMonitor",
-        "tags": ["Monitoring"],
+        "tags": [
+          "Monitoring"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -226,7 +241,9 @@
       "delete": {
         "summary": "Delete a monitor",
         "operationId": "deleteMonitor",
-        "tags": ["Monitoring"],
+        "tags": [
+          "Monitoring"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -258,7 +275,9 @@
       "post": {
         "summary": "Run a monitor",
         "operationId": "runMonitor",
-        "tags": ["Monitoring"],
+        "tags": [
+          "Monitoring"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -290,7 +309,9 @@
       "get": {
         "summary": "List monitor checks",
         "operationId": "listMonitorChecks",
-        "tags": ["Monitoring"],
+        "tags": [
+          "Monitoring"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -324,7 +345,14 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["queued", "running", "completed", "failed", "partial", "skipped_overlap"]
+              "enum": [
+                "queued",
+                "running",
+                "completed",
+                "failed",
+                "partial",
+                "skipped_overlap"
+              ]
             },
             "description": "Filter checks by status."
           }
@@ -347,7 +375,9 @@
       "get": {
         "summary": "Get a monitor check",
         "operationId": "getMonitorCheck",
-        "tags": ["Monitoring"],
+        "tags": [
+          "Monitoring"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -392,7 +422,13 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["same", "new", "changed", "removed", "error"]
+              "enum": [
+                "same",
+                "new",
+                "changed",
+                "removed",
+                "error"
+              ]
             }
           }
         ],
@@ -417,7 +453,9 @@
       "post": {
         "summary": "Scrape a single URL and optionally extract information using an LLM",
         "operationId": "scrapeAndExtractFromUrl",
-        "tags": ["Scraping"],
+        "tags": [
+          "Scraping"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -438,7 +476,9 @@
                         "description": "The URL to scrape"
                       }
                     },
-                    "required": ["url"]
+                    "required": [
+                      "url"
+                    ]
                   },
                   {
                     "$ref": "#/components/schemas/ScrapeOptions"
@@ -532,7 +572,9 @@
       "post": {
         "summary": "Interact with the browser session associated with a scrape job",
         "operationId": "interactWithScrapeBrowserSession",
-        "tags": ["Scraping"],
+        "tags": [
+          "Scraping"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -556,7 +598,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["code"],
+                "required": [
+                  "code"
+                ],
                 "properties": {
                   "code": {
                     "type": "string",
@@ -566,7 +610,11 @@
                   },
                   "language": {
                     "type": "string",
-                    "enum": ["python", "node", "bash"],
+                    "enum": [
+                      "python",
+                      "node",
+                      "bash"
+                    ],
                     "default": "node",
                     "description": "Language of the code to execute. Use `node` for JavaScript or `bash` for agent-browser CLI commands."
                   },
@@ -796,7 +844,9 @@
       "delete": {
         "summary": "Stop the interactive browser session associated with a scrape job",
         "operationId": "stopInteractiveScrapeBrowserSession",
-        "tags": ["Scraping"],
+        "tags": [
+          "Scraping"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -877,7 +927,9 @@
       "post": {
         "summary": "Upload and parse a file",
         "operationId": "parseFile",
-        "tags": ["Scraping"],
+        "tags": [
+          "Scraping"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -899,7 +951,9 @@
                     "$ref": "#/components/schemas/ParseOptions"
                   }
                 },
-                "required": ["file"]
+                "required": [
+                  "file"
+                ]
               },
               "encoding": {
                 "options": {
@@ -1007,7 +1061,9 @@
       "post": {
         "summary": "Scrape multiple URLs and optionally extract information using an LLM",
         "operationId": "scrapeAndExtractFromUrls",
-        "tags": ["Scraping"],
+        "tags": [
+          "Scraping"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -1055,11 +1111,18 @@
                             "description": "Type of events that should be sent to the webhook URL. (default: all)",
                             "items": {
                               "type": "string",
-                              "enum": ["completed", "page", "failed", "started"]
+                              "enum": [
+                                "completed",
+                                "page",
+                                "failed",
+                                "started"
+                              ]
                             }
                           }
                         },
-                        "required": ["url"]
+                        "required": [
+                          "url"
+                        ]
                       },
                       "maxConcurrency": {
                         "type": "integer",
@@ -1071,7 +1134,9 @@
                         "description": "If invalid URLs are specified in the urls array, they will be ignored. Instead of them failing the entire request, a batch scrape using the remaining valid URLs will be created, and the invalid URLs will be returned in the invalidURLs field of the response."
                       }
                     },
-                    "required": ["urls"]
+                    "required": [
+                      "urls"
+                    ]
                   },
                   {
                     "$ref": "#/components/schemas/ScrapeOptions"
@@ -1169,7 +1234,9 @@
       "get": {
         "summary": "Get the status of a batch scrape job",
         "operationId": "getBatchScrapeStatus",
-        "tags": ["Scraping"],
+        "tags": [
+          "Scraping"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -1239,7 +1306,9 @@
       "delete": {
         "summary": "Cancel a batch scrape job",
         "operationId": "cancelBatchScrape",
-        "tags": ["Scraping"],
+        "tags": [
+          "Scraping"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -1255,7 +1324,9 @@
                   "properties": {
                     "status": {
                       "type": "string",
-                      "enum": ["cancelled"],
+                      "enum": [
+                        "cancelled"
+                      ],
                       "example": "cancelled"
                     }
                   }
@@ -1314,7 +1385,9 @@
       "get": {
         "summary": "Get the errors of a batch scrape job",
         "operationId": "getBatchScrapeErrors",
-        "tags": ["Scraping"],
+        "tags": [
+          "Scraping"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -1398,7 +1471,9 @@
       "get": {
         "summary": "Get the status of a crawl job",
         "operationId": "getCrawlStatus",
-        "tags": ["Crawling"],
+        "tags": [
+          "Crawling"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -1468,7 +1543,9 @@
       "delete": {
         "summary": "Cancel a crawl job",
         "operationId": "cancelCrawl",
-        "tags": ["Crawling"],
+        "tags": [
+          "Crawling"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -1484,7 +1561,9 @@
                   "properties": {
                     "status": {
                       "type": "string",
-                      "enum": ["cancelled"],
+                      "enum": [
+                        "cancelled"
+                      ],
                       "example": "cancelled"
                     }
                   }
@@ -1543,7 +1622,9 @@
       "get": {
         "summary": "Get the errors of a crawl job",
         "operationId": "getCrawlErrors",
-        "tags": ["Crawling"],
+        "tags": [
+          "Crawling"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -1615,7 +1696,9 @@
       "post": {
         "summary": "Crawl multiple URLs based on options",
         "operationId": "crawlUrls",
-        "tags": ["Crawling"],
+        "tags": [
+          "Crawling"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -1649,7 +1732,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "URL pathname regex patterns that include matching URLs in the crawl. Only the paths that match the specified patterns will be included in the response. Note: the starting URL is also checked against these patterns — if it does not match, the crawl may return 0 pages. For example, if you set \"includePaths\": [\"blog/.*\"] for the base URL firecrawl.dev/blog, only pages under /blog/ will be included in the results, such as https://www.firecrawl.dev/blog/firecrawl-launch-week-1-recap."
+                    "description": "URL pathname regex patterns that include matching URLs in the crawl. Only the paths that match the specified patterns will be included in the response. Note: the starting URL is also checked against these patterns \u2014 if it does not match, the crawl may return 0 pages. For example, if you set \"includePaths\": [\"blog/.*\"] for the base URL firecrawl.dev/blog, only pages under /blog/ will be included in the results, such as https://www.firecrawl.dev/blog/firecrawl-launch-week-1-recap."
                   },
                   "maxDiscoveryDepth": {
                     "type": "integer",
@@ -1657,7 +1740,11 @@
                   },
                   "sitemap": {
                     "type": "string",
-                    "enum": ["skip", "include", "only"],
+                    "enum": [
+                      "skip",
+                      "include",
+                      "only"
+                    ],
                     "description": "Sitemap mode when crawling. If you set it to 'skip', the crawler will ignore the website sitemap and only crawl the entered URL and discover pages from there onwards. If you set it to 'only', the crawler will only crawl URLs from the sitemap (plus the start URL) and will not discover links from HTML.",
                     "default": "include"
                   },
@@ -1678,7 +1765,7 @@
                   },
                   "crawlEntireDomain": {
                     "type": "boolean",
-                    "description": "Allows the crawler to follow internal links to sibling or parent URLs, not just child paths.\n\nfalse: Only crawls deeper (child) URLs.\n→ e.g. /features/feature-1 → /features/feature-1/tips ✅\n→ Won't follow /pricing or / ❌\n\ntrue: Crawls any internal links, including siblings and parents.\n→ e.g. /features/feature-1 → /pricing, /, etc. ✅\n\nUse true for broader internal coverage beyond nested paths.",
+                    "description": "Allows the crawler to follow internal links to sibling or parent URLs, not just child paths.\n\nfalse: Only crawls deeper (child) URLs.\n\u2192 e.g. /features/feature-1 \u2192 /features/feature-1/tips \u2705\n\u2192 Won't follow /pricing or / \u274c\n\ntrue: Crawls any internal links, including siblings and parents.\n\u2192 e.g. /features/feature-1 \u2192 /pricing, /, etc. \u2705\n\nUse true for broader internal coverage beyond nested paths.",
                     "default": false
                   },
                   "allowExternalLinks": {
@@ -1693,12 +1780,12 @@
                   },
                   "ignoreRobotsTxt": {
                     "type": "boolean",
-                    "description": "Ignore the website's robots.txt rules. Enterprise only — contact support@firecrawl.com to enable.",
+                    "description": "Ignore the website's robots.txt rules. Enterprise only \u2014 contact support@firecrawl.com to enable.",
                     "default": false
                   },
                   "robotsUserAgent": {
                     "type": "string",
-                    "description": "Custom User-Agent string for robots.txt evaluation. When set, robots.txt is fetched with this User-Agent and allow/disallow rules are matched against it instead of the default. Enterprise only — contact support@firecrawl.com to enable."
+                    "description": "Custom User-Agent string for robots.txt evaluation. When set, robots.txt is fetched with this User-Agent and allow/disallow rules are matched against it instead of the default. Enterprise only \u2014 contact support@firecrawl.com to enable."
                   },
                   "delay": {
                     "type": "number",
@@ -1733,11 +1820,18 @@
                         "description": "Type of events that should be sent to the webhook URL. (default: all)",
                         "items": {
                           "type": "string",
-                          "enum": ["completed", "page", "failed", "started"]
+                          "enum": [
+                            "completed",
+                            "page",
+                            "failed",
+                            "started"
+                          ]
                         }
                       }
                     },
-                    "required": ["url"]
+                    "required": [
+                      "url"
+                    ]
                   },
                   "scrapeOptions": {
                     "$ref": "#/components/schemas/ScrapeOptions"
@@ -1748,7 +1842,9 @@
                     "description": "If true, this will enable zero data retention for this crawl. To enable this feature, please contact help@firecrawl.dev"
                   }
                 },
-                "required": ["url"]
+                "required": [
+                  "url"
+                ]
               }
             }
           }
@@ -1819,7 +1915,9 @@
       "post": {
         "summary": "Preview crawl parameters generated from natural language prompt",
         "operationId": "crawlParamsPreview",
-        "tags": ["Crawling"],
+        "tags": [
+          "Crawling"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -1843,7 +1941,10 @@
                     "description": "Natural language prompt describing what you want to crawl"
                   }
                 },
-                "required": ["url", "prompt"]
+                "required": [
+                  "url",
+                  "prompt"
+                ]
               }
             }
           }
@@ -1904,7 +2005,10 @@
                         },
                         "sitemap": {
                           "type": "string",
-                          "enum": ["skip", "include"],
+                          "enum": [
+                            "skip",
+                            "include"
+                          ],
                           "description": "Sitemap handling strategy"
                         },
                         "ignoreQueryParameters": {
@@ -2005,7 +2109,9 @@
       "post": {
         "summary": "Map multiple URLs based on options",
         "operationId": "mapUrls",
-        "tags": ["Mapping"],
+        "tags": [
+          "Mapping"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -2029,7 +2135,11 @@
                   },
                   "sitemap": {
                     "type": "string",
-                    "enum": ["skip", "include", "only"],
+                    "enum": [
+                      "skip",
+                      "include",
+                      "only"
+                    ],
                     "description": "Sitemap mode when mapping. If you set it to `skip`, the sitemap won't be used to find URLs. If you set it to `only`, only URLs that are in the sitemap will be returned. By default (`include`), the sitemap and other methods will be used together to find URLs.",
                     "default": "include"
                   },
@@ -2079,7 +2189,9 @@
                     }
                   }
                 },
-                "required": ["url"]
+                "required": [
+                  "url"
+                ]
               },
               "examples": {
                 "example1": {
@@ -2094,7 +2206,9 @@
                     "limit": 5000,
                     "location": {
                       "country": "US",
-                      "languages": ["en-US"]
+                      "languages": [
+                        "en-US"
+                      ]
                     },
                     "timeout": 60000
                   }
@@ -2169,7 +2283,9 @@
       "post": {
         "summary": "Extract structured data from pages using LLMs",
         "operationId": "extractData",
-        "tags": ["Extraction"],
+        "tags": [
+          "Extraction"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -2227,7 +2343,9 @@
                     "description": "If invalid URLs are specified in the urls array, they will be ignored. Instead of them failing the entire request, an extract using the remaining valid URLs will be performed, and the invalid URLs will be returned in the invalidURLs field of the response."
                   }
                 },
-                "required": ["urls"]
+                "required": [
+                  "urls"
+                ]
               }
             }
           }
@@ -2294,7 +2412,9 @@
       "get": {
         "summary": "Get the status of an extract job",
         "operationId": "getExtractStatus",
-        "tags": ["Extraction"],
+        "tags": [
+          "Extraction"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -2318,7 +2438,9 @@
       "post": {
         "summary": "Start an agent task for agentic data extraction",
         "operationId": "startAgent",
-        "tags": ["Agent"],
+        "tags": [
+          "Agent"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -2358,12 +2480,17 @@
                   },
                   "model": {
                     "type": "string",
-                    "enum": ["spark-1-mini", "spark-1-pro"],
+                    "enum": [
+                      "spark-1-mini",
+                      "spark-1-pro"
+                    ],
                     "default": "spark-1-mini",
                     "description": "The model to use for the agent task. spark-1-mini (default) is 60% cheaper, spark-1-pro offers higher accuracy for complex tasks"
                   }
                 },
-                "required": ["prompt"]
+                "required": [
+                  "prompt"
+                ]
               }
             }
           }
@@ -2439,7 +2566,9 @@
       "get": {
         "summary": "Get the status of an agent job",
         "operationId": "getAgentStatus",
-        "tags": ["Agent"],
+        "tags": [
+          "Agent"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -2458,7 +2587,11 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["processing", "completed", "failed"]
+                      "enum": [
+                        "processing",
+                        "completed",
+                        "failed"
+                      ]
                     },
                     "data": {
                       "type": "object",
@@ -2466,7 +2599,10 @@
                     },
                     "model": {
                       "type": "string",
-                      "enum": ["spark-1-pro", "spark-1-mini"],
+                      "enum": [
+                        "spark-1-pro",
+                        "spark-1-mini"
+                      ],
                       "default": "spark-1-pro",
                       "description": "Model preset used for the agent run"
                     },
@@ -2491,7 +2627,9 @@
       "delete": {
         "summary": "Cancel an agent job",
         "operationId": "cancelAgent",
-        "tags": ["Agent"],
+        "tags": [
+          "Agent"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -2520,7 +2658,9 @@
       "get": {
         "summary": "Get all active crawls for the authenticated team",
         "operationId": "getActiveCrawls",
-        "tags": ["Crawling"],
+        "tags": [
+          "Crawling"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -2567,11 +2707,20 @@
                             }
                           }
                         },
-                        "required": ["id", "teamId", "url", "status", "options"]
+                        "required": [
+                          "id",
+                          "teamId",
+                          "url",
+                          "status",
+                          "options"
+                        ]
                       }
                     }
                   },
-                  "required": ["success", "data"]
+                  "required": [
+                    "success",
+                    "data"
+                  ]
                 }
               }
             }
@@ -2643,7 +2792,9 @@
       "get": {
         "summary": "Get remaining credits for the authenticated team",
         "operationId": "getCreditUsage",
-        "tags": ["Billing"],
+        "tags": [
+          "Billing"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -2742,7 +2893,9 @@
       "get": {
         "summary": "Get historical credit usage for the authenticated team",
         "operationId": "getHistoricalCreditUsage",
-        "tags": ["Billing"],
+        "tags": [
+          "Billing"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -2834,7 +2987,9 @@
       "get": {
         "summary": "Get remaining tokens for the authenticated team (Extract only)",
         "operationId": "getTokenUsage",
-        "tags": ["Billing"],
+        "tags": [
+          "Billing"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -2933,7 +3088,9 @@
       "get": {
         "summary": "Get historical token usage for the authenticated team (Extract only)",
         "operationId": "getHistoricalTokenUsage",
-        "tags": ["Billing"],
+        "tags": [
+          "Billing"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -3025,7 +3182,9 @@
       "get": {
         "summary": "Metrics about your team's scrape queue",
         "operationId": "getQueueStatus",
-        "tags": ["Miscellaneous"],
+        "tags": [
+          "Miscellaneous"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -3078,7 +3237,9 @@
         "summary": "List recent API activity",
         "operationId": "getActivity",
         "description": "Lists your team's recent API activity from the last 24 hours. Returns metadata about each job including the job ID, which can be used with the corresponding GET endpoint (e.g. GET /crawl/{id}) to retrieve full results. Supports cursor-based pagination and filtering by endpoint.",
-        "tags": ["Account"],
+        "tags": [
+          "Account"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -3091,7 +3252,19 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["scrape", "crawl", "batch_scrape", "search", "extract", "llmstxt", "deep_research", "map", "agent", "browser", "interact"]
+              "enum": [
+                "scrape",
+                "crawl",
+                "batch_scrape",
+                "search",
+                "extract",
+                "llmstxt",
+                "deep_research",
+                "map",
+                "agent",
+                "browser",
+                "interact"
+              ]
             },
             "description": "Filter by endpoint"
           },
@@ -3140,7 +3313,19 @@
                           },
                           "endpoint": {
                             "type": "string",
-                            "enum": ["scrape", "crawl", "batch_scrape", "search", "extract", "llmstxt", "deep_research", "map", "agent", "browser", "interact"],
+                            "enum": [
+                              "scrape",
+                              "crawl",
+                              "batch_scrape",
+                              "search",
+                              "extract",
+                              "llmstxt",
+                              "deep_research",
+                              "map",
+                              "agent",
+                              "browser",
+                              "interact"
+                            ],
                             "description": "The endpoint used for this job"
                           },
                           "api_version": {
@@ -3182,7 +3367,9 @@
       "post": {
         "summary": "Search and optionally scrape search results",
         "operationId": "searchAndScrape",
-        "tags": ["Search"],
+        "tags": [
+          "Search"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -3217,7 +3404,9 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "enum": ["web"]
+                              "enum": [
+                                "web"
+                              ]
                             },
                             "tbs": {
                               "type": "string",
@@ -3228,7 +3417,9 @@
                               "description": "Location parameter for search results"
                             }
                           },
-                          "required": ["type"]
+                          "required": [
+                            "type"
+                          ]
                         },
                         {
                           "type": "object",
@@ -3236,10 +3427,14 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "enum": ["images"]
+                              "enum": [
+                                "images"
+                              ]
                             }
                           },
-                          "required": ["type"]
+                          "required": [
+                            "type"
+                          ]
                         },
                         {
                           "type": "object",
@@ -3247,15 +3442,21 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "enum": ["news"]
+                              "enum": [
+                                "news"
+                              ]
                             }
                           },
-                          "required": ["type"]
+                          "required": [
+                            "type"
+                          ]
                         }
                       ]
                     },
                     "description": "Sources to search. Will determine the arrays available in the response. Defaults to ['web'].",
-                    "default": ["web"]
+                    "default": [
+                      "web"
+                    ]
                   },
                   "categories": {
                     "type": "array",
@@ -3267,10 +3468,14 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "enum": ["github"]
+                              "enum": [
+                                "github"
+                              ]
                             }
                           },
-                          "required": ["type"]
+                          "required": [
+                            "type"
+                          ]
                         },
                         {
                           "type": "object",
@@ -3278,10 +3483,14 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "enum": ["research"]
+                              "enum": [
+                                "research"
+                              ]
                             }
                           },
-                          "required": ["type"]
+                          "required": [
+                            "type"
+                          ]
                         },
                         {
                           "type": "object",
@@ -3289,10 +3498,14 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "enum": ["pdf"]
+                              "enum": [
+                                "pdf"
+                              ]
                             }
                           },
-                          "required": ["type"]
+                          "required": [
+                            "type"
+                          ]
                         }
                       ]
                     },
@@ -3341,7 +3554,10 @@
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "enum": ["anon", "zdr"]
+                      "enum": [
+                        "anon",
+                        "zdr"
+                      ]
                     },
                     "description": "Enterprise search options for Zero Data Retention (ZDR). Use `[\"zdr\"]` for end-to-end ZDR (10 credits / 10 results) or `[\"anon\"]` for anonymized ZDR (2 credits / 10 results). Must be enabled for your team."
                   },
@@ -3355,7 +3571,9 @@
                     "default": {}
                   }
                 },
-                "required": ["query"]
+                "required": [
+                  "query"
+                ]
               }
             }
           }
@@ -3656,7 +3874,9 @@
       "post": {
         "summary": "Create a browser session",
         "operationId": "createBrowserSession",
-        "tags": ["Browser"],
+        "tags": [
+          "Browser"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -3703,7 +3923,9 @@
                         "description": "When true, browser state is saved back to the profile on close. Set to false to load existing data without writing. Multiple non-saving sessions are allowed but only one saving session at a time."
                       }
                     },
-                    "required": ["name"]
+                    "required": [
+                      "name"
+                    ]
                   }
                 }
               }
@@ -3768,7 +3990,9 @@
       "get": {
         "summary": "List browser sessions",
         "operationId": "listBrowserSessions",
-        "tags": ["Browser"],
+        "tags": [
+          "Browser"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -3781,7 +4005,10 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["active", "destroyed"]
+              "enum": [
+                "active",
+                "destroyed"
+              ]
             },
             "description": "Filter sessions by status"
           }
@@ -3807,7 +4034,10 @@
                           },
                           "status": {
                             "type": "string",
-                            "enum": ["active", "destroyed"]
+                            "enum": [
+                              "active",
+                              "destroyed"
+                            ]
                           },
                           "cdpUrl": {
                             "type": "string"
@@ -3861,7 +4091,9 @@
       "post": {
         "summary": "Execute code in a browser session",
         "operationId": "executeBrowserCode",
-        "tags": ["Browser"],
+        "tags": [
+          "Browser"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -3884,7 +4116,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["code"],
+                "required": [
+                  "code"
+                ],
                 "properties": {
                   "code": {
                     "type": "string",
@@ -3894,7 +4128,11 @@
                   },
                   "language": {
                     "type": "string",
-                    "enum": ["python", "node", "bash"],
+                    "enum": [
+                      "python",
+                      "node",
+                      "bash"
+                    ],
                     "default": "node",
                     "description": "Language of the code to execute. Use `node` for JavaScript or `bash` for agent-browser CLI commands."
                   },
@@ -3977,7 +4215,9 @@
       "delete": {
         "summary": "Delete a browser session",
         "operationId": "deleteBrowserSession",
-        "tags": ["Browser"],
+        "tags": [
+          "Browser"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -4030,6 +4270,464 @@
                       "example": "Payment required to access this resource."
                     }
                   }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/scrape/{jobId}": {
+      "parameters": [
+        {
+          "name": "jobId",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "description": "The ID of the job"
+        }
+      ],
+      "get": {
+        "summary": "Get the status of a scrape job",
+        "operationId": "getScrapeStatus",
+        "tags": [
+          "Scraping"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Scrape job status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScrapeResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/{jobId}/feedback": {
+      "parameters": [
+        {
+          "name": "jobId",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "description": "The search job ID"
+        }
+      ],
+      "post": {
+        "summary": "Submit feedback for a search job",
+        "operationId": "submitSearchFeedback",
+        "tags": [
+          "Search"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchFeedbackRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Feedback recorded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchFeedbackResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "details": {}
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "details": {}
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "details": {}
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "details": {}
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "details": {}
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "details": {}
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "details": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/support/ask": {
+      "post": {
+        "summary": "Ask the Firecrawl support agent",
+        "description": "Diagnose Firecrawl job, account, and API usage issues with an AI support agent.",
+        "operationId": "askSupportAgent",
+        "tags": [
+          "Support"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SupportAskRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Support agent answer",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportAskResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportProxyErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid bearer token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportProxyErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Support agent unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportProxyErrorResponse"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "Support agent timeout",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportProxyErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/support/docs-search": {
+      "post": {
+        "summary": "Search Firecrawl docs with citations",
+        "description": "Answer Firecrawl documentation questions using the public docs corpus.",
+        "operationId": "searchSupportDocs",
+        "tags": [
+          "Support"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SupportDocsSearchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Docs-grounded answer",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportDocsSearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportProxyErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid bearer token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportProxyErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Support agent unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportProxyErrorResponse"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "Support agent timeout",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportProxyErrorResponse"
                 }
               }
             }
@@ -4115,11 +4813,16 @@
             "description": "Monitor webhook events to receive. Defaults to all monitor events.",
             "items": {
               "type": "string",
-              "enum": ["monitor.page", "monitor.check.completed"]
+              "enum": [
+                "monitor.page",
+                "monitor.check.completed"
+              ]
             }
           }
         },
-        "required": ["url"]
+        "required": [
+          "url"
+        ]
       },
       "MonitorNotification": {
         "type": "object",
@@ -4161,7 +4864,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["scrape"]
+                "enum": [
+                  "scrape"
+                ]
               },
               "urls": {
                 "type": "array",
@@ -4175,7 +4880,10 @@
                 "$ref": "#/components/schemas/ScrapeOptions"
               }
             },
-            "required": ["type", "urls"]
+            "required": [
+              "type",
+              "urls"
+            ]
           },
           {
             "type": "object",
@@ -4188,7 +4896,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["crawl"]
+                "enum": [
+                  "crawl"
+                ]
               },
               "url": {
                 "type": "string",
@@ -4202,7 +4912,10 @@
                 "$ref": "#/components/schemas/ScrapeOptions"
               }
             },
-            "required": ["type", "url"]
+            "required": [
+              "type",
+              "url"
+            ]
           }
         ]
       },
@@ -4247,7 +4960,11 @@
             "description": "Whether to judge changed pages against `goal`. Requires a non-empty `goal` to run."
           }
         },
-        "required": ["name", "schedule", "targets"]
+        "required": [
+          "name",
+          "schedule",
+          "targets"
+        ]
       },
       "MonitorUpdateRequest": {
         "type": "object",
@@ -4291,37 +5008,80 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "paused"]
+            "enum": [
+              "active",
+              "paused"
+            ]
           }
         }
       },
       "MonitorSummary": {
         "type": "object",
         "properties": {
-          "totalPages": { "type": "integer" },
-          "same": { "type": "integer" },
-          "changed": { "type": "integer" },
-          "new": { "type": "integer" },
-          "removed": { "type": "integer" },
-          "error": { "type": "integer" }
+          "totalPages": {
+            "type": "integer"
+          },
+          "same": {
+            "type": "integer"
+          },
+          "changed": {
+            "type": "integer"
+          },
+          "new": {
+            "type": "integer"
+          },
+          "removed": {
+            "type": "integer"
+          },
+          "error": {
+            "type": "integer"
+          }
         }
       },
       "Monitor": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "name": { "type": "string" },
-          "status": { "type": "string", "enum": ["active", "paused", "deleted"] },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "paused",
+              "deleted"
+            ]
+          },
           "schedule": {
             "type": "object",
             "properties": {
-              "cron": { "type": "string" },
-              "timezone": { "type": "string" }
+              "cron": {
+                "type": "string"
+              },
+              "timezone": {
+                "type": "string"
+              }
             }
           },
-          "nextRunAt": { "type": "string", "format": "date-time", "nullable": true },
-          "lastRunAt": { "type": "string", "format": "date-time", "nullable": true },
-          "currentCheckId": { "type": "string", "format": "uuid", "nullable": true },
+          "nextRunAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastRunAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "currentCheckId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
           "targets": {
             "type": "array",
             "items": {
@@ -4334,7 +5094,9 @@
           "notification": {
             "$ref": "#/components/schemas/MonitorNotification"
           },
-          "retentionDays": { "type": "integer" },
+          "retentionDays": {
+            "type": "integer"
+          },
           "estimatedCreditsPerMonth": {
             "type": "integer",
             "nullable": true,
@@ -4343,57 +5105,155 @@
           "lastCheckSummary": {
             "$ref": "#/components/schemas/MonitorSummary"
           },
-          "goal": { "type": "string", "nullable": true },
-          "judgeEnabled": { "type": "boolean" },
-          "createdAt": { "type": "string", "format": "date-time" },
-          "updatedAt": { "type": "string", "format": "date-time" }
+          "goal": {
+            "type": "string",
+            "nullable": true
+          },
+          "judgeEnabled": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "MonitorCheck": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "monitorId": { "type": "string", "format": "uuid" },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "monitorId": {
+            "type": "string",
+            "format": "uuid"
+          },
           "status": {
             "type": "string",
-            "enum": ["queued", "running", "completed", "failed", "partial", "skipped_overlap"]
+            "enum": [
+              "queued",
+              "running",
+              "completed",
+              "failed",
+              "partial",
+              "skipped_overlap"
+            ]
           },
-          "trigger": { "type": "string", "enum": ["scheduled", "manual"] },
-          "scheduledFor": { "type": "string", "format": "date-time", "nullable": true },
-          "startedAt": { "type": "string", "format": "date-time", "nullable": true },
-          "finishedAt": { "type": "string", "format": "date-time", "nullable": true },
+          "trigger": {
+            "type": "string",
+            "enum": [
+              "scheduled",
+              "manual"
+            ]
+          },
+          "scheduledFor": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "startedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "finishedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
           "estimatedCredits": {
             "type": "integer",
             "nullable": true,
             "description": "Upper-bound credits reserved for this check before Firecrawl knows how many pages changed and require judging."
           },
-          "reservedCredits": { "type": "integer", "nullable": true },
+          "reservedCredits": {
+            "type": "integer",
+            "nullable": true
+          },
           "actualCredits": {
             "type": "integer",
             "nullable": true,
             "description": "Final credits charged for this check after scrapes, crawls, and any changed-page judge calls complete."
           },
-          "billingStatus": { "type": "string" },
-          "summary": { "$ref": "#/components/schemas/MonitorSummary" },
-          "targetResults": { "type": "array", "nullable": true },
-          "notificationStatus": { "type": "object", "nullable": true },
-          "error": { "type": "string", "nullable": true },
-          "createdAt": { "type": "string", "format": "date-time" },
-          "updatedAt": { "type": "string", "format": "date-time" }
+          "billingStatus": {
+            "type": "string"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/MonitorSummary"
+          },
+          "targetResults": {
+            "type": "array",
+            "nullable": true
+          },
+          "notificationStatus": {
+            "type": "object",
+            "nullable": true
+          },
+          "error": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "MonitorCheckPage": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "targetId": { "type": "string" },
-          "url": { "type": "string", "format": "uri" },
-          "status": { "type": "string", "enum": ["same", "new", "changed", "removed", "error"] },
-          "previousScrapeId": { "type": "string", "format": "uuid", "nullable": true },
-          "currentScrapeId": { "type": "string", "format": "uuid", "nullable": true },
-          "statusCode": { "type": "integer", "nullable": true },
-          "error": { "type": "string", "nullable": true },
-          "metadata": { "type": "object", "nullable": true },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "targetId": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "same",
+              "new",
+              "changed",
+              "removed",
+              "error"
+            ]
+          },
+          "previousScrapeId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "currentScrapeId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "statusCode": {
+            "type": "integer",
+            "nullable": true
+          },
+          "error": {
+            "type": "string",
+            "nullable": true
+          },
+          "metadata": {
+            "type": "object",
+            "nullable": true
+          },
           "judgment": {
             "$ref": "#/components/schemas/MonitorPageJudgment"
           },
@@ -4423,7 +5283,10 @@
               }
             }
           },
-          "createdAt": { "type": "string", "format": "date-time" }
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "MonitorPageJudgment": {
@@ -4436,7 +5299,11 @@
           },
           "confidence": {
             "type": "string",
-            "enum": ["high", "medium", "low"]
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ]
           },
           "reason": {
             "type": "string"
@@ -4449,7 +5316,11 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["added", "removed", "changed"]
+                  "enum": [
+                    "added",
+                    "removed",
+                    "changed"
+                  ]
                 },
                 "before": {
                   "type": "string",
@@ -4470,42 +5341,63 @@
       "MonitorResponse": {
         "type": "object",
         "properties": {
-          "success": { "type": "boolean" },
-          "data": { "$ref": "#/components/schemas/Monitor" }
+          "success": {
+            "type": "boolean"
+          },
+          "data": {
+            "$ref": "#/components/schemas/Monitor"
+          }
         }
       },
       "MonitorListResponse": {
         "type": "object",
         "properties": {
-          "success": { "type": "boolean" },
+          "success": {
+            "type": "boolean"
+          },
           "data": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Monitor" }
+            "items": {
+              "$ref": "#/components/schemas/Monitor"
+            }
           }
         }
       },
       "MonitorRunResponse": {
         "type": "object",
         "properties": {
-          "success": { "type": "boolean" },
-          "id": { "type": "string", "format": "uuid" },
-          "data": { "$ref": "#/components/schemas/MonitorCheck" }
+          "success": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "data": {
+            "$ref": "#/components/schemas/MonitorCheck"
+          }
         }
       },
       "MonitorCheckListResponse": {
         "type": "object",
         "properties": {
-          "success": { "type": "boolean" },
+          "success": {
+            "type": "boolean"
+          },
           "data": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/MonitorCheck" }
+            "items": {
+              "$ref": "#/components/schemas/MonitorCheck"
+            }
           }
         }
       },
       "MonitorCheckDetailResponse": {
         "type": "object",
         "properties": {
-          "success": { "type": "boolean" },
+          "success": {
+            "type": "boolean"
+          },
           "next": {
             "type": "string",
             "nullable": true,
@@ -4513,13 +5405,17 @@
           },
           "data": {
             "allOf": [
-              { "$ref": "#/components/schemas/MonitorCheck" },
+              {
+                "$ref": "#/components/schemas/MonitorCheck"
+              },
               {
                 "type": "object",
                 "properties": {
                   "pages": {
                     "type": "array",
-                    "items": { "$ref": "#/components/schemas/MonitorCheckPage" }
+                    "items": {
+                      "$ref": "#/components/schemas/MonitorCheckPage"
+                    }
                   },
                   "next": {
                     "type": "string",
@@ -4542,10 +5438,14 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["markdown"]
+                  "enum": [
+                    "markdown"
+                  ]
                 }
               },
-              "required": ["type"]
+              "required": [
+                "type"
+              ]
             },
             {
               "type": "object",
@@ -4553,10 +5453,14 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["summary"]
+                  "enum": [
+                    "summary"
+                  ]
                 }
               },
-              "required": ["type"]
+              "required": [
+                "type"
+              ]
             },
             {
               "type": "object",
@@ -4564,10 +5468,14 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["html"]
+                  "enum": [
+                    "html"
+                  ]
                 }
               },
-              "required": ["type"]
+              "required": [
+                "type"
+              ]
             },
             {
               "type": "object",
@@ -4575,10 +5483,14 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["rawHtml"]
+                  "enum": [
+                    "rawHtml"
+                  ]
                 }
               },
-              "required": ["type"]
+              "required": [
+                "type"
+              ]
             },
             {
               "type": "object",
@@ -4586,10 +5498,14 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["links"]
+                  "enum": [
+                    "links"
+                  ]
                 }
               },
-              "required": ["type"]
+              "required": [
+                "type"
+              ]
             },
             {
               "type": "object",
@@ -4597,10 +5513,14 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["images"]
+                  "enum": [
+                    "images"
+                  ]
                 }
               },
-              "required": ["type"]
+              "required": [
+                "type"
+              ]
             },
             {
               "type": "object",
@@ -4608,7 +5528,9 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["screenshot"]
+                  "enum": [
+                    "screenshot"
+                  ]
                 },
                 "fullPage": {
                   "type": "boolean",
@@ -4631,10 +5553,15 @@
                       "description": "The height of the viewport in pixels"
                     }
                   },
-                  "required": ["width", "height"]
+                  "required": [
+                    "width",
+                    "height"
+                  ]
                 }
               },
-              "required": ["type"]
+              "required": [
+                "type"
+              ]
             },
             {
               "type": "object",
@@ -4642,7 +5569,9 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["json"]
+                  "enum": [
+                    "json"
+                  ]
                 },
                 "schema": {
                   "type": "object",
@@ -4653,7 +5582,9 @@
                   "description": "The prompt to use for the JSON output"
                 }
               },
-              "required": ["type"]
+              "required": [
+                "type"
+              ]
             },
             {
               "type": "object",
@@ -4661,13 +5592,18 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["changeTracking"]
+                  "enum": [
+                    "changeTracking"
+                  ]
                 },
                 "modes": {
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "enum": ["git-diff", "json"]
+                    "enum": [
+                      "git-diff",
+                      "json"
+                    ]
                   },
                   "description": "The mode to use for change tracking. 'git-diff' provides a detailed diff, and 'json' compares extracted JSON data."
                 },
@@ -4686,7 +5622,9 @@
                   "description": "Tag to use for change tracking. Tags can separate change tracking history into separate \"branches\", where change tracking with a specific tagwill only compare to scrapes made in the same tag. If not provided, the default tag (null) will be used."
                 }
               },
-              "required": ["type"]
+              "required": [
+                "type"
+              ]
             },
             {
               "type": "object",
@@ -4694,10 +5632,14 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["branding"]
+                  "enum": [
+                    "branding"
+                  ]
                 }
               },
-              "required": ["type"]
+              "required": [
+                "type"
+              ]
             },
             {
               "type": "object",
@@ -4706,10 +5648,14 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["audio"]
+                  "enum": [
+                    "audio"
+                  ]
                 }
               },
-              "required": ["type"]
+              "required": [
+                "type"
+              ]
             },
             {
               "type": "object",
@@ -4718,10 +5664,14 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["video"]
+                  "enum": [
+                    "video"
+                  ]
                 }
               },
-              "required": ["type"]
+              "required": [
+                "type"
+              ]
             },
             {
               "type": "object",
@@ -4730,7 +5680,9 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["question"]
+                  "enum": [
+                    "question"
+                  ]
                 },
                 "question": {
                   "type": "string",
@@ -4738,7 +5690,10 @@
                   "description": "The question to answer about the page. Maximum 10,000 characters."
                 }
               },
-              "required": ["type", "question"]
+              "required": [
+                "type",
+                "question"
+              ]
             },
             {
               "type": "object",
@@ -4747,7 +5702,9 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["highlights"]
+                  "enum": [
+                    "highlights"
+                  ]
                 },
                 "query": {
                   "type": "string",
@@ -4755,12 +5712,17 @@
                   "description": "The text-selection query to run against the page. Maximum 10,000 characters."
                 }
               },
-              "required": ["type", "query"]
+              "required": [
+                "type",
+                "query"
+              ]
             }
           ]
         },
         "description": "Output formats to include in the response. You can specify one or more formats, either as strings (e.g., `'markdown'`) or as objects with additional options (e.g., `{ type: 'json', schema: {...} }`). Some formats require specific options to be set. Example: `['markdown', { type: 'json', schema: {...} }]`.",
-        "default": ["markdown"]
+        "default": [
+          "markdown"
+        ]
       },
       "ParseFormats": {
         "type": "array",
@@ -4772,10 +5734,14 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["markdown"]
+                  "enum": [
+                    "markdown"
+                  ]
                 }
               },
-              "required": ["type"]
+              "required": [
+                "type"
+              ]
             },
             {
               "type": "object",
@@ -4783,10 +5749,14 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["summary"]
+                  "enum": [
+                    "summary"
+                  ]
                 }
               },
-              "required": ["type"]
+              "required": [
+                "type"
+              ]
             },
             {
               "type": "object",
@@ -4794,10 +5764,14 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["html"]
+                  "enum": [
+                    "html"
+                  ]
                 }
               },
-              "required": ["type"]
+              "required": [
+                "type"
+              ]
             },
             {
               "type": "object",
@@ -4805,10 +5779,14 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["rawHtml"]
+                  "enum": [
+                    "rawHtml"
+                  ]
                 }
               },
-              "required": ["type"]
+              "required": [
+                "type"
+              ]
             },
             {
               "type": "object",
@@ -4816,10 +5794,14 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["links"]
+                  "enum": [
+                    "links"
+                  ]
                 }
               },
-              "required": ["type"]
+              "required": [
+                "type"
+              ]
             },
             {
               "type": "object",
@@ -4827,10 +5809,14 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["images"]
+                  "enum": [
+                    "images"
+                  ]
                 }
               },
-              "required": ["type"]
+              "required": [
+                "type"
+              ]
             },
             {
               "type": "object",
@@ -4838,7 +5824,9 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["json"]
+                  "enum": [
+                    "json"
+                  ]
                 },
                 "schema": {
                   "type": "object",
@@ -4849,12 +5837,16 @@
                   "description": "The prompt to use for the JSON output"
                 }
               },
-              "required": ["type"]
+              "required": [
+                "type"
+              ]
             }
           ]
         },
         "description": "Output formats supported for `/parse` uploads. Browser-rendering formats and change tracking are not supported.",
-        "default": ["markdown"]
+        "default": [
+          "markdown"
+        ]
       },
       "ParseOptions": {
         "type": "object",
@@ -4902,11 +5894,17 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["pdf"]
+                      "enum": [
+                        "pdf"
+                      ]
                     },
                     "mode": {
                       "type": "string",
-                      "enum": ["fast", "auto", "ocr"],
+                      "enum": [
+                        "fast",
+                        "auto",
+                        "ocr"
+                      ],
                       "default": "auto",
                       "description": "PDF parsing mode. \"fast\": text-only extraction. \"auto\": text-first with OCR fallback. \"ocr\": OCR on every page."
                     },
@@ -4917,12 +5915,16 @@
                       "description": "Maximum number of pages to parse from the PDF."
                     }
                   },
-                  "required": ["type"],
+                  "required": [
+                    "type"
+                  ],
                   "additionalProperties": false
                 }
               ]
             },
-            "default": ["pdf"]
+            "default": [
+              "pdf"
+            ]
           },
           "skipTlsVerification": {
             "type": "boolean",
@@ -4941,7 +5943,10 @@
           },
           "proxy": {
             "type": "string",
-            "enum": ["basic", "auto"],
+            "enum": [
+              "basic",
+              "auto"
+            ],
             "description": "Proxy mode for parse uploads. `/parse` supports only `basic` and `auto`."
           },
           "origin": {
@@ -5036,11 +6041,17 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["pdf"]
+                      "enum": [
+                        "pdf"
+                      ]
                     },
                     "mode": {
                       "type": "string",
-                      "enum": ["fast", "auto", "ocr"],
+                      "enum": [
+                        "fast",
+                        "auto",
+                        "ocr"
+                      ],
                       "default": "auto",
                       "description": "PDF parsing mode. \"fast\": text-based extraction only (embedded text, fastest). \"auto\" (default): attempts fast extraction first, falls back to OCR if needed. \"ocr\": forces OCR parsing on every page."
                     },
@@ -5051,12 +6062,16 @@
                       "description": "Maximum number of pages to parse from the PDF. Must be a positive integer up to 10000."
                     }
                   },
-                  "required": ["type"],
+                  "required": [
+                    "type"
+                  ],
                   "additionalProperties": false
                 }
               ]
             },
-            "default": ["pdf"]
+            "default": [
+              "pdf"
+            ]
           },
           "actions": {
             "type": "array",
@@ -5072,7 +6087,9 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": ["wait"],
+                          "enum": [
+                            "wait"
+                          ],
                           "description": "Wait for a specified amount of milliseconds"
                         },
                         "milliseconds": {
@@ -5081,7 +6098,10 @@
                           "description": "Number of milliseconds to wait"
                         }
                       },
-                      "required": ["type", "milliseconds"],
+                      "required": [
+                        "type",
+                        "milliseconds"
+                      ],
                       "additionalProperties": false
                     },
                     {
@@ -5090,7 +6110,9 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": ["wait"],
+                          "enum": [
+                            "wait"
+                          ],
                           "description": "Wait for a specific element to appear"
                         },
                         "selector": {
@@ -5099,7 +6121,10 @@
                           "example": "#my-element"
                         }
                       },
-                      "required": ["type", "selector"],
+                      "required": [
+                        "type",
+                        "selector"
+                      ],
                       "additionalProperties": false
                     }
                   ]
@@ -5110,7 +6135,9 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["screenshot"],
+                      "enum": [
+                        "screenshot"
+                      ],
                       "description": "Take a screenshot. The links will be in the response's `actions.screenshots` array."
                     },
                     "fullPage": {
@@ -5134,10 +6161,15 @@
                           "description": "The height of the viewport in pixels"
                         }
                       },
-                      "required": ["width", "height"]
+                      "required": [
+                        "width",
+                        "height"
+                      ]
                     }
                   },
-                  "required": ["type"]
+                  "required": [
+                    "type"
+                  ]
                 },
                 {
                   "type": "object",
@@ -5145,7 +6177,9 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["click"],
+                      "enum": [
+                        "click"
+                      ],
                       "description": "Click on an element"
                     },
                     "selector": {
@@ -5159,7 +6193,10 @@
                       "default": false
                     }
                   },
-                  "required": ["type", "selector"]
+                  "required": [
+                    "type",
+                    "selector"
+                  ]
                 },
                 {
                   "type": "object",
@@ -5167,7 +6204,9 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["write"],
+                      "enum": [
+                        "write"
+                      ],
                       "description": "Write text into an input field, text area, or contenteditable element. Note: You must first focus the element using a 'click' action before writing. The text will be typed character by character to simulate keyboard input."
                     },
                     "text": {
@@ -5176,7 +6215,10 @@
                       "example": "Hello, world!"
                     }
                   },
-                  "required": ["type", "text"]
+                  "required": [
+                    "type",
+                    "text"
+                  ]
                 },
                 {
                   "type": "object",
@@ -5185,7 +6227,9 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["press"],
+                      "enum": [
+                        "press"
+                      ],
                       "description": "Press a key on the page"
                     },
                     "key": {
@@ -5194,7 +6238,10 @@
                       "example": "Enter"
                     }
                   },
-                  "required": ["type", "key"]
+                  "required": [
+                    "type",
+                    "key"
+                  ]
                 },
                 {
                   "type": "object",
@@ -5202,12 +6249,17 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["scroll"],
+                      "enum": [
+                        "scroll"
+                      ],
                       "description": "Scroll the page or a specific element"
                     },
                     "direction": {
                       "type": "string",
-                      "enum": ["up", "down"],
+                      "enum": [
+                        "up",
+                        "down"
+                      ],
                       "description": "Direction to scroll",
                       "default": "down"
                     },
@@ -5217,7 +6269,9 @@
                       "example": "#my-element"
                     }
                   },
-                  "required": ["type"]
+                  "required": [
+                    "type"
+                  ]
                 },
                 {
                   "type": "object",
@@ -5225,11 +6279,15 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["scrape"],
+                      "enum": [
+                        "scrape"
+                      ],
                       "description": "Scrape the current page content, returns the url and the html."
                     }
                   },
-                  "required": ["type"]
+                  "required": [
+                    "type"
+                  ]
                 },
                 {
                   "type": "object",
@@ -5237,7 +6295,9 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["executeJavascript"],
+                      "enum": [
+                        "executeJavascript"
+                      ],
                       "description": "Execute JavaScript code on the page"
                     },
                     "script": {
@@ -5246,7 +6306,10 @@
                       "example": "document.querySelector('.button').click();"
                     }
                   },
-                  "required": ["type", "script"]
+                  "required": [
+                    "type",
+                    "script"
+                  ]
                 },
                 {
                   "type": "object",
@@ -5254,7 +6317,9 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["pdf"],
+                      "enum": [
+                        "pdf"
+                      ],
                       "description": "Generate a PDF of the current page. The PDF will be returned in the `actions.pdfs` array of the response."
                     },
                     "format": {
@@ -5286,7 +6351,9 @@
                       "default": 1
                     }
                   },
-                  "required": ["type"]
+                  "required": [
+                    "type"
+                  ]
                 }
               ]
             }
@@ -5323,7 +6390,11 @@
           },
           "proxy": {
             "type": "string",
-            "enum": ["basic", "enhanced", "auto"],
+            "enum": [
+              "basic",
+              "enhanced",
+              "auto"
+            ],
             "description": "Specifies the type of proxy to use.\n\n - **basic**: Proxies for scraping sites with none to basic anti-bot solutions. Fast and usually works.\n - **enhanced**: Enhanced proxies for scraping sites with advanced anti-bot solutions. Slower, but more reliable on certain sites. Costs up to 5 credits per request.\n - **auto**: Firecrawl will automatically retry scraping with enhanced proxies if the basic proxy fails. If the retry with enhanced is successful, 5 credits will be billed for the scrape. If the first attempt with basic is successful, only the regular cost will be billed.",
             "default": "auto"
           },
@@ -5353,7 +6424,9 @@
                 "description": "When true, browser state is saved back to the profile when the interact session stops. Set to false to load existing data without writing. Only one saving session is allowed at a time."
               }
             },
-            "required": ["name"]
+            "required": [
+              "name"
+            ]
           }
         }
       },
@@ -5598,12 +6671,20 @@
                   },
                   "changeStatus": {
                     "type": "string",
-                    "enum": ["new", "same", "changed", "removed"],
+                    "enum": [
+                      "new",
+                      "same",
+                      "changed",
+                      "removed"
+                    ],
                     "description": "The result of the comparison between the two page versions. 'new' means this page did not exist before, 'same' means content has not changed, 'changed' means content has changed, 'removed' means the page was removed."
                   },
                   "visibility": {
                     "type": "string",
-                    "enum": ["visible", "hidden"],
+                    "enum": [
+                      "visible",
+                      "hidden"
+                    ],
                     "description": "The visibility of the current page/URL. 'visible' means the URL was discovered through an organic route (links or sitemap), 'hidden' means the URL was discovered through memory from previous crawls."
                   },
                   "diff": {
@@ -5625,7 +6706,10 @@
                 "properties": {
                   "colorScheme": {
                     "type": "string",
-                    "enum": ["light", "dark"],
+                    "enum": [
+                      "light",
+                      "dark"
+                    ],
                     "description": "The detected color scheme of the page."
                   },
                   "logo": {
@@ -5638,16 +6722,46 @@
                     "nullable": true,
                     "description": "Brand colors extracted from the page.",
                     "properties": {
-                      "primary": { "type": "string", "description": "Primary brand color (hex)." },
-                      "secondary": { "type": "string", "description": "Secondary brand color (hex)." },
-                      "accent": { "type": "string", "description": "Accent color (hex)." },
-                      "background": { "type": "string", "description": "Background color (hex)." },
-                      "textPrimary": { "type": "string", "description": "Primary text color (hex)." },
-                      "textSecondary": { "type": "string", "description": "Secondary text color (hex)." },
-                      "link": { "type": "string", "description": "Link color (hex)." },
-                      "success": { "type": "string", "description": "Success/positive color (hex)." },
-                      "warning": { "type": "string", "description": "Warning color (hex)." },
-                      "error": { "type": "string", "description": "Error/danger color (hex)." }
+                      "primary": {
+                        "type": "string",
+                        "description": "Primary brand color (hex)."
+                      },
+                      "secondary": {
+                        "type": "string",
+                        "description": "Secondary brand color (hex)."
+                      },
+                      "accent": {
+                        "type": "string",
+                        "description": "Accent color (hex)."
+                      },
+                      "background": {
+                        "type": "string",
+                        "description": "Background color (hex)."
+                      },
+                      "textPrimary": {
+                        "type": "string",
+                        "description": "Primary text color (hex)."
+                      },
+                      "textSecondary": {
+                        "type": "string",
+                        "description": "Secondary text color (hex)."
+                      },
+                      "link": {
+                        "type": "string",
+                        "description": "Link color (hex)."
+                      },
+                      "success": {
+                        "type": "string",
+                        "description": "Success/positive color (hex)."
+                      },
+                      "warning": {
+                        "type": "string",
+                        "description": "Warning color (hex)."
+                      },
+                      "error": {
+                        "type": "string",
+                        "description": "Error/danger color (hex)."
+                      }
                     }
                   },
                   "fonts": {
@@ -5657,7 +6771,10 @@
                     "items": {
                       "type": "object",
                       "properties": {
-                        "family": { "type": "string", "description": "Font family name." }
+                        "family": {
+                          "type": "string",
+                          "description": "Font family name."
+                        }
                       }
                     }
                   },
@@ -5670,37 +6787,66 @@
                         "type": "object",
                         "description": "Font families by role.",
                         "properties": {
-                          "primary": { "type": "string", "description": "Primary font family." },
-                          "heading": { "type": "string", "description": "Heading font family." },
-                          "code": { "type": "string", "description": "Code/monospace font family." }
+                          "primary": {
+                            "type": "string",
+                            "description": "Primary font family."
+                          },
+                          "heading": {
+                            "type": "string",
+                            "description": "Heading font family."
+                          },
+                          "code": {
+                            "type": "string",
+                            "description": "Code/monospace font family."
+                          }
                         }
                       },
                       "fontSizes": {
                         "type": "object",
                         "description": "Font sizes for different text levels.",
                         "properties": {
-                          "h1": { "type": "string" },
-                          "h2": { "type": "string" },
-                          "h3": { "type": "string" },
-                          "body": { "type": "string" }
+                          "h1": {
+                            "type": "string"
+                          },
+                          "h2": {
+                            "type": "string"
+                          },
+                          "h3": {
+                            "type": "string"
+                          },
+                          "body": {
+                            "type": "string"
+                          }
                         }
                       },
                       "fontWeights": {
                         "type": "object",
                         "description": "Font weight definitions.",
                         "properties": {
-                          "light": { "type": "integer" },
-                          "regular": { "type": "integer" },
-                          "medium": { "type": "integer" },
-                          "bold": { "type": "integer" }
+                          "light": {
+                            "type": "integer"
+                          },
+                          "regular": {
+                            "type": "integer"
+                          },
+                          "medium": {
+                            "type": "integer"
+                          },
+                          "bold": {
+                            "type": "integer"
+                          }
                         }
                       },
                       "lineHeights": {
                         "type": "object",
                         "description": "Line height values for different text types.",
                         "properties": {
-                          "heading": { "type": "string" },
-                          "body": { "type": "string" }
+                          "heading": {
+                            "type": "string"
+                          },
+                          "body": {
+                            "type": "string"
+                          }
                         }
                       }
                     }
@@ -5710,10 +6856,22 @@
                     "nullable": true,
                     "description": "Spacing and layout information.",
                     "properties": {
-                      "baseUnit": { "type": "integer", "description": "Base spacing unit in pixels." },
-                      "borderRadius": { "type": "string", "description": "Default border radius." },
-                      "padding": { "type": "object", "description": "Padding values." },
-                      "margins": { "type": "object", "description": "Margin values." }
+                      "baseUnit": {
+                        "type": "integer",
+                        "description": "Base spacing unit in pixels."
+                      },
+                      "borderRadius": {
+                        "type": "string",
+                        "description": "Default border radius."
+                      },
+                      "padding": {
+                        "type": "object",
+                        "description": "Padding values."
+                      },
+                      "margins": {
+                        "type": "object",
+                        "description": "Margin values."
+                      }
                     }
                   },
                   "components": {
@@ -5725,19 +6883,33 @@
                         "type": "object",
                         "description": "Primary button styles.",
                         "properties": {
-                          "background": { "type": "string" },
-                          "textColor": { "type": "string" },
-                          "borderRadius": { "type": "string" }
+                          "background": {
+                            "type": "string"
+                          },
+                          "textColor": {
+                            "type": "string"
+                          },
+                          "borderRadius": {
+                            "type": "string"
+                          }
                         }
                       },
                       "buttonSecondary": {
                         "type": "object",
                         "description": "Secondary button styles.",
                         "properties": {
-                          "background": { "type": "string" },
-                          "textColor": { "type": "string" },
-                          "borderColor": { "type": "string" },
-                          "borderRadius": { "type": "string" }
+                          "background": {
+                            "type": "string"
+                          },
+                          "textColor": {
+                            "type": "string"
+                          },
+                          "borderColor": {
+                            "type": "string"
+                          },
+                          "borderRadius": {
+                            "type": "string"
+                          }
                         }
                       },
                       "input": {
@@ -5756,9 +6928,18 @@
                     "nullable": true,
                     "description": "Brand images.",
                     "properties": {
-                      "logo": { "type": "string", "description": "Logo image URL." },
-                      "favicon": { "type": "string", "description": "Favicon URL." },
-                      "ogImage": { "type": "string", "description": "Open Graph image URL." }
+                      "logo": {
+                        "type": "string",
+                        "description": "Logo image URL."
+                      },
+                      "favicon": {
+                        "type": "string",
+                        "description": "Favicon URL."
+                      },
+                      "ogImage": {
+                        "type": "string",
+                        "description": "Open Graph image URL."
+                      }
                     }
                   },
                   "animations": {
@@ -6209,7 +7390,9 @@
                   "description": "A description of the page, if available."
                 }
               },
-              "required": ["url"]
+              "required": [
+                "url"
+              ]
             }
           }
         }
@@ -6244,7 +7427,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["completed", "processing", "failed", "cancelled"],
+            "enum": [
+              "completed",
+              "processing",
+              "failed",
+              "cancelled"
+            ],
             "description": "The current status of the extract job"
           },
           "expiresAt": {
@@ -6254,6 +7442,241 @@
           "tokensUsed": {
             "type": "integer",
             "description": "The number of tokens used by the extract job. Only available if the job is completed."
+          }
+        }
+      },
+      "SearchFeedbackRequest": {
+        "type": "object",
+        "properties": {
+          "rating": {
+            "type": "string",
+            "enum": [
+              "good",
+              "bad",
+              "partial"
+            ]
+          },
+          "valuableSources": {
+            "type": "array",
+            "maxItems": 50,
+            "items": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "reason": {
+                  "type": "string",
+                  "maxLength": 1000
+                }
+              },
+              "required": [
+                "url"
+              ]
+            }
+          },
+          "missingContent": {
+            "type": "array",
+            "maxItems": 20,
+            "items": {
+              "type": "object",
+              "properties": {
+                "topic": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 200
+                },
+                "description": {
+                  "type": "string",
+                  "maxLength": 2000
+                }
+              },
+              "required": [
+                "topic"
+              ]
+            }
+          },
+          "querySuggestions": {
+            "type": "string",
+            "maxLength": 2000
+          },
+          "origin": {
+            "type": "string",
+            "default": "api"
+          },
+          "integration": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "rating"
+        ],
+        "description": "Substantive feedback is required by rating: good requires valuableSources; partial requires valuableSources or missingContent; bad requires missingContent or querySuggestions."
+      },
+      "SearchFeedbackResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "feedbackId": {
+            "type": "string"
+          },
+          "creditsRefunded": {
+            "type": "number"
+          },
+          "alreadySubmitted": {
+            "type": "boolean"
+          },
+          "dailyCapReached": {
+            "type": "boolean"
+          },
+          "creditsRefundedToday": {
+            "type": "number"
+          },
+          "dailyRefundCap": {
+            "type": "number"
+          },
+          "warning": {
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          },
+          "feedbackErrorCode": {
+            "type": "string",
+            "enum": [
+              "SEARCH_NOT_FOUND",
+              "FEEDBACK_WINDOW_EXPIRED",
+              "SEARCH_FAILED",
+              "PREVIEW_TEAM_NOT_ALLOWED",
+              "TEAM_OPTED_OUT",
+              "INVALID_BODY",
+              "DB_DISABLED",
+              "INTERNAL"
+            ]
+          }
+        }
+      },
+      "SupportAskRequest": {
+        "type": "object",
+        "required": [
+          "question"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "question": {
+            "type": "string",
+            "description": "Question or issue for the support agent to diagnose."
+          },
+          "rationale": {
+            "type": "string",
+            "description": "Optional context about what the end user is trying to accomplish."
+          }
+        }
+      },
+      "SupportAskResponse": {
+        "type": "object",
+        "properties": {
+          "answer": {
+            "type": "string",
+            "description": "Diagnosis and recommended fix."
+          },
+          "confidence": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ]
+          },
+          "fixParameters": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true,
+            "description": "Machine-readable API parameters that may fix the issue."
+          },
+          "validation": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true,
+            "description": "Validation result when the support agent tested or attempted a fix."
+          },
+          "feedback": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true,
+            "description": "Present when the support agent is blocked or needs more information."
+          },
+          "durationMs": {
+            "type": "integer",
+            "description": "Total support-agent execution time in milliseconds."
+          }
+        }
+      },
+      "SupportDocsSearchRequest": {
+        "type": "object",
+        "required": [
+          "question"
+        ],
+        "properties": {
+          "question": {
+            "type": "string",
+            "description": "Documentation question to answer."
+          }
+        }
+      },
+      "SupportDocsSearchResponse": {
+        "type": "object",
+        "properties": {
+          "requestId": {
+            "type": "string"
+          },
+          "answer": {
+            "type": "string",
+            "description": "Concise answer grounded in Firecrawl documentation."
+          },
+          "evidence": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "pathOrUrl": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "usage": {
+            "type": "object",
+            "properties": {
+              "inputTokens": {
+                "type": "integer"
+              },
+              "outputTokens": {
+                "type": "integer"
+              },
+              "totalTokens": {
+                "type": "integer"
+              }
+            }
+          },
+          "durationMs": {
+            "type": "integer",
+            "description": "Total docs-search execution time in milliseconds."
+          }
+        }
+      },
+      "SupportProxyErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Support proxy or upstream error code."
           }
         }
       }


### PR DESCRIPTION
## Summary

Adds 4 documented v2 endpoints missing from the docs-hosted OpenAPI contract. Supersedes #1002 which had merge conflicts after main merged monitor docs (#900).

## Why this matters for agents

The spec at `api-reference/v2-openapi.json` is the machine-readable API contract agents fall back to when web tools are unavailable. In our May 27 Sapient trace analysis (510 traces), 8 traces showed agents fetching this spec directly via `curl`. These 4 endpoints were missing, forcing agents needing them to reverse-engineer the API shape from SDK source code.

## What changed

Added 4 paths (31 -> 35):
- `GET /scrape/{jobId}` - scrape job status polling
- `POST /search/{jobId}/feedback` - search quality feedback (refunds 1 credit)
- `POST /support/ask` - support proxy
- `POST /support/docs-search` - docs search proxy

Added 7 schemas: SearchFeedbackRequest/Response, SupportAskRequest/Response, SupportDocsSearchRequest/Response, SupportProxyErrorResponse.

Monitor endpoints are no longer included (already merged via #900).

## What's preserved

All 31 existing paths and 30 existing schemas verified unchanged. Zero paths lost, zero schemas lost. The line-level diff shows reformatting from `json.dump` re-indentation but no structural content changes.

## Validation

- `python3 -m json.tool api-reference/v2-openapi.json` - valid JSON
- 35 paths, 37 schemas, 73 `$ref` entries, 0 unresolved
- Structural diff: 0 missing paths, 0 missing schemas vs main

## Test plan

- [ ] Verify v2-openapi.json parses and renders on docs site
- [ ] Existing endpoint pages still resolve against the spec
