### PR TITLE
docs(interact): document cdpUrl in the interact response

### DIFF
--- a/api-reference/endpoint/scrape-execute.mdx
+++ b/api-reference/endpoint/scrape-execute.mdx
@@ -35,6 +35,7 @@ When you are done, call `DELETE /v2/scrape/{jobId}/interact` to stop the session
 | Field | Type | Description |
 |-------|------|-------------|
 | `success` | boolean | Whether the execution completed without errors |
+| `cdpUrl` | string | Raw Chrome DevTools Protocol (CDP) WebSocket URL for the browser session. Connect directly with Playwright, Puppeteer, or any CDP client |
 | `liveViewUrl` | string | Read-only live view URL for the browser session |
 | `interactiveLiveViewUrl` | string | Interactive live view URL (viewers can control the browser) |
 | `output` | string | AI agent's final response (only present when using `prompt`) |
@@ -63,6 +64,7 @@ curl -X POST "https://api.firecrawl.dev/v2/scrape/550e8400-e29b-41d4-a716-446655
 ```json
 {
   "success": true,
+  "cdpUrl": "wss://browser.firecrawl.dev/...",
   "liveViewUrl": "https://liveview.firecrawl.dev/...",
   "interactiveLiveViewUrl": "https://liveview.firecrawl.dev/...",
   "stdout": "",
@@ -90,6 +92,7 @@ curl -X POST "https://api.firecrawl.dev/v2/scrape/550e8400-e29b-41d4-a716-446655
 ```json
 {
   "success": true,
+  "cdpUrl": "wss://browser.firecrawl.dev/...",
   "liveViewUrl": "https://liveview.firecrawl.dev/...",
   "interactiveLiveViewUrl": "https://liveview.firecrawl.dev/...",
   "output": "The Pro plan costs $49/month and includes unlimited scrapes, priority support, and custom integrations.",

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -645,6 +645,26 @@
                     "success": {
                       "type": "boolean"
                     },
+                    "cdpUrl": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Raw Chrome DevTools Protocol (CDP) WebSocket URL for the browser session. Use it to connect directly with Playwright, Puppeteer, or any CDP client."
+                    },
+                    "liveViewUrl": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Read-only live view URL for the browser session"
+                    },
+                    "interactiveLiveViewUrl": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Interactive live view URL (viewers can control the browser)"
+                    },
+                    "output": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "AI agent's final response (only present when using prompt)"
+                    },
                     "stdout": {
                       "type": "string",
                       "nullable": true,

--- a/features/interact.mdx
+++ b/features/interact.mdx
@@ -172,6 +172,7 @@ Every interact response returns a `liveViewUrl` that you can embed to watch the 
 ```json Response
 {
   "success": true,
+  "cdpUrl": "wss://browser.firecrawl.dev/...",
   "liveViewUrl": "https://liveview.firecrawl.dev/...",
   "interactiveLiveViewUrl": "https://liveview.firecrawl.dev/...",
   "stdout": "",
@@ -190,6 +191,18 @@ The response also includes an `interactiveLiveViewUrl`. Unlike the standard live
 
 ```html
 <iframe src="INTERACTIVE_LIVE_VIEW_URL" width="100%" height="600" />
+```
+
+### CDP URL
+
+Every interact response also returns a `cdpUrl` — the raw Chrome DevTools Protocol (CDP) WebSocket URL for the browser session. Use it to connect to the live session directly from Playwright, Puppeteer, or any CDP client and drive the browser with your own code.
+
+```js
+import { chromium } from "playwright";
+
+const browser = await chromium.connectOverCDP(cdpUrl);
+const context = browser.contexts()[0];
+const page = context.pages()[0];
 ```
 
 ## Session Lifecycle
@@ -406,6 +419,7 @@ Profiles created through the API may not appear in Dashboard > Interact > Profil
 | Field | Description |
 |-------|-------------|
 | `success` | `true` if the execution completed without errors |
+| `cdpUrl` | Raw Chrome DevTools Protocol (CDP) WebSocket URL for the browser session. Connect directly with Playwright, Puppeteer, or any CDP client |
 | `liveViewUrl` | Read-only live view URL for the browser session |
 | `interactiveLiveViewUrl` | Interactive live view URL (viewers can control the browser) |
 | `output` | The agent's natural language answer to your prompt. Only present when using `prompt`. |

--- a/snippets/v2/interact/response/output.mdx
+++ b/snippets/v2/interact/response/output.mdx
@@ -1,6 +1,7 @@
 ```json Response
 {
   "success": true,
+  "cdpUrl": "wss://browser.firecrawl.dev/...",
   "liveViewUrl": "https://liveview.firecrawl.dev/...",
   "interactiveLiveViewUrl": "https://liveview.firecrawl.dev/...",
   "output": "The iPhone 16 Pro Max (256GB) is priced at $1,199.00.",

--- a/snippets/v2/interact/response/prompt-output.mdx
+++ b/snippets/v2/interact/response/prompt-output.mdx
@@ -1,6 +1,7 @@
 ```json Response
 {
   "success": true,
+  "cdpUrl": "wss://browser.firecrawl.dev/...",
   "liveViewUrl": "https://liveview.firecrawl.dev/...",
   "interactiveLiveViewUrl": "https://liveview.firecrawl.dev/...",
   "output": "Customers are generally positive about battery life. Most reviewers report 8-10 hours of use on a single charge. A few noted it drains faster with heavy multitasking.",


### PR DESCRIPTION
## What

The interact endpoint now returns `cdpUrl` — the raw Chrome DevTools Protocol WebSocket URL for the browser session (API change: firecrawl/firecrawl#3806). This documents it across the docs.

## Changes

- **OpenAPI** (`v2-openapi.json`): add `cdpUrl` to the interact 200 response schema; also backfill `liveViewUrl`, `interactiveLiveViewUrl`, and `output` which were returned but undocumented.
- **API reference** (`scrape-execute.mdx`): add `cdpUrl` to the response field table and both example responses.
- **Feature guide** (`features/interact.mdx`): new "CDP URL" section with a Playwright `connectOverCDP` example, plus the field table and Live View example.
- **Snippets**: add `cdpUrl` to the response examples.

English files only — translations autogenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)