### PR TITLE
docs(interact): clarified wording that code takes precendence of prompt

### DIFF
--- a/api-reference/endpoint/scrape-execute.mdx
+++ b/api-reference/endpoint/scrape-execute.mdx
@@ -4,7 +4,7 @@ description: "Execute code or an AI prompt in the browser session bound to a scr
 openapi: '/api-reference/v2-openapi.json POST /scrape/{jobId}/interact'
 ---
 
-Use this endpoint to continue interacting with the same browser state initialized from a previous scrape. Either `code` or `prompt` must be provided — not both.
+Use this endpoint to continue interacting with the same browser state initialized from a previous scrape. At least one of `code` or `prompt` must be provided. If both are provided, `code` takes precedence and the request runs in code-execution mode.
 
 `POST /v2/scrape/{jobId}/interact` handles the full lifecycle:
 

--- a/features/interact.mdx
+++ b/features/interact.mdx
@@ -401,6 +401,8 @@ Profiles created through the API may not appear in Dashboard > Interact > Profil
 | `timeout` | `number` | `30` | Timeout in seconds (1–300). |
 | `origin` | `string` | — | Caller identifier for activity tracking. |
 
+If both `code` and `prompt` are provided, Firecrawl runs the `code` request and ignores `prompt`.
+
 ### Response
 
 | Field | Description |


### PR DESCRIPTION
# Summary

- Update the interact API reference to remove the incorrect “not both” wording for `code` and `prompt`
- Document current server behavior: at least one of `code` or `prompt` is required, and when both are provided, `code` takes precedence
- Add the same precedence note to the Interact feature guide

## Implementation reference

The API chooses prompt mode only when `prompt && !rawCode`; otherwise it falls
through to code execution: [apps/api/src/controllers/v2/scrape-browser.ts#L256-L328](https://github.com/firecrawl/firecrawl/blob/222606e53db90acf8fee7c418c19f0cdff331954/apps/api/src/controllers/v2/scrape-browser.ts#L256-L328)
