### PR TITLE
docs(ai-onboarding): simplify get agent credentials

### DIFF
--- a/ai-onboarding.mdx
+++ b/ai-onboarding.mdx
@@ -6,7 +6,7 @@ og:description: "Everything you need to onboard your AI agent to Firecrawl. Skil
 sidebarTitle: "Build with AI"
 ---
 
-If you're developing with AI, Firecrawl offers several resources to improve your experience. Firecrawl ships with **skills** — self-contained knowledge packs that AI coding agents discover and use automatically. One install command gives agents three complete skill segments: CLI skills for live web work, build skills for integrating Firecrawl into application code, and workflow skills for producing repeatable deliverables. How you get a bearer token depends on your setup. See [Get credentials](#get-credentials) below.
+If you're developing with AI, Firecrawl offers several resources to improve your experience. Firecrawl ships with **skills** — self-contained knowledge packs that AI coding agents discover and use automatically. One install command gives agents three complete skill segments: CLI skills for live web work, build skills for integrating Firecrawl into application code, and workflow skills for producing repeatable deliverables. Firecrawl users can get an API key in two ways. See [Get credentials](#get-credentials) below.
 
 - [Get credentials](#get-credentials)
 - [Skills + CLI](#skills-cli)

--- a/ai-onboarding.mdx
+++ b/ai-onboarding.mdx
@@ -202,8 +202,8 @@ All three skill categories use the same install. The difference is what happens 
 
 The full onboarding definitions live at:
 
-- Path A: Human + agent assist (default): [`firecrawl.dev/agent-onboarding/SKILL.md`](https://www.firecrawl.dev/agent-onboarding/SKILL.md)
-- Path B: Machine registration (ID-JAG): [`firecrawl.dev/auth.md`](https://www.firecrawl.dev/auth.md)
+- Browser sign-in, CLI setup, skills, MCP, and dashboard keys: [`firecrawl.dev/agent-onboarding/SKILL.md`](https://www.firecrawl.dev/agent-onboarding/SKILL.md)
+- Agent registration with WorkOS ID-JAG: [`firecrawl.dev/auth.md`](https://www.firecrawl.dev/auth.md)
 
 Agents can fetch either doc directly: use [`agent-onboarding/SKILL.md`](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for human-in-the-loop CLI/browser onboarding, or [`auth.md`](https://www.firecrawl.dev/auth.md) for WorkOS ID-JAG registration.
 
@@ -407,7 +407,7 @@ You can give your agent current Firecrawl docs in a context-aware way. Agents ca
 
 <Steps>
   <Step title="Credential routing">
-    Start at [Get credentials](/ai-onboarding#get-credentials) to choose Path A (default, human + agent assist) or Path B (WorkOS ID-JAG). For ID-JAG registration, follow [`auth.md`](https://www.firecrawl.dev/auth.md).
+    Start at [Get credentials](/ai-onboarding#get-credentials) to choose between dashboard/CLI setup and WorkOS ID-JAG registration. For ID-JAG registration, follow [`auth.md`](https://www.firecrawl.dev/auth.md).
   </Step>
   <Step title="Markdown docs">
     Every page has a markdown version. Append `.md` to any docs URL, or use the page action menu to copy the page as markdown.

--- a/ai-onboarding.mdx
+++ b/ai-onboarding.mdx
@@ -6,7 +6,7 @@ og:description: "Everything you need to onboard your AI agent to Firecrawl. Skil
 sidebarTitle: "Build with AI"
 ---
 
-If you're developing with AI, Firecrawl offers several resources to improve your experience. Firecrawl ships with **skills** — self-contained knowledge packs that AI coding agents discover and use automatically. One install command gives agents three complete skill segments: CLI skills for live web work, build skills for integrating Firecrawl into application code, and workflow skills for producing repeatable deliverables. How you get a bearer token depends on your setup — see [Get credentials](#get-credentials) below.
+If you're developing with AI, Firecrawl offers several resources to improve your experience. Firecrawl ships with **skills** — self-contained knowledge packs that AI coding agents discover and use automatically. One install command gives agents three complete skill segments: CLI skills for live web work, build skills for integrating Firecrawl into application code, and workflow skills for producing repeatable deliverables. How you get a bearer token depends on your setup. See [Get credentials](#get-credentials) below.
 
 - [Get credentials](#get-credentials)
 - [Skills + CLI](#skills-cli)
@@ -20,42 +20,32 @@ If you're developing with AI, Firecrawl offers several resources to improve your
 
 ## Get credentials
 
-This page is a **decision layer** — it routes you to the right credential path. Execution lives in the canonical docs linked below, not here.
-
-Firecrawl supports two credential paths: human-in-the-loop CLI/browser onboarding when a person needs to sign in or create a dashboard API key (Path A, default), and WorkOS ID-JAG registration only when your agent platform can mint an ID-JAG (Path B).
+Firecrawl supports two credential paths. Use Path A by default. Use Path B only if your agent platform can mint a WorkOS ID-JAG for Firecrawl.
 
 **Decision rule:** No ID-JAG or unsure → **Path A (default)**. ID-JAG capable → **Path B**.
 
 **How you might arrive:**
 
-- **API `401`** — an unauthenticated call to `https://api.firecrawl.dev` returns `WWW-Authenticate: Bearer resource_metadata="https://www.firecrawl.dev/.well-known/oauth-protected-resource"`. Follow that discovery chain in [`auth.md`](https://www.firecrawl.dev/auth.md) Step 1. If your platform can complete WorkOS ID-JAG registration → **Path B**. Otherwise → **Path A (default)**. You do not need this page.
-- **Docs** — you landed here. Use the decision rule above.
-- **Direct URL** — if you already have `auth.md` or `SKILL.md`, fetch and follow that doc.
+- **API `401`:** an unauthenticated call to `https://api.firecrawl.dev` returns `WWW-Authenticate: Bearer resource_metadata="https://www.firecrawl.dev/.well-known/oauth-protected-resource"`. Follow that discovery chain in [`auth.md`](https://www.firecrawl.dev/auth.md) Step 1. If your platform can complete WorkOS ID-JAG registration → **Path B**. Otherwise → **Path A (default)**. You do not need this page.
+- **Docs:** you landed here. Use the decision rule above.
+- **Direct URL:** if you already have `auth.md` or `SKILL.md`, fetch and follow that doc.
 
 <CardGroup cols={2}>
   <Card
-    title="Path A — Human + agent assist (default)"
+    title="Path A: Human + agent assist (default)"
     icon="user"
     href="https://www.firecrawl.dev/agent-onboarding/SKILL.md"
   >
-    **Path A (default).** Use when you cannot mint a WorkOS ID-JAG, or you are not sure. Browser sign-in, CLI `--browser`, skills and MCP install, or a human-created API key from the dashboard.
+    **Default.** Use browser sign-in, CLI `--browser`, skills and MCP install, or a dashboard API key when a human is in the loop.
   </Card>
   <Card
-    title="Path B — Agentic registration (WorkOS ID-JAG)"
+    title="Path B: Agentic registration (WorkOS ID-JAG)"
     icon="robot"
-    href="/ai-onboarding/agent-auth"
+    href="https://www.firecrawl.dev/auth.md"
   >
-    **Only if ID-JAG capable.** Your agent platform must be able to mint a WorkOS ID-JAG for `aud=https://api.firecrawl.dev/`. See [Agent Auth](/ai-onboarding/agent-auth), then follow the canonical [`auth.md`](https://www.firecrawl.dev/auth.md) spec.
+    **Only if ID-JAG capable.** Use this when your agent platform can mint a WorkOS ID-JAG for Firecrawl. Follow the [`auth.md`](https://www.firecrawl.dev/auth.md) spec.
   </Card>
 </CardGroup>
-
-<Card
-  title="Get your API key (Path A)"
-  icon="key"
-  href="https://www.firecrawl.dev/app/api-keys"
->
-  Sign up and grab an API key from the dashboard — the default path when you are not using WorkOS ID-JAG registration.
-</Card>
 
 Once you have a bearer token, continue with [Skills + CLI](#skills-cli) below.
 
@@ -212,8 +202,8 @@ All three skill categories use the same install. The difference is what happens 
 
 The full onboarding definitions live at:
 
-- Path A — Human + agent assist (default): [`firecrawl.dev/agent-onboarding/SKILL.md`](https://www.firecrawl.dev/agent-onboarding/SKILL.md)
-- Path B — Machine registration (ID-JAG): [`firecrawl.dev/auth.md`](https://www.firecrawl.dev/auth.md)
+- Path A: Human + agent assist (default): [`firecrawl.dev/agent-onboarding/SKILL.md`](https://www.firecrawl.dev/agent-onboarding/SKILL.md)
+- Path B: Machine registration (ID-JAG): [`firecrawl.dev/auth.md`](https://www.firecrawl.dev/auth.md)
 
 Agents can fetch either doc directly: use [`agent-onboarding/SKILL.md`](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for human-in-the-loop CLI/browser onboarding, or [`auth.md`](https://www.firecrawl.dev/auth.md) for WorkOS ID-JAG registration.
 
@@ -417,7 +407,7 @@ You can give your agent current Firecrawl docs in a context-aware way. Agents ca
 
 <Steps>
   <Step title="Credential routing">
-    Start at [Get credentials](/ai-onboarding#get-credentials) to pick Path A (default, human + agent assist) or Path B (WorkOS ID-JAG). For ID-JAG registration, see [Agent Auth](/ai-onboarding/agent-auth) and the canonical [`auth.md`](https://www.firecrawl.dev/auth.md) spec.
+    Start at [Get credentials](/ai-onboarding#get-credentials) to choose Path A (default, human + agent assist) or Path B (WorkOS ID-JAG). For ID-JAG registration, follow [`auth.md`](https://www.firecrawl.dev/auth.md).
   </Step>
   <Step title="Markdown docs">
     Every page has a markdown version. Append `.md` to any docs URL, or use the page action menu to copy the page as markdown.

--- a/ai-onboarding.mdx
+++ b/ai-onboarding.mdx
@@ -20,7 +20,7 @@ If you're developing with AI, Firecrawl offers several resources to improve your
 
 ## Get credentials
 
-Firecrawl can get a bearer token in two ways. Most users should sign in through the dashboard or CLI. If your agent platform supports WorkOS ID-JAG, it can register directly with Firecrawl.
+Firecrawl users can get an API key in two ways. Most users should sign in through the dashboard or CLI. If your agent platform supports WorkOS ID-JAG, it can register directly with Firecrawl.
 
 **Which should I use?** Use the dashboard or CLI unless you know your platform supports WorkOS ID-JAG.
 
@@ -47,7 +47,7 @@ Firecrawl can get a bearer token in two ways. Most users should sign in through 
   </Card>
 </CardGroup>
 
-Once you have a bearer token, continue with [Skills + CLI](#skills-cli) below.
+Once you have an API key, continue with [Skills + CLI](#skills-cli) below.
 
 ## Skills + CLI
 

--- a/ai-onboarding.mdx
+++ b/ai-onboarding.mdx
@@ -20,7 +20,7 @@ If you're developing with AI, Firecrawl offers several resources to improve your
 
 ## Get credentials
 
-Firecrawl supports two credential paths. Use Path A by default. Use Path B only if your agent platform can mint a WorkOS ID-JAG for Firecrawl.
+Firecrawl supports two credential paths: Path A for human-in-the-loop CLI/browser onboarding or dashboard API keys, and Path B for WorkOS ID-JAG registration when your agent platform can mint one for Firecrawl.
 
 **Decision rule:** No ID-JAG or unsure → **Path A (default)**. ID-JAG capable → **Path B**.
 
@@ -41,9 +41,9 @@ Firecrawl supports two credential paths. Use Path A by default. Use Path B only 
   <Card
     title="Path B: Agentic registration (WorkOS ID-JAG)"
     icon="robot"
-    href="https://www.firecrawl.dev/auth.md"
+    href="/ai-onboarding/agent-auth"
   >
-    **Only if ID-JAG capable.** Use this when your agent platform can mint a WorkOS ID-JAG for Firecrawl. Follow the [`auth.md`](https://www.firecrawl.dev/auth.md) spec.
+    **Only if ID-JAG capable.** Use this when your agent platform can mint a WorkOS ID-JAG for Firecrawl. See [Agent Auth](/ai-onboarding/agent-auth), then follow [`auth.md`](https://www.firecrawl.dev/auth.md).
   </Card>
 </CardGroup>
 

--- a/ai-onboarding.mdx
+++ b/ai-onboarding.mdx
@@ -406,7 +406,7 @@ Or add the local server to any MCP client:
 You can give your agent current Firecrawl docs in a context-aware way. Agents can self-onboard by pulling these resources directly — no human wiring required.
 
 <Steps>
-  <Step title="Credential routing">
+  <Step title="Get credentials">
     Start at [Get credentials](/ai-onboarding#get-credentials) to choose between dashboard/CLI setup and WorkOS ID-JAG registration. For ID-JAG registration, follow [`auth.md`](https://www.firecrawl.dev/auth.md).
   </Step>
   <Step title="Markdown docs">

--- a/ai-onboarding.mdx
+++ b/ai-onboarding.mdx
@@ -20,30 +20,30 @@ If you're developing with AI, Firecrawl offers several resources to improve your
 
 ## Get credentials
 
-Firecrawl supports two credential paths: Path A for human-in-the-loop CLI/browser onboarding or dashboard API keys, and Path B for WorkOS ID-JAG registration when your agent platform can mint one for Firecrawl.
+Firecrawl can get a bearer token in two ways. Most users should sign in through the dashboard or CLI. If your agent platform supports WorkOS ID-JAG, it can register directly with Firecrawl.
 
-**Decision rule:** No ID-JAG or unsure → **Path A (default)**. ID-JAG capable → **Path B**.
+**Which should I use?** Use the dashboard or CLI unless you know your platform supports WorkOS ID-JAG.
 
 **How you might arrive:**
 
-- **API `401`:** an unauthenticated call to `https://api.firecrawl.dev` returns `WWW-Authenticate: Bearer resource_metadata="https://www.firecrawl.dev/.well-known/oauth-protected-resource"`. Follow that discovery chain in [`auth.md`](https://www.firecrawl.dev/auth.md) Step 1. If your platform can complete WorkOS ID-JAG registration → **Path B**. Otherwise → **Path A (default)**. You do not need this page.
-- **Docs:** you landed here. Use the decision rule above.
-- **Direct URL:** if you already have `auth.md` or `SKILL.md`, fetch and follow that doc.
+- **API `401`:** an unauthenticated call to `https://api.firecrawl.dev` returns `WWW-Authenticate: Bearer resource_metadata="https://www.firecrawl.dev/.well-known/oauth-protected-resource"`. ID-JAG capable agents should follow that discovery chain in [`auth.md`](https://www.firecrawl.dev/auth.md) Step 1. Everyone else should use the dashboard or CLI.
+- **Docs:** you landed here. Pick the option below that matches how you can sign in.
+- **Direct URL:** follow [`SKILL.md`](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for browser sign-in and setup, or [`auth.md`](https://www.firecrawl.dev/auth.md) for WorkOS ID-JAG registration.
 
 <CardGroup cols={2}>
   <Card
-    title="Path A: Human + agent assist (default)"
+    title="Use the dashboard or CLI"
     icon="user"
     href="https://www.firecrawl.dev/agent-onboarding/SKILL.md"
   >
-    **Default.** Use browser sign-in, CLI `--browser`, skills and MCP install, or a dashboard API key when a human is in the loop.
+    **Default for most users.** Sign in in the browser, run CLI `--browser`, install skills and MCP, or create an API key in the dashboard.
   </Card>
   <Card
-    title="Path B: Agentic registration (WorkOS ID-JAG)"
+    title="Register with WorkOS ID-JAG"
     icon="robot"
     href="/ai-onboarding/agent-auth"
   >
-    **Only if ID-JAG capable.** Use this when your agent platform can mint a WorkOS ID-JAG for Firecrawl. See [Agent Auth](/ai-onboarding/agent-auth), then follow [`auth.md`](https://www.firecrawl.dev/auth.md).
+    **For supported agent platforms.** Use this when your platform can mint a WorkOS ID-JAG for Firecrawl. Review [Agent Auth](/ai-onboarding/agent-auth), then follow [`auth.md`](https://www.firecrawl.dev/auth.md).
   </Card>
 </CardGroup>
 

--- a/ai-onboarding.mdx
+++ b/ai-onboarding.mdx
@@ -26,8 +26,8 @@ Firecrawl users can get an API key in two ways. Most users should sign in throug
 
 **How you might arrive:**
 
-- **API `401`:** an unauthenticated call to `https://api.firecrawl.dev` returns `WWW-Authenticate: Bearer resource_metadata="https://www.firecrawl.dev/.well-known/oauth-protected-resource"`. ID-JAG capable agents should follow that discovery chain in [`auth.md`](https://www.firecrawl.dev/auth.md) Step 1. Everyone else should use the dashboard or CLI.
 - **Docs:** you landed here. Pick the option below that matches how you can sign in.
+- **API `401`:** ID-JAG capable agents can follow the discovery flow in [`auth.md`](https://www.firecrawl.dev/auth.md) Step 1. Everyone else should use the dashboard or CLI.
 - **Direct URL:** follow [`SKILL.md`](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for browser sign-in and setup, or [`auth.md`](https://www.firecrawl.dev/auth.md) for WorkOS ID-JAG registration.
 
 <CardGroup cols={2}>

--- a/ai-onboarding/agent-auth.mdx
+++ b/ai-onboarding/agent-auth.mdx
@@ -27,7 +27,7 @@ Use this if you cannot mint a WorkOS ID-JAG for Firecrawl, or you are not sure.
 Use this when your agent platform can mint a WorkOS ID-JAG for Firecrawl.
 
 <Card title="Open auth.md" icon="file-lines" href="https://www.firecrawl.dev/auth.md">
-  Machine registration instructions for identity-aware agents. Follow the steps in order.
+  Agent registration instructions for identity-aware agents. Follow the steps in order.
 </Card>
 
 For claim requirements, discovery, registration, limits, and errors, use [`auth.md`](https://www.firecrawl.dev/auth.md).
@@ -38,4 +38,4 @@ Discovery steps live in [`auth.md`](https://www.firecrawl.dev/auth.md) Step 1. I
 
 ## What happens next
 
-Follow [`auth.md`](https://www.firecrawl.dev/auth.md) Steps 1–4: discover → register at `POST /agent/auth` → use the returned API key as a bearer token against `https://api.firecrawl.dev`.
+Follow [`auth.md`](https://www.firecrawl.dev/auth.md) Steps 1–4 to discover the registration flow, register at `POST /agent/auth`, and use the returned API key with the Firecrawl API.

--- a/ai-onboarding/agent-auth.mdx
+++ b/ai-onboarding/agent-auth.mdx
@@ -1,14 +1,14 @@
 ---
 title: Agent Auth (WorkOS ID-JAG)
 sidebarTitle: Agent Auth
-description: "Register a Firecrawl API key via WorkOS ID-JAG agent auth. Discovery, routing, and links to the auth.md spec."
+description: "Register a Firecrawl API key via WorkOS ID-JAG agent auth. Discovery, routing, and links to the canonical auth.md spec."
 og:title: "Agent Auth (WorkOS ID-JAG) | Firecrawl"
 og:description: "Identity-aware agents: discover Firecrawl agent auth metadata and register via POST /agent/auth."
 ---
 
 If you cannot mint a WorkOS ID-JAG, or you are not sure, use human-in-the-loop onboarding via [`SKILL.md`](https://www.firecrawl.dev/agent-onboarding/SKILL.md). See [Get credentials](/ai-onboarding#get-credentials).
 
-This page covers **Path B only.** WorkOS ID-JAG registration for Firecrawl. Follow [`auth.md`](https://www.firecrawl.dev/auth.md) for every step, claim requirement, and error code.
+This page summarizes **Path B only**: WorkOS ID-JAG registration for Firecrawl. Follow the canonical [`auth.md`](https://www.firecrawl.dev/auth.md) spec for every step, claim requirement, and error code.
 
 <Card title="Back to credential routing" icon="arrow-left" href="/ai-onboarding#get-credentials">
   Compare Path A and Path B on the Build with AI onboarding page.
@@ -26,11 +26,13 @@ If you cannot mint a WorkOS ID-JAG for Firecrawl, or you are not sure, use the h
 
 ## Path B: Agentic registration (WorkOS ID-JAG)
 
-**Only if ID-JAG capable → Path B.** Use this when your agent platform can mint a WorkOS ID-JAG for Firecrawl. Follow the [`auth.md`](https://www.firecrawl.dev/auth.md) spec.
+**Only if ID-JAG capable → Path B.** Use this when your agent platform can mint a WorkOS ID-JAG for Firecrawl.
 
-<Card title="auth.md spec" icon="file-lines" href="https://www.firecrawl.dev/auth.md">
+<Card title="Canonical spec: auth.md" icon="file-lines" href="https://www.firecrawl.dev/auth.md">
   Machine registration instructions for identity-aware agents. Follow Steps 1–4 in order.
 </Card>
+
+For ID-JAG claim requirements, discovery steps, registration body, limits, and errors, use the canonical [`auth.md`](https://www.firecrawl.dev/auth.md) spec.
 
 ## Discovery
 

--- a/ai-onboarding/agent-auth.mdx
+++ b/ai-onboarding/agent-auth.mdx
@@ -6,27 +6,25 @@ og:title: "Agent Auth (WorkOS ID-JAG) | Firecrawl"
 og:description: "Identity-aware agents: discover Firecrawl agent auth metadata and register via POST /agent/auth."
 ---
 
-If you cannot mint a WorkOS ID-JAG, or you are not sure, use human-in-the-loop onboarding via [`SKILL.md`](https://www.firecrawl.dev/agent-onboarding/SKILL.md). See [Get credentials](/ai-onboarding#get-credentials).
+If you need a browser sign-in or dashboard API key, use human-in-the-loop onboarding via [`SKILL.md`](https://www.firecrawl.dev/agent-onboarding/SKILL.md). See [Get credentials](/ai-onboarding#get-credentials).
 
-This page summarizes **Path B only**: WorkOS ID-JAG registration for Firecrawl. Follow the canonical [`auth.md`](https://www.firecrawl.dev/auth.md) spec for every step, claim requirement, and error code.
+This page summarizes WorkOS ID-JAG registration for Firecrawl. Follow the canonical [`auth.md`](https://www.firecrawl.dev/auth.md) spec for every step, claim requirement, and error code.
 
 <Card title="Back to credential routing" icon="arrow-left" href="/ai-onboarding#get-credentials">
-  Compare Path A and Path B on the Build with AI onboarding page.
+  Compare the dashboard, CLI, and WorkOS ID-JAG options on the Build with AI onboarding page.
 </Card>
 
-## Path A: Human + agent assist (default)
+## Need a human sign-in or dashboard key?
 
-**No ID-JAG or unsure → Path A (default).**
+Use this if you cannot mint a WorkOS ID-JAG for Firecrawl, or you are not sure.
 
-If you cannot mint a WorkOS ID-JAG for Firecrawl, or you are not sure, use the human + agent assist path:
-
-<Card title="Path A: Human + agent assist (default)" icon="user" href="https://www.firecrawl.dev/agent-onboarding/SKILL.md">
+<Card title="Use SKILL.md onboarding" icon="user" href="https://www.firecrawl.dev/agent-onboarding/SKILL.md">
   Browser sign-in, CLI install, skills, MCP wiring, and dashboard API keys.
 </Card>
 
-## Path B: Agentic registration (WorkOS ID-JAG)
+## Using WorkOS ID-JAG
 
-**Only if ID-JAG capable → Path B.** Use this when your agent platform can mint a WorkOS ID-JAG for Firecrawl.
+Use this when your agent platform can mint a WorkOS ID-JAG for Firecrawl.
 
 <Card title="Canonical spec: auth.md" icon="file-lines" href="https://www.firecrawl.dev/auth.md">
   Machine registration instructions for identity-aware agents. Follow Steps 1–4 in order.

--- a/ai-onboarding/agent-auth.mdx
+++ b/ai-onboarding/agent-auth.mdx
@@ -1,14 +1,14 @@
 ---
 title: Agent Auth (WorkOS ID-JAG)
 sidebarTitle: Agent Auth
-description: "Register a Firecrawl API key via WorkOS ID-JAG agent auth. Discovery, routing, and links to the canonical auth.md spec."
+description: "Register a Firecrawl API key via WorkOS ID-JAG agent auth. Discovery, routing, and links to auth.md."
 og:title: "Agent Auth (WorkOS ID-JAG) | Firecrawl"
 og:description: "Identity-aware agents: discover Firecrawl agent auth metadata and register via POST /agent/auth."
 ---
 
 If you need a browser sign-in or dashboard API key, use human-in-the-loop onboarding via [`SKILL.md`](https://www.firecrawl.dev/agent-onboarding/SKILL.md). See [Get credentials](/ai-onboarding#get-credentials).
 
-This page summarizes WorkOS ID-JAG registration for Firecrawl. Follow the canonical [`auth.md`](https://www.firecrawl.dev/auth.md) spec for every step, claim requirement, and error code.
+This page summarizes WorkOS ID-JAG registration for Firecrawl. Use [`auth.md`](https://www.firecrawl.dev/auth.md) for the full registration instructions, claim requirements, and error handling.
 
 <Card title="Back to credential routing" icon="arrow-left" href="/ai-onboarding#get-credentials">
   Compare the dashboard, CLI, and WorkOS ID-JAG options on the Build with AI onboarding page.
@@ -26,11 +26,11 @@ Use this if you cannot mint a WorkOS ID-JAG for Firecrawl, or you are not sure.
 
 Use this when your agent platform can mint a WorkOS ID-JAG for Firecrawl.
 
-<Card title="Canonical spec: auth.md" icon="file-lines" href="https://www.firecrawl.dev/auth.md">
-  Machine registration instructions for identity-aware agents. Follow Steps 1–4 in order.
+<Card title="Open auth.md" icon="file-lines" href="https://www.firecrawl.dev/auth.md">
+  Machine registration instructions for identity-aware agents. Follow the steps in order.
 </Card>
 
-For ID-JAG claim requirements, discovery steps, registration body, limits, and errors, use the canonical [`auth.md`](https://www.firecrawl.dev/auth.md) spec.
+For claim requirements, discovery, registration, limits, and errors, use [`auth.md`](https://www.firecrawl.dev/auth.md).
 
 ## Discovery
 

--- a/ai-onboarding/agent-auth.mdx
+++ b/ai-onboarding/agent-auth.mdx
@@ -1,7 +1,7 @@
 ---
 title: Agent Auth (WorkOS ID-JAG)
 sidebarTitle: Agent Auth
-description: "Register a Firecrawl API key via WorkOS ID-JAG agent auth. Discovery, routing, and links to auth.md."
+description: "Register a Firecrawl API key via WorkOS ID-JAG agent auth. Discovery and links to auth.md."
 og:title: "Agent Auth (WorkOS ID-JAG) | Firecrawl"
 og:description: "Identity-aware agents: discover Firecrawl agent auth metadata and register via POST /agent/auth."
 ---
@@ -10,7 +10,7 @@ If you need a browser sign-in or dashboard API key, use human-in-the-loop onboar
 
 This page summarizes WorkOS ID-JAG registration for Firecrawl. Use [`auth.md`](https://www.firecrawl.dev/auth.md) for the full registration instructions, claim requirements, and error handling.
 
-<Card title="Back to credential routing" icon="arrow-left" href="/ai-onboarding#get-credentials">
+<Card title="Back to Get credentials" icon="arrow-left" href="/ai-onboarding#get-credentials">
   Compare the dashboard, CLI, and WorkOS ID-JAG options on the Build with AI onboarding page.
 </Card>
 

--- a/ai-onboarding/agent-auth.mdx
+++ b/ai-onboarding/agent-auth.mdx
@@ -1,44 +1,40 @@
 ---
 title: Agent Auth (WorkOS ID-JAG)
 sidebarTitle: Agent Auth
-description: "Register a Firecrawl API key via WorkOS ID-JAG agent auth. Discovery, routing, and links to the canonical auth.md spec."
+description: "Register a Firecrawl API key via WorkOS ID-JAG agent auth. Discovery, routing, and links to the auth.md spec."
 og:title: "Agent Auth (WorkOS ID-JAG) | Firecrawl"
 og:description: "Identity-aware agents: discover Firecrawl agent auth metadata and register via POST /agent/auth."
 ---
 
-**Default: Path A.** If you cannot mint a WorkOS ID-JAG — or you are not sure — use human-in-the-loop onboarding via [`SKILL.md`](https://www.firecrawl.dev/agent-onboarding/SKILL.md) (see [Get credentials](/ai-onboarding#get-credentials)).
+If you cannot mint a WorkOS ID-JAG, or you are not sure, use human-in-the-loop onboarding via [`SKILL.md`](https://www.firecrawl.dev/agent-onboarding/SKILL.md). See [Get credentials](/ai-onboarding#get-credentials).
 
-This page covers **Path B only** — WorkOS ID-JAG registration for Firecrawl. It is not the execution spec; follow the canonical [`auth.md`](https://www.firecrawl.dev/auth.md) for every step, claim requirement, and error code.
+This page covers **Path B only.** WorkOS ID-JAG registration for Firecrawl. Follow [`auth.md`](https://www.firecrawl.dev/auth.md) for every step, claim requirement, and error code.
 
 <Card title="Back to credential routing" icon="arrow-left" href="/ai-onboarding#get-credentials">
   Compare Path A and Path B on the Build with AI onboarding page.
 </Card>
 
-## Path A — Human + agent assist (default)
+## Path A: Human + agent assist (default)
 
 **No ID-JAG or unsure → Path A (default).**
 
 If you cannot mint a WorkOS ID-JAG for Firecrawl, or you are not sure, use the human + agent assist path:
 
-<Card title="Path A — Human + agent assist (default)" icon="user" href="https://www.firecrawl.dev/agent-onboarding/SKILL.md">
+<Card title="Path A: Human + agent assist (default)" icon="user" href="https://www.firecrawl.dev/agent-onboarding/SKILL.md">
   Browser sign-in, CLI install, skills, MCP wiring, and dashboard API keys.
 </Card>
 
-## Path B — Agentic registration (WorkOS ID-JAG)
+## Path B: Agentic registration (WorkOS ID-JAG)
 
-**Only if ID-JAG capable → Path B.**
+**Only if ID-JAG capable → Path B.** Use this when your agent platform can mint a WorkOS ID-JAG for Firecrawl. Follow the [`auth.md`](https://www.firecrawl.dev/auth.md) spec.
 
-Fetch [`auth.md`](https://www.firecrawl.dev/auth.md) for ID-JAG claim requirements, discovery steps, registration body, and error handling. Do not skip ahead in that doc.
-
-<Card title="Canonical spec — auth.md" icon="file-lines" href="https://www.firecrawl.dev/auth.md">
+<Card title="auth.md spec" icon="file-lines" href="https://www.firecrawl.dev/auth.md">
   Machine registration instructions for identity-aware agents. Follow Steps 1–4 in order.
 </Card>
 
-For supported methods, limits, and errors, see the canonical [`auth.md`](https://www.firecrawl.dev/auth.md) spec.
-
 ## Discovery
 
-Discovery steps live in [`auth.md`](https://www.firecrawl.dev/auth.md) Step 1. If you already have a direct link to [`auth.md`](https://www.firecrawl.dev/auth.md), fetch it — you do not need this page.
+Discovery steps live in [`auth.md`](https://www.firecrawl.dev/auth.md) Step 1. If you already have a direct link to [`auth.md`](https://www.firecrawl.dev/auth.md), fetch it. You do not need this page.
 
 ## What happens next
 

--- a/api-reference/v2-introduction.mdx
+++ b/api-reference/v2-introduction.mdx
@@ -58,7 +58,7 @@ Authorization: Bearer fc-YOUR-API-KEY
 
 Include this header in all API calls. You can find your API key in the [Firecrawl dashboard](https://www.firecrawl.dev/app/api-keys).
 
-If you are an agent without a key, see [Build with AI credential routing](/ai-onboarding#get-credentials) to choose the right path. Identity-aware agents that can mint a WorkOS ID-JAG should follow the canonical [`auth.md`](https://www.firecrawl.dev/auth.md) spec.
+If you are an agent without a key, see [Build with AI credential routing](/ai-onboarding#get-credentials) to choose the right path. Identity-aware agents that can mint a WorkOS ID-JAG should follow [`auth.md`](https://www.firecrawl.dev/auth.md).
 
 <CodeGroup>
 

--- a/api-reference/v2-introduction.mdx
+++ b/api-reference/v2-introduction.mdx
@@ -58,7 +58,7 @@ Authorization: Bearer fc-YOUR-API-KEY
 
 Include this header in all API calls. You can find your API key in the [Firecrawl dashboard](https://www.firecrawl.dev/app/api-keys).
 
-If you are an agent without a key, see [Build with AI credential routing](/ai-onboarding#get-credentials) to choose the right path. Identity-aware agents that can mint a WorkOS ID-JAG should follow the canonical [`auth.md`](https://www.firecrawl.dev/auth.md) spec.
+If you are an agent without an API key, start with [Get credentials](/ai-onboarding#get-credentials). If your platform supports WorkOS ID-JAG, use [`auth.md`](https://www.firecrawl.dev/auth.md) for registration instructions.
 
 <CodeGroup>
 

--- a/api-reference/v2-introduction.mdx
+++ b/api-reference/v2-introduction.mdx
@@ -58,7 +58,7 @@ Authorization: Bearer fc-YOUR-API-KEY
 
 Include this header in all API calls. You can find your API key in the [Firecrawl dashboard](https://www.firecrawl.dev/app/api-keys).
 
-If you are an agent without a key, see [Build with AI credential routing](/ai-onboarding#get-credentials) to choose the right path. Identity-aware agents that can mint a WorkOS ID-JAG should follow [`auth.md`](https://www.firecrawl.dev/auth.md).
+If you are an agent without a key, see [Build with AI credential routing](/ai-onboarding#get-credentials) to choose the right path. Identity-aware agents that can mint a WorkOS ID-JAG should follow the canonical [`auth.md`](https://www.firecrawl.dev/auth.md) spec.
 
 <CodeGroup>
 


### PR DESCRIPTION
## Why this is needed

This follow-up to PR #1016 makes the credential choice easier to read and preview while keeping the same routing logic.

Users who need a browser sign-in, CLI setup, MCP setup, or a dashboard API key should use the dashboard or CLI flow. Agent platforms that support WorkOS ID-JAG can use the direct registration flow.

## Summary

- Removes the convoluted decision-layer sentence
- Keeps the credential section to two cards, with no duplicate dashboard/API-key card.
- Replaces internal Path A / Path B card labels with clearer credential choices: dashboard or CLI, and WorkOS ID-JAG.
- Keeps WorkOS ID-JAG conditional and routes through the Agent Auth overview before the auth.md spec.
- Aligns the Agent Auth page wording with the same user-facing credential choices.