### PR TITLE
Update OpenAPI schemas for schedules and diffs

### DIFF
--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -4078,7 +4078,7 @@
           },
           "text": {
             "type": "string",
-            "description": "Natural language schedule. Supported examples include `every 30 minutes`, `every 15 minutes starting at :07`, `hourly`, `every 2 hours`, `daily`, `daily at 9:00`, and `weekly`.",
+            "description": "Natural language schedule. Supported examples include `every 30 minutes`, `every 15 minutes starting at :07`, `hourly`, `every 2 hours`, `daily`, `daily at 9:00`, `daily at 9am`, `daily at 5:30 PM`, and `weekly`.",
             "example": "every 30 minutes"
           },
           "timezone": {

--- a/api-reference/webhooks-openapi.json
+++ b/api-reference/webhooks-openapi.json
@@ -992,7 +992,14 @@
                       "meaningful": true,
                       "confidence": "high",
                       "reason": "The page headline changed to announce a new release cadence.",
-                      "fields": ["headline"]
+                      "meaningfulChanges": [
+                        {
+                          "type": "changed",
+                          "before": "Welcome to our weekly update.",
+                          "after": "Welcome to our weekly update — now with daily releases!",
+                          "reason": "The headline changed in a way that matches the monitor goal."
+                        }
+                      ]
                     },
                     "diff": {
                       "text": "--- previous\n+++ current\n@@ -1,3 +1,3 @@\n # Latest posts\n-Welcome to our weekly update.\n+Welcome to our weekly update — now with daily releases!\n"
@@ -1253,9 +1260,29 @@
             "enum": ["high", "medium", "low"]
           },
           "reason": { "type": "string" },
-          "fields": {
+          "meaningfulChanges": {
             "type": "array",
-            "items": { "type": "string" }
+            "description": "Goal-relevant changes selected by the judge from the page diff.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["added", "removed", "changed"]
+                },
+                "before": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "after": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "reason": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
v2-openapi.json: Expand the natural-language schedule examples to include variants like "daily at 9am" and "daily at 5:30 PM". webhooks-openapi.json: Replace the previous simple "fields" array with a structured "meaningfulChanges" array of objects (type, before, after, reason), and update the example webhook payload to include a meaningfulChanges entry describing a headline change. This clarifies goal-relevant diff information in the webhook schema.