### PR TITLE
docs(scrape): document PII redaction

### DIFF
--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -5716,22 +5716,6 @@
                 "type",
                 "query"
               ]
-            },
-            {
-              "type": "object",
-              "title": "PII",
-              "description": "Include PII redaction diagnostics in the response. Redaction itself is controlled by the `redactPII` option; this format only returns status, spans, and counts.",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "pii"
-                  ]
-                }
-              },
-              "required": [
-                "type"
-              ]
             }
           ]
         },
@@ -5856,22 +5840,6 @@
               "required": [
                 "type"
               ]
-            },
-            {
-              "type": "object",
-              "title": "PII",
-              "description": "Include PII redaction diagnostics in the response. Redaction itself is controlled by the `redactPII` option; this format only returns status, spans, and counts.",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "pii"
-                  ]
-                }
-              },
-              "required": [
-                "type"
-              ]
             }
           ]
         },
@@ -5983,7 +5951,7 @@
               }
             ],
             "default": false,
-            "description": "Redact personally identifiable information from returned markdown. Pass `true` to use defaults, or an object to tune mode, entities, and replacement style. Add `pii` to `formats` to receive redaction diagnostics."
+            "description": "Redact personally identifiable information from returned markdown. Pass `true` to use defaults, or an object to tune mode, entities, and replacement style."
           },
           "proxy": {
             "type": "string",
@@ -6462,7 +6430,7 @@
               }
             ],
             "default": false,
-            "description": "Redact personally identifiable information from returned markdown. Pass `true` to use defaults, or an object to tune mode, entities, and replacement style. Add `pii` to `formats` to receive redaction diagnostics."
+            "description": "Redact personally identifiable information from returned markdown. Pass `true` to use defaults, or an object to tune mode, entities, and replacement style."
           },
           "profile": {
             "type": "object",
@@ -6537,10 +6505,6 @@
                 "type": "string",
                 "nullable": true,
                 "description": "Relevant source text selected by the `highlights` format. Only present if a `highlights` format object was included in `formats`."
-              },
-              "pii": {
-                "$ref": "#/components/schemas/PIIBlock",
-                "description": "PII redaction diagnostics if `redactPII` is enabled and `pii` is requested in `formats`."
               },
               "links": {
                 "type": "array",
@@ -7785,100 +7749,6 @@
           }
         },
         "additionalProperties": false
-      },
-      "PIISpan": {
-        "type": "object",
-        "properties": {
-          "start": {
-            "type": "integer",
-            "description": "Start character offset of the detected span in the source markdown."
-          },
-          "end": {
-            "type": "integer",
-            "description": "End character offset of the detected span in the source markdown."
-          },
-          "entity": {
-            "$ref": "#/components/schemas/RedactPIIEntity",
-            "description": "Unified public entity bucket. Omitted when the recognizer kind does not map to a public bucket."
-          },
-          "kind": {
-            "type": "string",
-            "description": "Granular recognizer label returned by the redaction service, such as EMAIL_ADDRESS."
-          },
-          "source": {
-            "type": "string",
-            "enum": [
-              "model",
-              "heuristics",
-              "unknown"
-            ],
-            "description": "Recognizer source for this span."
-          },
-          "score": {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 1,
-            "description": "Confidence score when provided by the recognizer."
-          }
-        },
-        "required": [
-          "start",
-          "end",
-          "kind",
-          "source"
-        ]
-      },
-      "PIIBlock": {
-        "type": "object",
-        "description": "PII redaction diagnostics returned when `redactPII` is enabled and `pii` is requested in formats.",
-        "properties": {
-          "status": {
-            "type": "string",
-            "enum": [
-              "ok",
-              "skipped",
-              "failed"
-            ],
-            "description": "`ok` means redaction completed, `skipped` means redaction was not performed, and `failed` means redaction was attempted but did not produce usable content."
-          },
-          "reason": {
-            "type": "string",
-            "enum": [
-              "empty_input",
-              "too_large",
-              "upstream_skipped",
-              "service_unavailable",
-              "timeout",
-              "error"
-            ],
-            "description": "Reason redaction was skipped or failed. Present when status is not `ok`."
-          },
-          "redactedMarkdown": {
-            "type": "string",
-            "nullable": true,
-            "description": "The redacted markdown result, or null when no usable redacted content was produced."
-          },
-          "spans": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PIISpan"
-            },
-            "description": "Detected PII spans in the source markdown."
-          },
-          "counts": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "integer"
-            },
-            "description": "Count of detected spans by public entity bucket. Only non-zero entries are present."
-          }
-        },
-        "required": [
-          "status",
-          "redactedMarkdown",
-          "spans",
-          "counts"
-        ]
       }
     }
   },

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -5716,6 +5716,22 @@
                 "type",
                 "query"
               ]
+            },
+            {
+              "type": "object",
+              "title": "PII",
+              "description": "Include PII redaction diagnostics in the response. Redaction itself is controlled by the `redactPII` option; this format only returns status, spans, and counts.",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "pii"
+                  ]
+                }
+              },
+              "required": [
+                "type"
+              ]
             }
           ]
         },
@@ -5840,6 +5856,22 @@
               "required": [
                 "type"
               ]
+            },
+            {
+              "type": "object",
+              "title": "PII",
+              "description": "Include PII redaction diagnostics in the response. Redaction itself is controlled by the `redactPII` option; this format only returns status, spans, and counts.",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "pii"
+                  ]
+                }
+              },
+              "required": [
+                "type"
+              ]
             }
           ]
         },
@@ -5940,6 +5972,18 @@
             "type": "boolean",
             "description": "Enable ad and cookie popup blocking.",
             "default": true
+          },
+          "redactPII": {
+            "oneOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "$ref": "#/components/schemas/RedactPIIOptions"
+              }
+            ],
+            "default": false,
+            "description": "Redact personally identifiable information from returned markdown. Pass `true` to use defaults, or an object to tune mode, entities, and replacement style. Add `pii` to `formats` to receive redaction diagnostics."
           },
           "proxy": {
             "type": "string",
@@ -6408,6 +6452,18 @@
             "description": "If true, serves the request from Firecrawl's cache only and never makes an outbound request to the target URL. Designed for compliance-constrained or air-gapped environments where the scrape request itself could leak sensitive information. On cache miss, returns a 404 with error code SCRAPE_LOCKDOWN_CACHE_MISS (the URL is never logged on miss). Lockdown requests are treated as zero data retention. Default maxAge is extended to 2 years so existing cached pages remain eligible. Billed at 5 credits on hit, 1 credit on cache miss.",
             "default": false
           },
+          "redactPII": {
+            "oneOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "$ref": "#/components/schemas/RedactPIIOptions"
+              }
+            ],
+            "default": false,
+            "description": "Redact personally identifiable information from returned markdown. Pass `true` to use defaults, or an object to tune mode, entities, and replacement style. Add `pii` to `formats` to receive redaction diagnostics."
+          },
           "profile": {
             "type": "object",
             "description": "Enable persistent browser storage across scrape and interact sessions. Pass a profile when scraping to preserve cookies, localStorage, and session data. Sessions with the same profile name share browser state.",
@@ -6481,6 +6537,10 @@
                 "type": "string",
                 "nullable": true,
                 "description": "Relevant source text selected by the `highlights` format. Only present if a `highlights` format object was included in `formats`."
+              },
+              "pii": {
+                "$ref": "#/components/schemas/PIIBlock",
+                "description": "PII redaction diagnostics if `redactPII` is enabled and `pii` is requested in `formats`."
               },
               "links": {
                 "type": "array",
@@ -7679,6 +7739,146 @@
             "description": "Support proxy or upstream error code."
           }
         }
+      },
+      "RedactPIIEntity": {
+        "type": "string",
+        "enum": [
+          "PERSON",
+          "EMAIL",
+          "PHONE",
+          "LOCATION",
+          "FINANCIAL",
+          "SECRET"
+        ],
+        "description": "Public PII entity buckets supported by Firecrawl redaction."
+      },
+      "RedactPIIOptions": {
+        "type": "object",
+        "description": "Tuning options for PII redaction.",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "accurate",
+              "aggressive",
+              "fast"
+            ],
+            "default": "accurate",
+            "description": "Redaction strategy. `accurate` is model-only and optimized for precision, `aggressive` increases recall with additional heuristics, and `fast` uses heuristics without the model call."
+          },
+          "entities": {
+            "type": "array",
+            "description": "Restrict redaction to these entity buckets. If omitted, all supported entities are redacted.",
+            "items": {
+              "$ref": "#/components/schemas/RedactPIIEntity"
+            }
+          },
+          "replaceStyle": {
+            "type": "string",
+            "enum": [
+              "tag",
+              "mask",
+              "remove"
+            ],
+            "default": "tag",
+            "description": "`tag` replaces spans with placeholders like `<EMAIL>`, `mask` replaces characters with `*`, and `remove` deletes the span text."
+          }
+        },
+        "additionalProperties": false
+      },
+      "PIISpan": {
+        "type": "object",
+        "properties": {
+          "start": {
+            "type": "integer",
+            "description": "Start character offset of the detected span in the source markdown."
+          },
+          "end": {
+            "type": "integer",
+            "description": "End character offset of the detected span in the source markdown."
+          },
+          "entity": {
+            "$ref": "#/components/schemas/RedactPIIEntity",
+            "description": "Unified public entity bucket. Omitted when the recognizer kind does not map to a public bucket."
+          },
+          "kind": {
+            "type": "string",
+            "description": "Granular recognizer label returned by the redaction service, such as EMAIL_ADDRESS."
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "model",
+              "heuristics",
+              "unknown"
+            ],
+            "description": "Recognizer source for this span."
+          },
+          "score": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Confidence score when provided by the recognizer."
+          }
+        },
+        "required": [
+          "start",
+          "end",
+          "kind",
+          "source"
+        ]
+      },
+      "PIIBlock": {
+        "type": "object",
+        "description": "PII redaction diagnostics returned when `redactPII` is enabled and `pii` is requested in formats.",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "ok",
+              "skipped",
+              "failed"
+            ],
+            "description": "`ok` means redaction completed, `skipped` means redaction was not performed, and `failed` means redaction was attempted but did not produce usable content."
+          },
+          "reason": {
+            "type": "string",
+            "enum": [
+              "empty_input",
+              "too_large",
+              "upstream_skipped",
+              "service_unavailable",
+              "timeout",
+              "error"
+            ],
+            "description": "Reason redaction was skipped or failed. Present when status is not `ok`."
+          },
+          "redactedMarkdown": {
+            "type": "string",
+            "nullable": true,
+            "description": "The redacted markdown result, or null when no usable redacted content was produced."
+          },
+          "spans": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PIISpan"
+            },
+            "description": "Detected PII spans in the source markdown."
+          },
+          "counts": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "description": "Count of detected spans by public entity bucket. Only non-zero entries are present."
+          }
+        },
+        "required": [
+          "status",
+          "redactedMarkdown",
+          "spans",
+          "counts"
+        ]
       }
     }
   },

--- a/docs.json
+++ b/docs.json
@@ -156,6 +156,7 @@
                           "features/change-tracking",
                           "features/enhanced-mode",
                           "features/lockdown",
+                          "features/pii-redaction",
                           "features/proxies",
                           "features/document-parsing"
                         ]

--- a/features/parse.mdx
+++ b/features/parse.mdx
@@ -99,9 +99,10 @@ SDKs return the document object directly. cURL returns the JSON payload.
 
 `/parse` accepts a subset of scrape options under the `options` field. Common settings:
 
-- `formats`: Array of output formats. Defaults to `["markdown"]`. Supported: `markdown`, `html`, `rawHtml`, `links`, `images`, `summary`, and `json` (with a schema or prompt).
+- `formats`: Array of output formats. Defaults to `["markdown"]`. Supported: `markdown`, `html`, `rawHtml`, `links`, `images`, `summary`, `json` (with a schema or prompt), and `pii`.
 - `onlyMainContent`: Only return the main content of the document. Defaults to `true`.
 - `includeTags` / `excludeTags`: Tag-level inclusion or exclusion (HTML inputs).
+- `redactPII`: Redact personally identifiable information from returned markdown. Add the `pii` format to receive redaction diagnostics.
 - `timeout`: Request timeout in milliseconds. Defaults to `30000`, max `300000`.
 - `parsers`: File-parser controls. For PDFs, set `{ "type": "pdf", "mode": "fast" | "auto" | "ocr", "maxPages": <int> }`.
 

--- a/features/parse.mdx
+++ b/features/parse.mdx
@@ -99,10 +99,10 @@ SDKs return the document object directly. cURL returns the JSON payload.
 
 `/parse` accepts a subset of scrape options under the `options` field. Common settings:
 
-- `formats`: Array of output formats. Defaults to `["markdown"]`. Supported: `markdown`, `html`, `rawHtml`, `links`, `images`, `summary`, `json` (with a schema or prompt), and `pii`.
+- `formats`: Array of output formats. Defaults to `["markdown"]`. Supported: `markdown`, `html`, `rawHtml`, `links`, `images`, `summary`, and `json` (with a schema or prompt).
 - `onlyMainContent`: Only return the main content of the document. Defaults to `true`.
 - `includeTags` / `excludeTags`: Tag-level inclusion or exclusion (HTML inputs).
-- `redactPII`: Redact personally identifiable information from returned markdown. Add the `pii` format to receive redaction diagnostics.
+- `redactPII`: Redact personally identifiable information from returned markdown.
 - `timeout`: Request timeout in milliseconds. Defaults to `30000`, max `300000`.
 - `parsers`: File-parser controls. For PDFs, set `{ "type": "pdf", "mode": "fast" | "auto" | "ocr", "maxPages": <int> }`.
 

--- a/features/pii-redaction.mdx
+++ b/features/pii-redaction.mdx
@@ -14,9 +14,7 @@ PII redaction replaces personally identifiable information in returned markdown 
 
 ## How it works
 
-Set `redactPII: true` on a scrape request. Firecrawl redacts the generated markdown and returns the redacted version in `markdown`.
-
-If you also include the `pii` format, Firecrawl returns a `pii` block with redaction status, detected spans, and counts. Without the `pii` format, the content is still redacted, but the diagnostic block is omitted.
+Set `redactPII: true` on a scrape request. Firecrawl redacts the generated markdown and returns the redacted version in `markdown`. You do not need to pass `formats`; markdown is the default output.
 
 <CodeGroup>
 
@@ -51,42 +49,36 @@ For most requests, use `redactPII: true`. To tune redaction, pass an options obj
 | `replaceStyle` | `tag`, `mask`, `remove` | `tag` | Replace spans with tags like `<EMAIL>`, mask them with `*`, or remove the characters entirely. |
 
 <Note>
-The Firecrawl CLI and MCP server expose simple boolean redaction. Advanced options and the diagnostic `pii` format are available through the API and SDKs that expose the full `redactPII` options object.
+The Firecrawl CLI and MCP server expose simple boolean redaction. Advanced options are available through the API and SDKs that expose the full `redactPII` options object.
 </Note>
 
 ## Response
 
-When redaction succeeds, `markdown` contains the redacted content. If you request `formats: ["pii"]`, the response also includes:
+When redaction succeeds, `markdown` contains the redacted content:
 
 ```json
 {
-  "markdown": "Contact us at <EMAIL> or <PHONE>.",
-  "pii": {
-    "status": "ok",
-    "redactedMarkdown": "Contact us at <EMAIL> or <PHONE>.",
-    "spans": [
-      {
-        "start": 14,
-        "end": 30,
-        "entity": "EMAIL",
-        "kind": "EMAIL_ADDRESS",
-        "source": "heuristics",
-        "score": 0.99
-      }
-    ],
-    "counts": {
-      "EMAIL": 1,
-      "PHONE": 1
+  "success": true,
+  "data": {
+    "markdown": "Contact us at <EMAIL> or <PHONE>.",
+    "metadata": {
+      "sourceURL": "https://example.com/contact"
     }
   }
 }
 ```
 
-`pii.status` can be:
+For command-line viewing, pipe the markdown into your preferred renderer:
 
-- `ok`: Redaction completed and `redactedMarkdown` is the redacted result.
-- `skipped`: Redaction was not performed. `reason` explains why.
-- `failed`: Redaction was attempted but did not produce usable content. Firecrawl fails closed so raw markdown is not returned.
+```bash cURL
+curl -X POST https://api.firecrawl.dev/v2/scrape \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "url": "https://dlptest.com/sample-data.pdf",
+    "redactPII": true
+  }' | jq -r ".data.markdown" | glow
+```
 
 ## Billing
 

--- a/features/pii-redaction.mdx
+++ b/features/pii-redaction.mdx
@@ -1,0 +1,108 @@
+---
+title: "PII Redaction"
+description: "Redact personally identifiable information from scrape and parse output"
+og:title: "PII Redaction | Firecrawl"
+og:description: "Redact personally identifiable information from Firecrawl output"
+---
+
+import PIIPython from "/snippets/v2/scrape/pii/python.mdx";
+import PIINode from "/snippets/v2/scrape/pii/js.mdx";
+import PIICURL from "/snippets/v2/scrape/pii/curl.mdx";
+import PIICLI from "/snippets/v2/scrape/pii/cli.mdx";
+
+PII redaction replaces personally identifiable information in returned markdown before you send it downstream to agents, logs, vector stores, or analytics pipelines.
+
+## How it works
+
+Set `redactPII: true` on a scrape request. Firecrawl redacts the generated markdown and returns the redacted version in `markdown`.
+
+If you also include the `pii` format, Firecrawl returns a `pii` block with redaction status, detected spans, and counts. Without the `pii` format, the content is still redacted, but the diagnostic block is omitted.
+
+<CodeGroup>
+
+<PIIPython />
+
+<PIINode />
+
+<PIICURL />
+
+<PIICLI />
+
+</CodeGroup>
+
+## Redaction options
+
+For most requests, use `redactPII: true`. To tune redaction, pass an options object:
+
+```json
+{
+  "redactPII": {
+    "mode": "accurate",
+    "entities": ["EMAIL", "PHONE", "SECRET"],
+    "replaceStyle": "tag"
+  }
+}
+```
+
+| Option | Values | Default | Description |
+|---|---|---|---|
+| `mode` | `accurate`, `aggressive`, `fast` | `accurate` | Redaction strategy. `accurate` uses the model-only path, `aggressive` increases recall with additional heuristics, and `fast` skips the model call. |
+| `entities` | `PERSON`, `EMAIL`, `PHONE`, `LOCATION`, `FINANCIAL`, `SECRET` | All entities | Limit redaction to specific entity buckets. |
+| `replaceStyle` | `tag`, `mask`, `remove` | `tag` | Replace spans with tags like `<EMAIL>`, mask them with `*`, or remove the characters entirely. |
+
+<Note>
+The Firecrawl CLI and MCP server expose simple boolean redaction. Advanced options and the diagnostic `pii` format are available through the API and SDKs that expose the full `redactPII` options object.
+</Note>
+
+## Response
+
+When redaction succeeds, `markdown` contains the redacted content. If you request `formats: ["pii"]`, the response also includes:
+
+```json
+{
+  "markdown": "Contact us at <EMAIL> or <PHONE>.",
+  "pii": {
+    "status": "ok",
+    "redactedMarkdown": "Contact us at <EMAIL> or <PHONE>.",
+    "spans": [
+      {
+        "start": 14,
+        "end": 30,
+        "entity": "EMAIL",
+        "kind": "EMAIL_ADDRESS",
+        "source": "heuristics",
+        "score": 0.99
+      }
+    ],
+    "counts": {
+      "EMAIL": 1,
+      "PHONE": 1
+    }
+  }
+}
+```
+
+`pii.status` can be:
+
+- `ok`: Redaction completed and `redactedMarkdown` is the redacted result.
+- `skipped`: Redaction was not performed. `reason` explains why.
+- `failed`: Redaction was attempted but did not produce usable content. Firecrawl fails closed so raw markdown is not returned.
+
+## Billing
+
+PII redaction costs 5 credits per page: 1 base scrape credit plus 4 additional credits for redaction.
+
+For parsed PDFs, each additional PDF page still incurs the normal PDF parsing credit and also receives the additional redaction charge.
+
+## Availability
+
+PII redaction is supported anywhere Firecrawl accepts scrape options:
+
+- **Scrape** - set `redactPII` on `/v2/scrape`.
+- **Crawl, batch scrape, and search** - pass `redactPII` inside `scrapeOptions`.
+- **Parse** - pass `redactPII` inside the multipart `options` JSON.
+- **SDKs** - Python uses `redact_pii`; JavaScript and other SDKs use `redactPII` or their native option casing.
+- **CLI** - pass `--redact-pii` to `firecrawl scrape`.
+- **MCP server** - include `"redactPII": true` in `firecrawl_scrape` tool arguments for simple boolean redaction.
+
+> Are you an AI agent that needs a Firecrawl API key? See [firecrawl.dev/agent-onboarding/SKILL.md](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for automated onboarding instructions.

--- a/features/scrape.mdx
+++ b/features/scrape.mdx
@@ -135,7 +135,6 @@ You can now choose what formats you want your output in. You can specify multipl
 - Audio (`audio`) - extract MP3 audio from supported video URLs, e.g. YouTube (returns a signed GCS URL, expires after 1 hour)
 - Video (`video`) - extract best-quality video from supported video URLs, e.g. YouTube (returns a signed GCS URL, expires after 1 hour)
 - Query (`query`, with `prompt` and optional `mode`) - ask a natural-language question about the page; the answer is returned in the `answer` field
-- PII (`pii`) - include PII redaction diagnostics when used with `redactPII`
 
 Output keys will match the format you choose.
 
@@ -328,7 +327,7 @@ The `highlights` format is also available in `/search` via `scrapeOptions`, whic
 
 ## PII redaction
 
-Set `redactPII: true` to redact personally identifiable information from returned markdown. Add the `pii` format when you also want redaction status, spans, and counts in the response.
+Set `redactPII: true` to redact personally identifiable information from returned markdown. The `markdown` field contains the redacted result.
 
 See [PII Redaction](/features/pii-redaction) for SDK, cURL, CLI, and MCP examples.
 

--- a/features/scrape.mdx
+++ b/features/scrape.mdx
@@ -110,7 +110,7 @@ print(doc.markdown)
 </Tip>
 
 <Info>
-  Each scrape consumes 1 credit. Additional credits apply for certain options: JSON mode costs 4 additional credits per page, question and highlights formats cost 4 additional credits per page per format, enhanced proxy costs 4 additional credits per page, PDF parsing costs 1 credit per PDF page, and audio or video extraction costs 4 additional credits per page.
+  Each scrape consumes 1 credit. Additional credits apply for certain options: JSON mode costs 4 additional credits per page, question and highlights formats cost 4 additional credits per page per format, enhanced proxy costs 4 additional credits per page, PII redaction costs 4 additional credits per page, PDF parsing costs 1 credit per PDF page, and audio or video extraction costs 4 additional credits per page.
 </Info>
 
 ### Response
@@ -135,6 +135,7 @@ You can now choose what formats you want your output in. You can specify multipl
 - Audio (`audio`) - extract MP3 audio from supported video URLs, e.g. YouTube (returns a signed GCS URL, expires after 1 hour)
 - Video (`video`) - extract best-quality video from supported video URLs, e.g. YouTube (returns a signed GCS URL, expires after 1 hour)
 - Query (`query`, with `prompt` and optional `mode`) - ask a natural-language question about the page; the answer is returned in the `answer` field
+- PII (`pii`) - include PII redaction diagnostics when used with `redactPII`
 
 Output keys will match the format you choose.
 
@@ -324,6 +325,12 @@ You can combine `highlights` with other formats — for example, request `markdo
 </CodeGroup>
 
 The `highlights` format is also available in `/search` via `scrapeOptions`, which runs the same extraction across each search result.
+
+## PII redaction
+
+Set `redactPII: true` to redact personally identifiable information from returned markdown. Add the `pii` format when you also want redaction status, spans, and counts in the response.
+
+See [PII Redaction](/features/pii-redaction) for SDK, cURL, CLI, and MCP examples.
 
 ## Interacting with the page with Actions
 

--- a/mcp-server.mdx
+++ b/mcp-server.mdx
@@ -452,6 +452,19 @@ Scrape content from a single URL with advanced options.
 }
 ```
 
+To redact personally identifiable information, include `redactPII` in the scrape tool arguments.
+
+```json
+{
+  "name": "firecrawl_scrape",
+  "arguments": {
+    "url": "https://example.com/contact",
+    "formats": ["markdown"],
+    "redactPII": true
+  }
+}
+```
+
 ### 2. Map Tool (`firecrawl_map`)
 
 Map a website to discover all indexed URLs on the site.

--- a/sdks/cli.mdx
+++ b/sdks/cli.mdx
@@ -130,6 +130,7 @@ Scrape a single URL and extract its content in various formats.
 | `--actions <json>`       |       | JSON actions array to run during scrape                                                                                                                         |
 | `--actions-file <path>`  |       | Path to JSON actions file                                                                                                                                       |
 | `--proxy <proxy>`        |       | Proxy mode for scraping (for example, `auto` or `basic`)                                                                                                        |
+| `--redact-pii`           |       | Redact personally identifiable information from returned content                                                                                                 |
 | `--output <path>`        | `-o`  | Save output to file                                                                                                                                             |
 | `--json`                 |       | Force JSON output even with single format                                                                                                                       |
 | `--pretty`               |       | Pretty print JSON output                                                                                                                                        |

--- a/snippets/v2/cli/scrape/options.mdx
+++ b/snippets/v2/cli/scrape/options.mdx
@@ -17,6 +17,9 @@ firecrawl https://example.com --actions '[{"type":"wait","milliseconds":1000}]'
 # Select proxy mode
 firecrawl https://example.com --proxy basic
 
+# Redact personally identifiable information
+firecrawl https://example.com --redact-pii
+
 # Include/exclude specific HTML tags
 firecrawl https://example.com --include-tags article,main
 firecrawl https://example.com --exclude-tags nav,footer

--- a/snippets/v2/scrape/pii/cli.mdx
+++ b/snippets/v2/scrape/pii/cli.mdx
@@ -1,0 +1,4 @@
+```bash CLI
+# Return markdown with personally identifiable information redacted.
+firecrawl https://example.com/contact --redact-pii
+```

--- a/snippets/v2/scrape/pii/curl.mdx
+++ b/snippets/v2/scrape/pii/curl.mdx
@@ -1,0 +1,10 @@
+```bash cURL
+curl -X POST https://api.firecrawl.dev/v2/scrape \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer fc-YOUR_API_KEY' \
+  -d '{
+    "url": "https://example.com/contact",
+    "formats": ["markdown", "pii"],
+    "redactPII": true
+  }'
+```

--- a/snippets/v2/scrape/pii/curl.mdx
+++ b/snippets/v2/scrape/pii/curl.mdx
@@ -4,7 +4,6 @@ curl -X POST https://api.firecrawl.dev/v2/scrape \
   -H 'Authorization: Bearer fc-YOUR_API_KEY' \
   -d '{
     "url": "https://example.com/contact",
-    "formats": ["markdown", "pii"],
     "redactPII": true
   }'
 ```

--- a/snippets/v2/scrape/pii/js.mdx
+++ b/snippets/v2/scrape/pii/js.mdx
@@ -4,10 +4,8 @@ import { Firecrawl } from 'firecrawl';
 const firecrawl = new Firecrawl({ apiKey: "fc-YOUR_API_KEY" });
 
 const doc = await firecrawl.scrape('https://example.com/contact', {
-  formats: ['markdown', 'pii'],
   redactPII: true,
 });
 
 console.log(doc.markdown);
-console.log(doc.pii?.counts);
 ```

--- a/snippets/v2/scrape/pii/js.mdx
+++ b/snippets/v2/scrape/pii/js.mdx
@@ -1,0 +1,13 @@
+```javascript JavaScript
+import { Firecrawl } from 'firecrawl';
+
+const firecrawl = new Firecrawl({ apiKey: "fc-YOUR_API_KEY" });
+
+const doc = await firecrawl.scrape('https://example.com/contact', {
+  formats: ['markdown', 'pii'],
+  redactPII: true,
+});
+
+console.log(doc.markdown);
+console.log(doc.pii?.counts);
+```

--- a/snippets/v2/scrape/pii/python.mdx
+++ b/snippets/v2/scrape/pii/python.mdx
@@ -5,10 +5,8 @@ firecrawl = Firecrawl(api_key="fc-YOUR_API_KEY")
 
 doc = firecrawl.scrape(
     "https://example.com/contact",
-    formats=["markdown", "pii"],
     redact_pii=True,
 )
 
 print(doc.markdown)
-print(doc.pii.counts)
 ```

--- a/snippets/v2/scrape/pii/python.mdx
+++ b/snippets/v2/scrape/pii/python.mdx
@@ -1,0 +1,14 @@
+```python Python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(api_key="fc-YOUR_API_KEY")
+
+doc = firecrawl.scrape(
+    "https://example.com/contact",
+    formats=["markdown", "pii"],
+    redact_pii=True,
+)
+
+print(doc.markdown)
+print(doc.pii.counts)
+```


### PR DESCRIPTION
## Summary

Documents the new PII redaction option across the scrape and parse docs, API reference, CLI reference, and MCP server page. Adds a dedicated PII Redaction feature page with SDK, cURL, and CLI snippets plus availability and billing details.