### PR TITLE
docs: clarify batchScrape vs startBatchScrape in batch scrape example

### DIFF
--- a/snippets/v2/batch-scrape/base/js.mdx
+++ b/snippets/v2/batch-scrape/base/js.mdx
@@ -3,7 +3,15 @@ import { Firecrawl } from 'firecrawl';
 
 const firecrawl = new Firecrawl({ apiKey: "fc-YOUR-API-KEY" });
 
-// Start a batch scrape job
+// Synchronous: starts the batch and waits for completion
+const job = await firecrawl.batchScrape([
+  'https://firecrawl.dev',
+  'https://docs.firecrawl.dev'
+], { options: { formats: ['markdown'] }, pollInterval: 2, timeout: 120 });
+
+console.log(job.status, job.completed, job.total);
+
+// Or asynchronous: starts the batch and returns a job ID immediately
 const { id } = await firecrawl.startBatchScrape([
   'https://firecrawl.dev',
   'https://docs.firecrawl.dev'
@@ -11,13 +19,5 @@ const { id } = await firecrawl.startBatchScrape([
   options: { formats: ['markdown'] },
 });
 
-// Wait for completion
-const job = await firecrawl.batchScrape([
-  'https://firecrawl.dev',
-  'https://docs.firecrawl.dev'
-], { options: { formats: ['markdown'] }, pollInterval: 2, timeout: 120 });
-
-console.log(job.status, job.completed, job.total);
+const status = await firecrawl.getBatchScrapeStatus(id);
 ```
-
-

--- a/snippets/v2/batch-scrape/base/js.mdx
+++ b/snippets/v2/batch-scrape/base/js.mdx
@@ -3,15 +3,7 @@ import { Firecrawl } from 'firecrawl';
 
 const firecrawl = new Firecrawl({ apiKey: "fc-YOUR-API-KEY" });
 
-// Synchronous: starts the batch and waits for completion
-const job = await firecrawl.batchScrape([
-  'https://firecrawl.dev',
-  'https://docs.firecrawl.dev'
-], { options: { formats: ['markdown'] }, pollInterval: 2, timeout: 120 });
-
-console.log(job.status, job.completed, job.total);
-
-// Or asynchronous: starts the batch and returns a job ID immediately
+// Asynchronous: starts the batch and returns a job ID immediately
 const { id } = await firecrawl.startBatchScrape([
   'https://firecrawl.dev',
   'https://docs.firecrawl.dev'
@@ -20,4 +12,12 @@ const { id } = await firecrawl.startBatchScrape([
 });
 
 const status = await firecrawl.getBatchScrapeStatus(id);
+
+// Or synchronous: starts the batch and waits for completion
+const job = await firecrawl.batchScrape([
+  'https://firecrawl.dev',
+  'https://docs.firecrawl.dev'
+], { options: { formats: ['markdown'] }, pollInterval: 2, timeout: 120 });
+
+console.log(job.status, job.completed, job.total);
 ```

--- a/snippets/v2/batch-scrape/base/python.mdx
+++ b/snippets/v2/batch-scrape/base/python.mdx
@@ -3,17 +3,19 @@ from firecrawl import Firecrawl
 
 firecrawl = Firecrawl(api_key="fc-YOUR-API-KEY")
 
-start = firecrawl.start_batch_scrape([
-    "https://firecrawl.dev",
-    "https://docs.firecrawl.dev",
-], formats=["markdown"])  # returns id
-
+# Synchronous: starts the batch and waits for completion
 job = firecrawl.batch_scrape([
     "https://firecrawl.dev",
     "https://docs.firecrawl.dev",
 ], formats=["markdown"], poll_interval=2, wait_timeout=120)
 
 print(job.status, job.completed, job.total)
+
+# Or asynchronous: starts the batch and returns a job ID immediately
+start = firecrawl.start_batch_scrape([
+    "https://firecrawl.dev",
+    "https://docs.firecrawl.dev",
+], formats=["markdown"])
+
+status = firecrawl.get_batch_scrape_status(start.id)
 ```
-
-

--- a/snippets/v2/batch-scrape/base/python.mdx
+++ b/snippets/v2/batch-scrape/base/python.mdx
@@ -3,19 +3,19 @@ from firecrawl import Firecrawl
 
 firecrawl = Firecrawl(api_key="fc-YOUR-API-KEY")
 
-# Synchronous: starts the batch and waits for completion
-job = firecrawl.batch_scrape([
-    "https://firecrawl.dev",
-    "https://docs.firecrawl.dev",
-], formats=["markdown"], poll_interval=2, wait_timeout=120)
-
-print(job.status, job.completed, job.total)
-
-# Or asynchronous: starts the batch and returns a job ID immediately
+# Asynchronous: starts the batch and returns a job ID immediately
 start = firecrawl.start_batch_scrape([
     "https://firecrawl.dev",
     "https://docs.firecrawl.dev",
 ], formats=["markdown"])
 
 status = firecrawl.get_batch_scrape_status(start.id)
+
+# Or synchronous: starts the batch and waits for completion
+job = firecrawl.batch_scrape([
+    "https://firecrawl.dev",
+    "https://docs.firecrawl.dev",
+], formats=["markdown"], poll_interval=2, wait_timeout=120)
+
+print(job.status, job.completed, job.total)
 ```


### PR DESCRIPTION
## Problem

The Basic usage example on [/features/batch-scrape](https://docs.firecrawl.dev/features/batch-scrape) reads as a two-step flow — "Start a batch scrape job" then "Wait for completion" — implying you must call `startBatchScrape` before `batchScrape`. They're actually independent alternatives, and the example never uses the `id` it gets back. Copying it verbatim starts **two separate jobs** and scrapes every URL twice.

https://github.com/user-attachments/assets/963d0986-317d-46a0-9de6-f7197176f48c


## Fix

Relabel the two calls as synchronous/asynchronous alternatives (matching the table above the example), put the one-call `batchScrape` first, and have the async branch actually use the job ID with `getBatchScrapeStatus` / `get_batch_scrape_status`. Applied to both the Node and Python snippets.

## Before

![before](https://raw.githubusercontent.com/firecrawl/firecrawl-docs/pr-1046-assets/pr-1046-before.png)

## After

![after](https://raw.githubusercontent.com/firecrawl/firecrawl-docs/pr-1046-assets/pr-1046-after.png)

_Screenshots are hosted on the `pr-1046-assets` branch — delete it after merge._

🤖 Generated with [Claude Code](https://claude.com/claude-code)