### PR TITLE
[codex] Add research index docs

### DIFF
--- a/api-reference/endpoint/research-github-search.mdx
+++ b/api-reference/endpoint/research-github-search.mdx
@@ -1,0 +1,8 @@
+---
+title: "Search GitHub History"
+openapi: "/api-reference/v2-openapi.json GET /search/research/github"
+---
+
+Search GitHub issue/PR history, discussions, and repository READMEs. Results include repository metadata, URLs, snippets, and matched markdown content when available.
+
+For a workflow overview, see the [Research Index guide](/features/research).

--- a/api-reference/endpoint/research-paper.mdx
+++ b/api-reference/endpoint/research-paper.mdx
@@ -1,0 +1,10 @@
+---
+title: "Inspect or Read Paper"
+openapi: "/api-reference/v2-openapi.json GET /search/research/papers/{id}"
+---
+
+Inspect paper metadata by id, or add a `query` parameter to read the most relevant full-text passages for a question.
+
+Accepted ids include canonical `paperId`, `primaryId` values such as `arxiv:1706.03762`, bare arXiv ids, and arXiv URLs.
+
+For a workflow overview, see the [Research Index guide](/features/research).

--- a/api-reference/endpoint/research-paper.mdx
+++ b/api-reference/endpoint/research-paper.mdx
@@ -5,6 +5,6 @@ openapi: "/api-reference/v2-openapi.json GET /search/research/papers/{id}"
 
 Inspect paper metadata by id, or add a `query` parameter to read the most relevant full-text passages for a question.
 
-Accepted ids include canonical `paperId`, `primaryId` values such as `arxiv:1706.03762`, bare arXiv ids, and arXiv URLs.
+Accepted ids include canonical `paperId` values and source-specific `primaryId` values (e.g. `arxiv:1706.03762`).
 
 For a workflow overview, see the [Research Index guide](/features/research).

--- a/api-reference/endpoint/research-related-papers.mdx
+++ b/api-reference/endpoint/research-related-papers.mdx
@@ -1,0 +1,8 @@
+---
+title: "Find Related Papers"
+openapi: "/api-reference/v2-openapi.json GET /search/research/papers/{id}/similar"
+---
+
+Expand from a seed paper through the citation graph and rank candidate papers against a natural-language `intent`. Use `mode` to choose similar papers, citers, or references.
+
+For a workflow overview, see the [Research Index guide](/features/research).

--- a/api-reference/endpoint/research-related-papers.mdx
+++ b/api-reference/endpoint/research-related-papers.mdx
@@ -3,6 +3,6 @@ title: "Find Related Papers"
 openapi: "/api-reference/v2-openapi.json GET /search/research/papers/{id}/similar"
 ---
 
-Expand from a seed paper through the citation graph and rank candidate papers against a natural-language `intent`. Use `mode` to choose similar papers, citers, or references.
+Expand from a seed paper through structural expansion and rank candidate papers against a natural-language `intent`. Use `mode` to choose similar papers, citers, or references.
 
 For a workflow overview, see the [Research Index guide](/features/research).

--- a/api-reference/endpoint/research-search-papers.mdx
+++ b/api-reference/endpoint/research-search-papers.mdx
@@ -3,6 +3,6 @@ title: "Search Papers"
 openapi: "/api-reference/v2-openapi.json GET /search/research/papers"
 ---
 
-Search arXiv papers by topic, method, benchmark, author, or category. Results include canonical `paperId`, preferred `primaryId`, source ids, title, abstract, score, and optional ranking signals.
+Search papers by topic, method, benchmark, author, or category. Results include canonical `paperId`, preferred `primaryId`, source ids, title, abstract, score, and optional ranking signals.
 
 For a workflow overview, see the [Research Index guide](/features/research).

--- a/api-reference/endpoint/research-search-papers.mdx
+++ b/api-reference/endpoint/research-search-papers.mdx
@@ -1,0 +1,8 @@
+---
+title: "Search Papers"
+openapi: "/api-reference/v2-openapi.json GET /search/research/papers"
+---
+
+Search arXiv papers by topic, method, benchmark, author, or category. Results include canonical `paperId`, preferred `primaryId`, source ids, title, abstract, score, and optional ranking signals.
+
+For a workflow overview, see the [Research Index guide](/features/research).

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -4737,7 +4737,7 @@
     },
     "/search/research/papers": {
       "get": {
-        "summary": "Search arXiv papers",
+        "summary": "Search papers",
         "operationId": "researchSearchPapers",
         "tags": [
           "Research"
@@ -4783,7 +4783,7 @@
             "name": "categories",
             "in": "query",
             "required": false,
-            "description": "arXiv category filter. Repeat or pass a comma-separated value; all filters must match.",
+            "description": "Paper category filter. Repeat or pass a comma-separated value; all filters must match.",
             "schema": {
               "type": "string"
             }
@@ -4869,7 +4869,7 @@
             "name": "id",
             "in": "path",
             "required": true,
-            "description": "Paper reference: a canonical paperId, an id-key such as arxiv:<id>, a bare arXiv id, or an arXiv URL.",
+            "description": "Paper reference: a canonical paperId or source-specific primaryId.",
             "schema": {
               "type": "string"
             },
@@ -4878,13 +4878,9 @@
                 "summary": "Canonical paperId",
                 "value": "2014215642691656232"
               },
-              "arxiv": {
-                "summary": "arXiv id-key",
+              "sourceId": {
+                "summary": "Source-specific primaryId",
                 "value": "arxiv:2105.05233"
-              },
-              "bareArxiv": {
-                "summary": "Bare arXiv id",
-                "value": "2105.05233"
               }
             }
           },
@@ -4992,13 +4988,9 @@
                 "summary": "Canonical paperId",
                 "value": "2014215642691656232"
               },
-              "arxiv": {
-                "summary": "arXiv id-key",
+              "sourceId": {
+                "summary": "Source-specific primaryId",
                 "value": "arxiv:2105.05233"
-              },
-              "bareArxiv": {
-                "summary": "Bare arXiv id",
-                "value": "2105.05233"
               }
             }
           },
@@ -5016,7 +5008,7 @@
             "name": "mode",
             "in": "query",
             "required": false,
-            "description": "Citation-graph expansion mode.",
+            "description": "Structural expansion mode.",
             "schema": {
               "type": "string",
               "enum": [
@@ -8235,7 +8227,7 @@
       },
       "ResearchIdMap": {
         "type": "object",
-        "description": "Source identifiers grouped by namespace. arXiv ids appear under arxiv.",
+        "description": "Source identifiers grouped by namespace.",
         "additionalProperties": {
           "type": "array",
           "items": {
@@ -8270,7 +8262,7 @@
           "articleRank": {
             "type": "number",
             "format": "double",
-            "description": "Citation-graph article-rank score."
+            "description": "Structural expansion article-rank score."
           },
           "seedOverlap": {
             "type": "integer",
@@ -8345,7 +8337,7 @@
             "items": {
               "type": "string"
             },
-            "description": "arXiv categories."
+            "description": "Paper categories."
           },
           "createdDate": {
             "type": "string",

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -1732,7 +1732,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "description": "URL pathname regex patterns that include matching URLs in the crawl. Only the paths that match the specified patterns will be included in the response. Note: the starting URL is also checked against these patterns \u2014 if it does not match, the crawl may return 0 pages. For example, if you set \"includePaths\": [\"blog/.*\"] for the base URL firecrawl.dev/blog, only pages under /blog/ will be included in the results, such as https://www.firecrawl.dev/blog/firecrawl-launch-week-1-recap."
+                    "description": "URL pathname regex patterns that include matching URLs in the crawl. Only the paths that match the specified patterns will be included in the response. Note: the starting URL is also checked against these patterns — if it does not match, the crawl may return 0 pages. For example, if you set \"includePaths\": [\"blog/.*\"] for the base URL firecrawl.dev/blog, only pages under /blog/ will be included in the results, such as https://www.firecrawl.dev/blog/firecrawl-launch-week-1-recap."
                   },
                   "maxDiscoveryDepth": {
                     "type": "integer",
@@ -1765,7 +1765,7 @@
                   },
                   "crawlEntireDomain": {
                     "type": "boolean",
-                    "description": "Allows the crawler to follow internal links to sibling or parent URLs, not just child paths.\n\nfalse: Only crawls deeper (child) URLs.\n\u2192 e.g. /features/feature-1 \u2192 /features/feature-1/tips \u2705\n\u2192 Won't follow /pricing or / \u274c\n\ntrue: Crawls any internal links, including siblings and parents.\n\u2192 e.g. /features/feature-1 \u2192 /pricing, /, etc. \u2705\n\nUse true for broader internal coverage beyond nested paths.",
+                    "description": "Allows the crawler to follow internal links to sibling or parent URLs, not just child paths.\n\nfalse: Only crawls deeper (child) URLs.\n→ e.g. /features/feature-1 → /features/feature-1/tips ✅\n→ Won't follow /pricing or / ❌\n\ntrue: Crawls any internal links, including siblings and parents.\n→ e.g. /features/feature-1 → /pricing, /, etc. ✅\n\nUse true for broader internal coverage beyond nested paths.",
                     "default": false
                   },
                   "allowExternalLinks": {
@@ -1780,12 +1780,12 @@
                   },
                   "ignoreRobotsTxt": {
                     "type": "boolean",
-                    "description": "Ignore the website's robots.txt rules. Enterprise only \u2014 contact support@firecrawl.com to enable.",
+                    "description": "Ignore the website's robots.txt rules. Enterprise only — contact support@firecrawl.com to enable.",
                     "default": false
                   },
                   "robotsUserAgent": {
                     "type": "string",
-                    "description": "Custom User-Agent string for robots.txt evaluation. When set, robots.txt is fetched with this User-Agent and allow/disallow rules are matched against it instead of the default. Enterprise only \u2014 contact support@firecrawl.com to enable."
+                    "description": "Custom User-Agent string for robots.txt evaluation. When set, robots.txt is fetched with this User-Agent and allow/disallow rules are matched against it instead of the default. Enterprise only — contact support@firecrawl.com to enable."
                   },
                   "delay": {
                     "type": "number",
@@ -4731,6 +4731,461 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/search/research/papers": {
+      "get": {
+        "summary": "Search arXiv papers",
+        "operationId": "researchSearchPapers",
+        "tags": [
+          "Research"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "description": "Natural-language paper search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "name": "k",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of ranked papers to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500,
+              "default": 40
+            }
+          },
+          {
+            "name": "authors",
+            "in": "query",
+            "required": false,
+            "description": "Author substring filter. Repeat or pass a comma-separated value; all filters must match.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "categories",
+            "in": "query",
+            "required": false,
+            "description": "arXiv category filter. Repeat or pass a comma-separated value; all filters must match.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": false,
+            "description": "Inclusive lower bound on created/updated date.",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": false,
+            "description": "Inclusive upper bound on created/updated date.",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ranked paper results.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResearchSearchPapersResponse"
+                },
+                "example": {
+                  "success": true,
+                  "results": [
+                    {
+                      "paperId": "2014215642691656232",
+                      "primaryId": "arxiv:2105.05233",
+                      "ids": {
+                        "arxiv": [
+                          "2105.05233"
+                        ]
+                      },
+                      "title": "Diffusion Models Beat GANs on Image Synthesis",
+                      "abstract": "We show that diffusion models can achieve image sample quality superior to the current state-of-the-art generative models...",
+                      "score": 0.0163934
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Missing or invalid bearer token"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/search/research/papers/{id}": {
+      "get": {
+        "summary": "Inspect or read a paper",
+        "operationId": "researchGetPaper",
+        "tags": [
+          "Research"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Paper reference: a canonical paperId, an id-key such as arxiv:<id>, a bare arXiv id, or an arXiv URL.",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "paperId": {
+                "summary": "Canonical paperId",
+                "value": "2014215642691656232"
+              },
+              "arxiv": {
+                "summary": "arXiv id-key",
+                "value": "arxiv:2105.05233"
+              },
+              "bareArxiv": {
+                "summary": "Bare arXiv id",
+                "value": "2105.05233"
+              }
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "description": "When present, returns the top matching full-text passages for this question. Omit it to inspect metadata only.",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "name": "k",
+            "in": "query",
+            "required": false,
+            "description": "Passage count for read mode. Only valid when query is present.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 4
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paper metadata or read-mode passages.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ResearchPaperMetadataResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ResearchReadPaperResponse"
+                    }
+                  ]
+                },
+                "example": {
+                  "success": true,
+                  "paper": {
+                    "paperId": "2014215642691656232",
+                    "ids": {
+                      "arxiv": [
+                        "2105.05233"
+                      ]
+                    },
+                    "title": "Diffusion Models Beat GANs on Image Synthesis",
+                    "abstract": "We show that diffusion models can achieve image sample quality superior to the current state-of-the-art generative models...",
+                    "authors": "Prafulla Dhariwal, Alexander Nichol",
+                    "categories": [
+                      "cs.LG"
+                    ],
+                    "createdDate": "Wed, 11 May 2021 18:01:01 GMT",
+                    "updateDate": "2021-06-01"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Missing or invalid bearer token"
+          },
+          "404": {
+            "description": "Paper not found"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/search/research/papers/{id}/similar": {
+      "get": {
+        "summary": "Find related papers",
+        "operationId": "researchRelatedPapers",
+        "tags": [
+          "Research"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Primary seed paper reference.",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "paperId": {
+                "summary": "Canonical paperId",
+                "value": "2014215642691656232"
+              },
+              "arxiv": {
+                "summary": "arXiv id-key",
+                "value": "arxiv:2105.05233"
+              },
+              "bareArxiv": {
+                "summary": "Bare arXiv id",
+                "value": "2105.05233"
+              }
+            }
+          },
+          {
+            "name": "intent",
+            "in": "query",
+            "required": true,
+            "description": "Natural-language ranking/filtering intent used for semantic ranking.",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "name": "mode",
+            "in": "query",
+            "required": false,
+            "description": "Citation-graph expansion mode.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "similar",
+                "citers",
+                "references"
+              ],
+              "default": "similar"
+            }
+          },
+          {
+            "name": "k",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of related papers to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500,
+              "default": 40
+            }
+          },
+          {
+            "name": "rerank",
+            "in": "query",
+            "required": false,
+            "description": "Apply an additional rerank over fused candidates.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "anchor",
+            "in": "query",
+            "required": false,
+            "description": "Additional seed paper reference. Repeat this parameter for multiple anchors.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ranked related papers.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResearchSimilarPapersResponse"
+                },
+                "example": {
+                  "success": true,
+                  "results": [
+                    {
+                      "paperId": "482107036680302043",
+                      "primaryId": "arxiv:2006.11239",
+                      "ids": {
+                        "arxiv": [
+                          "2006.11239"
+                        ]
+                      },
+                      "title": "Denoising Diffusion Probabilistic Models",
+                      "abstract": "We present high quality image synthesis results using diffusion probabilistic models...",
+                      "score": 0.032119,
+                      "signals": {
+                        "structural": 12,
+                        "semantic": 0.61,
+                        "articleRank": 0.00031,
+                        "seedOverlap": 2
+                      }
+                    }
+                  ],
+                  "poolSize": 40,
+                  "truncated": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Missing or invalid bearer token"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/search/research/github": {
+      "get": {
+        "summary": "Search GitHub history",
+        "operationId": "researchSearchGitHub",
+        "tags": [
+          "Research"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "description": "Natural-language query for GitHub issues, pull requests, discussions, and repository READMEs.",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "name": "k",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of GitHub results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ranked GitHub history/readme results.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResearchGitHubSearchResponse"
+                },
+                "example": {
+                  "success": true,
+                  "results": [
+                    {
+                      "resultType": "issue",
+                      "repo": "firecrawl/firecrawl",
+                      "url": "https://github.com/firecrawl/firecrawl/issues/123",
+                      "pageType": "issue",
+                      "number": 123,
+                      "segmentCount": 2,
+                      "title": "Worker shutdown race",
+                      "snippet": "Queue worker shutdown can lose completion signals...",
+                      "contentMd": "Full matched markdown content when available.",
+                      "scores": {
+                        "semantic": 0.82
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Missing or invalid bearer token"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "description": "Internal server error"
           }
         }
       }
@@ -7777,6 +8232,311 @@
           }
         },
         "additionalProperties": false
+      },
+      "ResearchIdMap": {
+        "type": "object",
+        "description": "Source identifiers grouped by namespace. arXiv ids appear under arxiv.",
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "example": {
+          "arxiv": [
+            "2105.05233"
+          ]
+        }
+      },
+      "ResearchPaperSignals": {
+        "type": "object",
+        "required": [
+          "structural",
+          "semantic",
+          "articleRank",
+          "seedOverlap"
+        ],
+        "properties": {
+          "structural": {
+            "type": "number",
+            "format": "double",
+            "description": "Raw structural graph signal."
+          },
+          "semantic": {
+            "type": "number",
+            "format": "double",
+            "description": "Semantic score from the intent search."
+          },
+          "articleRank": {
+            "type": "number",
+            "format": "double",
+            "description": "Citation-graph article-rank score."
+          },
+          "seedOverlap": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of distinct seeds connected to this candidate."
+          }
+        }
+      },
+      "ResearchPaperResult": {
+        "type": "object",
+        "required": [
+          "paperId",
+          "primaryId",
+          "title",
+          "abstract",
+          "score"
+        ],
+        "properties": {
+          "paperId": {
+            "type": "string",
+            "description": "Canonical paper id, or web:<url> for SERP-discovered display results."
+          },
+          "primaryId": {
+            "type": "string",
+            "description": "Preferred cite/fetch id such as arxiv:<id>, pmid:<id>, pmcid:<id>, or doi:<id>."
+          },
+          "ids": {
+            "$ref": "#/components/schemas/ResearchIdMap"
+          },
+          "title": {
+            "type": "string"
+          },
+          "abstract": {
+            "type": "string"
+          },
+          "score": {
+            "type": "number",
+            "format": "double"
+          },
+          "signals": {
+            "$ref": "#/components/schemas/ResearchPaperSignals"
+          }
+        }
+      },
+      "ResearchPaperMetadata": {
+        "type": "object",
+        "required": [
+          "paperId",
+          "title",
+          "abstract"
+        ],
+        "properties": {
+          "paperId": {
+            "type": "string",
+            "description": "Canonical paper id."
+          },
+          "ids": {
+            "$ref": "#/components/schemas/ResearchIdMap"
+          },
+          "title": {
+            "type": "string"
+          },
+          "abstract": {
+            "type": "string"
+          },
+          "authors": {
+            "type": "string",
+            "description": "Comma-joined author names."
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "arXiv categories."
+          },
+          "createdDate": {
+            "type": "string",
+            "description": "Original creation date string."
+          },
+          "updateDate": {
+            "type": "string",
+            "description": "Last-updated date string."
+          }
+        }
+      },
+      "ResearchPassage": {
+        "type": "object",
+        "required": [
+          "text",
+          "score"
+        ],
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "In-body passage text. May include markdown tables."
+          },
+          "score": {
+            "type": "number",
+            "format": "double",
+            "description": "Dense similarity score for the passage."
+          }
+        }
+      },
+      "ResearchSearchPapersResponse": {
+        "type": "object",
+        "required": [
+          "success",
+          "results"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResearchPaperResult"
+            }
+          }
+        }
+      },
+      "ResearchPaperMetadataResponse": {
+        "type": "object",
+        "required": [
+          "success",
+          "paper"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "paper": {
+            "$ref": "#/components/schemas/ResearchPaperMetadata"
+          }
+        }
+      },
+      "ResearchReadPaperResponse": {
+        "type": "object",
+        "required": [
+          "success",
+          "paper",
+          "paperId",
+          "query",
+          "passages"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "paper": {
+            "$ref": "#/components/schemas/ResearchPaperMetadata"
+          },
+          "paperId": {
+            "type": "string"
+          },
+          "query": {
+            "type": "string"
+          },
+          "passages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResearchPassage"
+            }
+          }
+        }
+      },
+      "ResearchSimilarPapersResponse": {
+        "type": "object",
+        "required": [
+          "success",
+          "results",
+          "poolSize",
+          "truncated"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResearchPaperResult"
+            }
+          },
+          "poolSize": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "truncated": {
+            "type": "boolean"
+          },
+          "note": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "ResearchGitHubScoreBreakdown": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "number"
+        },
+        "description": "Component scores such as semantic, lexical, fusion, rrf, or rerank."
+      },
+      "ResearchGitHubItem": {
+        "type": "object",
+        "properties": {
+          "resultType": {
+            "type": "string",
+            "description": "Result class, such as issue, pull, discussion, or repo_readme."
+          },
+          "repo": {
+            "type": "string",
+            "description": "Repository in owner/name form."
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "pageType": {
+            "type": "string",
+            "description": "History page type for issue/PR/discussion results."
+          },
+          "number": {
+            "type": "integer"
+          },
+          "segmentCount": {
+            "type": "integer"
+          },
+          "readmeUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "snippet": {
+            "type": "string"
+          },
+          "contentMd": {
+            "type": "string",
+            "description": "Full matched markdown content when available."
+          },
+          "scores": {
+            "$ref": "#/components/schemas/ResearchGitHubScoreBreakdown"
+          }
+        }
+      },
+      "ResearchGitHubSearchResponse": {
+        "type": "object",
+        "required": [
+          "success",
+          "results"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResearchGitHubItem"
+            }
+          }
+        }
       }
     }
   },

--- a/docs.json
+++ b/docs.json
@@ -144,7 +144,14 @@
                   {
                     "group": "Core Endpoints",
                     "pages": [
-                      "features/search",
+                      {
+                        "group": "Search",
+                        "icon": "magnifying-glass",
+                        "pages": [
+                          "features/search",
+                          "features/research"
+                        ]
+                      },
                       {
                         "group": "Scrape",
                         "icon": "markdown",
@@ -415,6 +422,15 @@
                     "group": "Search Endpoints",
                     "pages": [
                       "api-reference/endpoint/search"
+                    ]
+                  },
+                  {
+                    "group": "Research Endpoints",
+                    "pages": [
+                      "api-reference/endpoint/research-search-papers",
+                      "api-reference/endpoint/research-paper",
+                      "api-reference/endpoint/research-related-papers",
+                      "api-reference/endpoint/research-github-search"
                     ]
                   },
                   {

--- a/docs.json
+++ b/docs.json
@@ -425,15 +425,6 @@
                     ]
                   },
                   {
-                    "group": "Research Endpoints",
-                    "pages": [
-                      "api-reference/endpoint/research-search-papers",
-                      "api-reference/endpoint/research-paper",
-                      "api-reference/endpoint/research-related-papers",
-                      "api-reference/endpoint/research-github-search"
-                    ]
-                  },
-                  {
                     "group": "Scrape Endpoints",
                     "pages": [
                       "api-reference/endpoint/scrape",
@@ -449,6 +440,15 @@
                       "api-reference/endpoint/scrape-execute",
                       "api-reference/endpoint/scrape-browser-delete",
                       "api-reference/endpoint/browser-list"
+                    ]
+                  },
+                  {
+                    "group": "Research Index Endpoints",
+                    "pages": [
+                      "api-reference/endpoint/research-search-papers",
+                      "api-reference/endpoint/research-paper",
+                      "api-reference/endpoint/research-related-papers",
+                      "api-reference/endpoint/research-github-search"
                     ]
                   },
                   {

--- a/features/research.mdx
+++ b/features/research.mdx
@@ -225,8 +225,6 @@ Modes:
 - `citers`: papers that cite the seed
 - `references`: papers cited by the seed
 
-Pass repeated `anchor` query parameters, or multiple CLI seed ids, to add more seed papers.
-
 ## Search GitHub history
 
 Search GitHub issues, pull requests, discussions, and repository READMEs for implementation details and engineering prior art.

--- a/features/research.mdx
+++ b/features/research.mdx
@@ -15,7 +15,7 @@ Firecrawl Research is a purpose-built index for scientific and engineering resea
 - Search GitHub history and READMEs for implementation notes, bugs, and design discussions
 
 <Note>
-To give your agent access to the Research Index, we strongly recommend using our CLI or MCP, combined with our [**dedicated research skill**](https://github.com/firecrawl/skills/blob/main/skills/firecrawl-research-index/SKILL.md), which you can install with:
+To give your agent access to the Research Index, we strongly recommend using our [CLI](/sdks/cli) or [MCP](/mcp-server), combined with our [**dedicated research skill**](https://github.com/firecrawl/skills/blob/main/skills/firecrawl-research-index/SKILL.md), which you can install with:
 ```bash
 npx skills add firecrawl/skills@firecrawl-research-index
 ```

--- a/features/research.mdx
+++ b/features/research.mdx
@@ -1,23 +1,24 @@
 ---
 title: "Research Index"
-description: "Search arXiv papers, read paper passages, find related work, and search GitHub history"
+description: "Search papers, read paper passages, find related work, and search across related GitHub repos"
 og:title: "Research Index | Firecrawl"
-og:description: "Use Firecrawl's research index for arXiv paper retrieval, citation-graph expansion, paper reading, and GitHub history search."
+og:description: "Use Firecrawl's research index for paper retrieval, semantic expansion, paper reading, and GitHub search."
 icon: "book-open"
 ---
 
-Firecrawl Research is a purpose-built index for scientific and engineering research workflows. It exposes endpoint-specific tools for searching arXiv papers, inspecting paper metadata, reading relevant full-text passages, expanding from seed papers through the citation graph, and searching GitHub issue/PR history plus repository READMEs.
+Firecrawl Research is a purpose-built index for scientific and engineering research agents. It exposes a research-specific toolset for searching papers, inspecting paper metadata, reading relevant full-text passages, discovering related papers through structural expansion, and searching over research-related GitHub repos.
 
-Use it when regular web search is too broad and you need a tighter research loop:
-
-- Find papers by topic, method, benchmark, author, or arXiv category
+- Find papers by topic, method, benchmark, author, or category
 - Inspect canonical paper metadata and source ids
 - Read the passages in one paper that answer a specific question
 - Expand from strong seed papers to related papers, citers, or references
-- Search GitHub history and READMEs for implementation notes, bugs, design discussions, and prior art
+- Search GitHub history and READMEs for implementation notes, bugs, and design discussions
 
 <Note>
-Research endpoints are available under `/v2/search/research/*`. Older `/v2/research/*` paths may continue to work during migration, but new integrations should use the `/v2/search/research/*` paths.
+To give your agent access to the Research Index, we strongly recommend using our CLI or MCP, combined with our [**dedicated research skill**](https://github.com/firecrawl/skills/blob/main/skills/firecrawl-research-index/SKILL.md), which you can install with:
+```bash
+npx skills add firecrawl/skills@firecrawl-research-index
+```
 </Note>
 
 ## Endpoints
@@ -33,60 +34,190 @@ Research endpoints are available under `/v2/search/research/*`. Older `/v2/resea
 
 Search paper abstracts with a natural-language query. The response returns ranked papers with canonical `paperId`, preferred `primaryId`, source ids, title, abstract, score, and optional ranking signals.
 
+<CodeGroup>
+
 ```bash cURL
-curl "https://api.firecrawl.dev/v2/search/research/papers?query=diffusion%20image%20synthesis&k=20" \
-  -H "Authorization: Bearer fc-YOUR_API_KEY"
+# No API key needed to get started; add -H "Authorization: Bearer $FIRECRAWL_API_KEY" for higher rate limits:
+curl -s "https://api.firecrawl.dev/v2/search/research/papers?query=diffusion%20image%20synthesis&k=20"
 ```
 
 ```bash CLI
 firecrawl research search-papers "diffusion image synthesis" --limit 20
 ```
 
+```python Python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(
+  # No API key needed to get started; add one for higher rate limits:
+  # api_key="fc-YOUR-API-KEY",
+)
+
+result = firecrawl.v2.search_papers("diffusion image synthesis", k=20)
+print(result)
+```
+
+```js Node
+import { Firecrawl } from "firecrawl";
+
+const firecrawl = new Firecrawl({
+  // No API key needed to get started; add one for higher rate limits:
+  // apiKey: "fc-YOUR-API-KEY",
+});
+
+const result = await firecrawl.research.searchPapers("diffusion image synthesis", {
+  k: 20,
+});
+console.log(result);
+```
+
+</CodeGroup>
+
 Optional filters:
 
 - `authors`: author substring filter; all filters must match
-- `categories`: arXiv category filter, such as `cs.LG`
+- `categories`: paper category filter, such as `cs.LG`
 - `from`: inclusive created/updated lower bound, `YYYY-MM-DD`
 - `to`: inclusive created/updated upper bound, `YYYY-MM-DD`
 
 ## Inspect a paper
 
-Use a canonical `paperId`, a `primaryId` like `arxiv:1706.03762`, a bare arXiv id, or an arXiv URL.
+Use a canonical `paperId` or a source-specific `primaryId`.
+
+<CodeGroup>
 
 ```bash cURL
-curl "https://api.firecrawl.dev/v2/search/research/papers/arxiv%3A1706.03762" \
-  -H "Authorization: Bearer fc-YOUR_API_KEY"
+# No API key needed to get started; add -H "Authorization: Bearer $FIRECRAWL_API_KEY" for higher rate limits:
+curl -s "https://api.firecrawl.dev/v2/search/research/papers/arxiv:1706.03762"
 ```
 
 ```bash CLI
 firecrawl research inspect-paper arxiv:1706.03762
 ```
 
+```python Python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(
+  # No API key needed to get started; add one for higher rate limits:
+  # api_key="fc-YOUR-API-KEY",
+)
+
+paper = firecrawl.v2.inspect_paper("arxiv:1706.03762")
+print(paper)
+```
+
+```js Node
+import { Firecrawl } from "firecrawl";
+
+const firecrawl = new Firecrawl({
+  // No API key needed to get started; add one for higher rate limits:
+  // apiKey: "fc-YOUR-API-KEY",
+});
+
+const paper = await firecrawl.research.getPaper("arxiv:1706.03762");
+console.log(paper);
+```
+
+</CodeGroup>
+
 ## Read paper passages
 
 Add `query` to the same paper path to retrieve the top full-text passages for a question. This is useful for verifying whether a candidate paper actually contains a method, dataset, constraint, or result before you include it.
 
+<CodeGroup>
+
 ```bash cURL
-curl "https://api.firecrawl.dev/v2/search/research/papers/arxiv%3A1706.03762?query=what%20is%20the%20attention%20mechanism&k=4" \
-  -H "Authorization: Bearer fc-YOUR_API_KEY"
+# No API key needed to get started; add -H "Authorization: Bearer $FIRECRAWL_API_KEY" for higher rate limits:
+curl -s "https://api.firecrawl.dev/v2/search/research/papers/arxiv:1706.03762?query=what%20is%20the%20attention%20mechanism&k=4"
 ```
 
 ```bash CLI
 firecrawl research read-paper arxiv:1706.03762 --question "What is the attention mechanism?" --limit 4
 ```
 
+```python Python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(
+  # No API key needed to get started; add one for higher rate limits:
+  # api_key="fc-YOUR-API-KEY",
+)
+
+passages = firecrawl.v2.read_paper(
+    "arxiv:1706.03762",
+    "What is the attention mechanism?",
+    k=4,
+)
+print(passages)
+```
+
+```js Node
+import { Firecrawl } from "firecrawl";
+
+const firecrawl = new Firecrawl({
+  // No API key needed to get started; add one for higher rate limits:
+  // apiKey: "fc-YOUR-API-KEY",
+});
+
+const passages = await firecrawl.research.getPaper("arxiv:1706.03762", {
+  query: "What is the attention mechanism?",
+  k: 4,
+});
+console.log(passages);
+```
+
+</CodeGroup>
+
 ## Find related papers
 
-Expand from one or more seed papers through citation-graph structure and rank the candidates against a natural-language `intent`.
+Expand from one or more seed papers through semantic expansion and rank the candidates against a natural-language `intent`.
+
+<CodeGroup>
 
 ```bash cURL
-curl "https://api.firecrawl.dev/v2/search/research/papers/arxiv%3A1706.03762/similar?intent=efficient%20transformers&mode=similar&k=20" \
-  -H "Authorization: Bearer fc-YOUR_API_KEY"
+# No API key needed to get started; add -H "Authorization: Bearer $FIRECRAWL_API_KEY" for higher rate limits:
+curl -s "https://api.firecrawl.dev/v2/search/research/papers/arxiv:1706.03762/similar?intent=efficient%20transformers&mode=similar&k=20"
 ```
 
 ```bash CLI
 firecrawl research related-papers arxiv:1706.03762 --intent "efficient transformers" --limit 20
 ```
+
+```python Python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(
+  # No API key needed to get started; add one for higher rate limits:
+  # api_key="fc-YOUR-API-KEY",
+)
+
+papers = firecrawl.v2.related_papers(
+    "arxiv:1706.03762",
+    "efficient transformers",
+    mode="similar",
+    k=20,
+)
+print(papers)
+```
+
+```js Node
+import { Firecrawl } from "firecrawl";
+
+const firecrawl = new Firecrawl({
+  // No API key needed to get started; add one for higher rate limits:
+  // apiKey: "fc-YOUR-API-KEY",
+});
+
+const papers = await firecrawl.research.similarPapers("arxiv:1706.03762", {
+  intent: "efficient transformers",
+  mode: "similar",
+  k: 20,
+});
+console.log(papers);
+```
+
+</CodeGroup>
 
 Modes:
 
@@ -100,24 +231,44 @@ Pass repeated `anchor` query parameters, or multiple CLI seed ids, to add more s
 
 Search GitHub issues, pull requests, discussions, and repository READMEs for implementation details and engineering prior art.
 
+<CodeGroup>
+
 ```bash cURL
-curl "https://api.firecrawl.dev/v2/search/research/github?query=foundationdb%20queue%20worker%20shutdown&k=10" \
-  -H "Authorization: Bearer fc-YOUR_API_KEY"
+# No API key needed to get started; add -H "Authorization: Bearer $FIRECRAWL_API_KEY" for higher rate limits:
+curl -s "https://api.firecrawl.dev/v2/search/research/github?query=flash%20attention%20implementation%20notes&k=10"
 ```
 
 ```bash CLI
-firecrawl research search-github "foundationdb queue worker shutdown" --limit 10
+firecrawl research search-github "flash attention implementation notes" --limit 10
 ```
 
+```python Python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(
+  # No API key needed to get started; add one for higher rate limits:
+  # api_key="fc-YOUR-API-KEY",
+)
+
+results = firecrawl.v2.search_github("flash attention implementation notes", k=10)
+print(results)
+```
+
+```js Node
+import { Firecrawl } from "firecrawl";
+
+const firecrawl = new Firecrawl({
+  // No API key needed to get started; add one for higher rate limits:
+  // apiKey: "fc-YOUR-API-KEY",
+});
+
+const results = await firecrawl.research.searchGithub(
+  "flash attention implementation notes",
+  { k: 10 },
+);
+console.log(results);
+```
+
+</CodeGroup>
+
 GitHub results include repository, URL, issue/PR metadata when available, snippet, and matched markdown content when available.
-
-## Response shape
-
-Research responses use camelCase field names:
-
-- Paper ids: `paperId`, `primaryId`
-- Dates: `createdDate`, `updateDate`
-- Similarity signals: `articleRank`, `seedOverlap`
-- Related-papers metadata: `poolSize`
-
-The `abstract` field remains named `abstract`.

--- a/features/research.mdx
+++ b/features/research.mdx
@@ -1,0 +1,123 @@
+---
+title: "Research Index"
+description: "Search arXiv papers, read paper passages, find related work, and search GitHub history"
+og:title: "Research Index | Firecrawl"
+og:description: "Use Firecrawl's research index for arXiv paper retrieval, citation-graph expansion, paper reading, and GitHub history search."
+icon: "book-open"
+---
+
+Firecrawl Research is a purpose-built index for scientific and engineering research workflows. It exposes endpoint-specific tools for searching arXiv papers, inspecting paper metadata, reading relevant full-text passages, expanding from seed papers through the citation graph, and searching GitHub issue/PR history plus repository READMEs.
+
+Use it when regular web search is too broad and you need a tighter research loop:
+
+- Find papers by topic, method, benchmark, author, or arXiv category
+- Inspect canonical paper metadata and source ids
+- Read the passages in one paper that answer a specific question
+- Expand from strong seed papers to related papers, citers, or references
+- Search GitHub history and READMEs for implementation notes, bugs, design discussions, and prior art
+
+<Note>
+Research endpoints are available under `/v2/search/research/*`. Older `/v2/research/*` paths may continue to work during migration, but new integrations should use the `/v2/search/research/*` paths.
+</Note>
+
+## Endpoints
+
+| Task | Endpoint |
+| --- | --- |
+| Search papers | [`GET /search/research/papers`](/api-reference/endpoint/research-search-papers) |
+| Inspect metadata or read passages | [`GET /search/research/papers/{id}`](/api-reference/endpoint/research-paper) |
+| Find related papers | [`GET /search/research/papers/{id}/similar`](/api-reference/endpoint/research-related-papers) |
+| Search GitHub history | [`GET /search/research/github`](/api-reference/endpoint/research-github-search) |
+
+## Search papers
+
+Search paper abstracts with a natural-language query. The response returns ranked papers with canonical `paperId`, preferred `primaryId`, source ids, title, abstract, score, and optional ranking signals.
+
+```bash cURL
+curl "https://api.firecrawl.dev/v2/search/research/papers?query=diffusion%20image%20synthesis&k=20" \
+  -H "Authorization: Bearer fc-YOUR_API_KEY"
+```
+
+```bash CLI
+firecrawl research search-papers "diffusion image synthesis" --limit 20
+```
+
+Optional filters:
+
+- `authors`: author substring filter; all filters must match
+- `categories`: arXiv category filter, such as `cs.LG`
+- `from`: inclusive created/updated lower bound, `YYYY-MM-DD`
+- `to`: inclusive created/updated upper bound, `YYYY-MM-DD`
+
+## Inspect a paper
+
+Use a canonical `paperId`, a `primaryId` like `arxiv:1706.03762`, a bare arXiv id, or an arXiv URL.
+
+```bash cURL
+curl "https://api.firecrawl.dev/v2/search/research/papers/arxiv%3A1706.03762" \
+  -H "Authorization: Bearer fc-YOUR_API_KEY"
+```
+
+```bash CLI
+firecrawl research inspect-paper arxiv:1706.03762
+```
+
+## Read paper passages
+
+Add `query` to the same paper path to retrieve the top full-text passages for a question. This is useful for verifying whether a candidate paper actually contains a method, dataset, constraint, or result before you include it.
+
+```bash cURL
+curl "https://api.firecrawl.dev/v2/search/research/papers/arxiv%3A1706.03762?query=what%20is%20the%20attention%20mechanism&k=4" \
+  -H "Authorization: Bearer fc-YOUR_API_KEY"
+```
+
+```bash CLI
+firecrawl research read-paper arxiv:1706.03762 --question "What is the attention mechanism?" --limit 4
+```
+
+## Find related papers
+
+Expand from one or more seed papers through citation-graph structure and rank the candidates against a natural-language `intent`.
+
+```bash cURL
+curl "https://api.firecrawl.dev/v2/search/research/papers/arxiv%3A1706.03762/similar?intent=efficient%20transformers&mode=similar&k=20" \
+  -H "Authorization: Bearer fc-YOUR_API_KEY"
+```
+
+```bash CLI
+firecrawl research related-papers arxiv:1706.03762 --intent "efficient transformers" --limit 20
+```
+
+Modes:
+
+- `similar`: co-citation and bibliographic-coupling neighborhood
+- `citers`: papers that cite the seed
+- `references`: papers cited by the seed
+
+Pass repeated `anchor` query parameters, or multiple CLI seed ids, to add more seed papers.
+
+## Search GitHub history
+
+Search GitHub issues, pull requests, discussions, and repository READMEs for implementation details and engineering prior art.
+
+```bash cURL
+curl "https://api.firecrawl.dev/v2/search/research/github?query=foundationdb%20queue%20worker%20shutdown&k=10" \
+  -H "Authorization: Bearer fc-YOUR_API_KEY"
+```
+
+```bash CLI
+firecrawl research search-github "foundationdb queue worker shutdown" --limit 10
+```
+
+GitHub results include repository, URL, issue/PR metadata when available, snippet, and matched markdown content when available.
+
+## Response shape
+
+Research responses use camelCase field names:
+
+- Paper ids: `paperId`, `primaryId`
+- Dates: `createdDate`, `updateDate`
+- Similarity signals: `articleRank`, `seedOverlap`
+- Related-papers metadata: `poolSize`
+
+The `abstract` field remains named `abstract`.


### PR DESCRIPTION
## Summary
- Add a standalone Research Index guide under Core Endpoints
- Add v2 OpenAPI paths and schemas for /search/research paper and GitHub endpoints
- Add English API reference wrapper pages for the new research endpoints
- Register the English docs and API Reference nav entries

## Notes
Only English/source docs were edited. Localized pages were not created or modified.

## Validation
- JSON parse check for docs.json and api-reference/v2-openapi.json
- OpenAPI local $ref check
- git diff --check