### PR TITLE
docs: add product scrape format (deterministic json variant)

### DIFF
--- a/advanced-scraping-guide.mdx
+++ b/advanced-scraping-guide.mdx
@@ -81,6 +81,7 @@ The `formats` array controls which output types the scraper returns. Default: `[
 | `images` | All images found on the page. |
 | `summary` | An LLM-generated summary of the page content. |
 | `branding` | Extracts brand identity (colors, fonts, typography, spacing, UI components). |
+| `product` | Extracts a structured product (title, price, availability, images, variants) from product pages via multi-source structured data. |
 
 **Object formats**: pass an object with `type` and additional options.
 

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -5659,6 +5659,21 @@
             },
             {
               "type": "object",
+              "title": "Product",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "product"
+                  ]
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            {
+              "type": "object",
               "title": "Audio",
               "description": "Extract audio (MP3) from supported video URLs, e.g. YouTube. Returns a signed GCS URL.",
               "properties": {
@@ -6998,6 +7013,223 @@
                     "description": "Brand personality traits (tone, energy, target audience)."
                   }
                 }
+              },
+              "product": {
+                "type": "object",
+                "nullable": true,
+                "description": "Product information extracted from the page if `product` is in `formats`. Includes title, brand, category, pricing, availability, images, and variants.",
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "description": "The product title."
+                  },
+                  "brand": {
+                    "type": "string",
+                    "description": "The product brand or manufacturer."
+                  },
+                  "category": {
+                    "type": "string",
+                    "description": "The product category, optionally as a breadcrumb path (e.g. 'Electronics > Audio > Headphones')."
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "The canonical URL of the product page."
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "The product description."
+                  },
+                  "images": {
+                    "type": "array",
+                    "description": "Product images.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string",
+                          "description": "Image URL."
+                        },
+                        "alt": {
+                          "type": "string",
+                          "description": "Alternative text for the image."
+                        }
+                      },
+                      "required": [
+                        "url"
+                      ]
+                    }
+                  },
+                  "price": {
+                    "type": "object",
+                    "description": "The current price of the product.",
+                    "properties": {
+                      "amount": {
+                        "type": "number",
+                        "description": "The numeric price amount."
+                      },
+                      "currency": {
+                        "type": "string",
+                        "description": "The ISO 4217 currency code (e.g. 'USD')."
+                      },
+                      "formatted": {
+                        "type": "string",
+                        "description": "The price formatted for display (e.g. '$199.99')."
+                      }
+                    },
+                    "required": [
+                      "amount"
+                    ]
+                  },
+                  "originalPrice": {
+                    "type": "object",
+                    "description": "The original (pre-discount) price of the product.",
+                    "properties": {
+                      "amount": {
+                        "type": "number",
+                        "description": "The numeric price amount."
+                      },
+                      "currency": {
+                        "type": "string",
+                        "description": "The ISO 4217 currency code (e.g. 'USD')."
+                      },
+                      "formatted": {
+                        "type": "string",
+                        "description": "The price formatted for display (e.g. '$249.99')."
+                      }
+                    },
+                    "required": [
+                      "amount"
+                    ]
+                  },
+                  "availability": {
+                    "type": "object",
+                    "description": "The availability of the product.",
+                    "properties": {
+                      "inStock": {
+                        "type": "boolean",
+                        "description": "Whether the product is in stock."
+                      },
+                      "text": {
+                        "type": "string",
+                        "description": "Human-readable availability text (e.g. 'In Stock')."
+                      }
+                    },
+                    "required": [
+                      "inStock"
+                    ]
+                  },
+                  "variants": {
+                    "type": "array",
+                    "description": "Product variants (e.g. different colors or sizes).",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "The variant identifier."
+                        },
+                        "sku": {
+                          "type": "string",
+                          "description": "The variant SKU."
+                        },
+                        "title": {
+                          "type": "string",
+                          "description": "The variant title."
+                        },
+                        "values": {
+                          "type": "object",
+                          "description": "The variant option values (e.g. { \"color\": \"Black\" }).",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "price": {
+                          "type": "object",
+                          "description": "The current price of the variant.",
+                          "properties": {
+                            "amount": {
+                              "type": "number",
+                              "description": "The numeric price amount."
+                            },
+                            "currency": {
+                              "type": "string",
+                              "description": "The ISO 4217 currency code (e.g. 'USD')."
+                            },
+                            "formatted": {
+                              "type": "string",
+                              "description": "The price formatted for display (e.g. '$199.99')."
+                            }
+                          },
+                          "required": [
+                            "amount"
+                          ]
+                        },
+                        "originalPrice": {
+                          "type": "object",
+                          "description": "The original (pre-discount) price of the variant.",
+                          "properties": {
+                            "amount": {
+                              "type": "number",
+                              "description": "The numeric price amount."
+                            },
+                            "currency": {
+                              "type": "string",
+                              "description": "The ISO 4217 currency code (e.g. 'USD')."
+                            },
+                            "formatted": {
+                              "type": "string",
+                              "description": "The price formatted for display (e.g. '$249.99')."
+                            }
+                          },
+                          "required": [
+                            "amount"
+                          ]
+                        },
+                        "availability": {
+                          "type": "object",
+                          "description": "The availability of the variant.",
+                          "properties": {
+                            "inStock": {
+                              "type": "boolean",
+                              "description": "Whether the variant is in stock."
+                            },
+                            "text": {
+                              "type": "string",
+                              "description": "Human-readable availability text (e.g. 'In Stock')."
+                            }
+                          },
+                          "required": [
+                            "inStock"
+                          ]
+                        },
+                        "images": {
+                          "type": "array",
+                          "description": "Variant images.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "url": {
+                                "type": "string",
+                                "description": "Image URL."
+                              },
+                              "alt": {
+                                "type": "string",
+                                "description": "Alternative text for the image."
+                              }
+                            },
+                            "required": [
+                              "url"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "title",
+                  "url"
+                ]
               }
             }
           }

--- a/features/scrape.mdx
+++ b/features/scrape.mdx
@@ -40,6 +40,13 @@ import ScrapeBrandingOutput from "/snippets/v2/scrape/branding/base/output.mdx";
 import ScrapeBrandingCombinedPython from "/snippets/v2/scrape/branding/combined/python.mdx";
 import ScrapeBrandingCombinedNode from "/snippets/v2/scrape/branding/combined/js.mdx";
 import ScrapeBrandingCombinedCURL from "/snippets/v2/scrape/branding/combined/curl.mdx";
+import ScrapeProductPython from "/snippets/v2/scrape/product/base/python.mdx";
+import ScrapeProductNode from "/snippets/v2/scrape/product/base/js.mdx";
+import ScrapeProductCURL from "/snippets/v2/scrape/product/base/curl.mdx";
+import ScrapeProductOutput from "/snippets/v2/scrape/product/base/output.mdx";
+import ScrapeProductCombinedPython from "/snippets/v2/scrape/product/combined/python.mdx";
+import ScrapeProductCombinedNode from "/snippets/v2/scrape/product/combined/js.mdx";
+import ScrapeProductCombinedCURL from "/snippets/v2/scrape/product/combined/curl.mdx";
 import ScrapeAudioPython from "/snippets/v2/scrape/audio/python.mdx";
 import ScrapeAudioNode from "/snippets/v2/scrape/audio/js.mdx";
 import ScrapeAudioCURL from "/snippets/v2/scrape/audio/curl.mdx";
@@ -132,6 +139,7 @@ You can now choose what formats you want your output in. You can specify multipl
 - JSON (`json`) - structured output
 - Images (`images`) - extract all image URLs from the page
 - Branding (`branding`) - extract brand identity and design system
+- Product (`product`) - extract a structured product (title, price, availability, variants) from product pages
 - Audio (`audio`) - extract MP3 audio from supported video URLs, e.g. YouTube (returns a signed GCS URL, expires after 1 hour)
 - Video (`video`) - extract best-quality video from supported video URLs, e.g. YouTube (returns a signed GCS URL, expires after 1 hour)
 - Query (`query`, with `prompt` and optional `mode`) - ask a natural-language question about the page; the answer is returned in the `answer` field
@@ -238,6 +246,66 @@ You can combine the branding format with other formats to get comprehensive page
 <ScrapeBrandingCombinedPython />
 <ScrapeBrandingCombinedNode />
 <ScrapeBrandingCombinedCURL />
+
+</CodeGroup>
+
+## Extract product data
+
+The product format extracts a structured product from product pages, including title, brand, category, description, images, price, original price, availability, and variants. This is useful for building price monitoring, catalog ingestion, or comparison-shopping tools that need clean, structured product data.
+
+### /scrape (with product) endpoint
+
+<CodeGroup>
+
+<ScrapeProductPython />
+<ScrapeProductNode />
+<ScrapeProductCURL />
+
+</CodeGroup>
+
+### Response
+
+The product format returns a `product` object with the following structure:
+
+<ScrapeProductOutput />
+
+### Product object structure
+
+The `product` object contains the following properties:
+
+- `title`: The product name
+- `brand`: The product brand (optional)
+- `category`: The product category (optional)
+- `url`: The canonical URL of the product
+- `description`: The product description (optional)
+- `images`: Array of product images, each with a `url` and optional `alt` text
+- `price`: The current price object:
+  - `amount`: The numeric price value
+  - `currency`: The currency code, reported only when the page sources it (optional)
+  - `formatted`: The price as displayed on the page (optional)
+- `originalPrice`: The original (pre-discount) price, same shape as `price` (optional)
+- `availability`: Availability information:
+  - `inStock`: Whether the product is in stock
+  - `text`: The raw availability text from the page (optional)
+- `variants`: Array of product variants, each with optional `id`, `sku`, `title`, `values` (a map of option name to value, e.g. `{ "color": "Charcoal" }`), `price`, `originalPrice`, `availability`, and `images`
+
+### How product extraction works
+
+The product format extracts the product deterministically from on-page structured data — no LLM is involved. It merges multiple sources by priority: **JSON-LD > schema.org microdata > RDFa > embedded state (`__NEXT_DATA__`/Nuxt/Apollo/Redux/Remix) > AliExpress `runParams` > GA4 `dataLayer` > OpenGraph/`<meta>`**. The merge is identity-aware, so fields from different products are never combined. Currency is reported only when the page sources it.
+
+<Note>
+  Product extraction is fail-closed: ambiguous pages yield no product, and weaker sources such as OpenGraph only contribute when a price is present. On a page with no extractable product, the response omits the `product` object and adds a `warning` (e.g. "No product found...").
+</Note>
+
+### Combining with other formats
+
+You can combine the product format with other formats to get comprehensive page data:
+
+<CodeGroup>
+
+<ScrapeProductCombinedPython />
+<ScrapeProductCombinedNode />
+<ScrapeProductCombinedCURL />
 
 </CodeGroup>
 

--- a/features/scrape.mdx
+++ b/features/scrape.mdx
@@ -255,9 +255,9 @@ You can combine the branding format with other formats to get comprehensive page
 
 ## Extract product data
 
-The product format extracts a structured product from product pages, including title, brand, category, description, images, price, original price, availability, and variants. This is useful for building price monitoring, catalog ingestion, or comparison-shopping tools that need clean, structured product data.
+The `product` format extracts a structured product **deterministically** — the same kind of structured output as the [`json` format](#extract-structured-data), but without an LLM call or a schema you define, purpose-built for product pages. If you've been pulling product fields with a `json` schema, use `formats: ["product"]` instead — it's faster and cheaper, just limited to products.
 
-Unlike the [`json` format](#extract-structured-data) — which uses an LLM and a schema you define — `product` is deterministic and purpose-built for product pages, so it's faster and cheaper but limited to products. If you've been pulling product fields with a `json` schema, you can use `formats: ["product"]` instead.
+It returns a `product` object with title, brand, category, description, images, price, original price, availability, and variants — useful for price monitoring, catalog ingestion, or comparison-shopping tools.
 
 ### /scrape (with product) endpoint
 

--- a/features/scrape.mdx
+++ b/features/scrape.mdx
@@ -152,6 +152,10 @@ Output keys will match the format you choose.
 
 Used to extract structured data from scraped pages.
 
+<Tip>
+  Extracting products? For product pages, the [`product` format](#extract-product-data) returns structured product fields (title, price, availability, variants) deterministically — no LLM call and no schema to define. Reach for `json` when you need custom fields or non-product pages.
+</Tip>
+
 <CodeGroup>
 
 <ExtractPython />
@@ -252,6 +256,8 @@ You can combine the branding format with other formats to get comprehensive page
 ## Extract product data
 
 The product format extracts a structured product from product pages, including title, brand, category, description, images, price, original price, availability, and variants. This is useful for building price monitoring, catalog ingestion, or comparison-shopping tools that need clean, structured product data.
+
+Unlike the [`json` format](#extract-structured-data) — which uses an LLM and a schema you define — `product` is deterministic and purpose-built for product pages, so it's faster and cheaper but limited to products. If you've been pulling product fields with a `json` schema, you can use `formats: ["product"]` instead.
 
 ### /scrape (with product) endpoint
 

--- a/snippets/v2/cli/scrape/formats.mdx
+++ b/snippets/v2/cli/scrape/formats.mdx
@@ -14,5 +14,5 @@ firecrawl https://example.com --format summary
 # Track changes on a page
 firecrawl https://example.com --format changeTracking
 
-# Available formats: markdown, html, rawHtml, links, screenshot, json, images, summary, changeTracking, attributes, branding
+# Available formats: markdown, html, rawHtml, links, screenshot, json, images, summary, changeTracking, attributes, branding, product
 ```

--- a/snippets/v2/scrape/product/base/curl.mdx
+++ b/snippets/v2/scrape/product/base/curl.mdx
@@ -3,7 +3,7 @@
 curl -s -X POST "https://api.firecrawl.dev/v2/scrape" \
   -H "Content-Type: application/json" \
   -d '{
-    "url": "https://www.amazon.com/dp/B08N5WRWNW",
+    "url": "https://example.com/products/wireless-headphones",
     "formats": ["product"]
   }'
 ```

--- a/snippets/v2/scrape/product/base/curl.mdx
+++ b/snippets/v2/scrape/product/base/curl.mdx
@@ -1,0 +1,10 @@
+```bash cURL
+# No API key needed to get started — add -H "Authorization: Bearer $FIRECRAWL_API_KEY" for higher rate limits:
+curl -s -X POST "https://api.firecrawl.dev/v2/scrape" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://www.amazon.com/dp/B08N5WRWNW",
+    "formats": ["product"]
+  }'
+```
+

--- a/snippets/v2/scrape/product/base/js.mdx
+++ b/snippets/v2/scrape/product/base/js.mdx
@@ -6,7 +6,7 @@ const firecrawl = new Firecrawl({
   // apiKey: "fc-YOUR-API-KEY",
 });
 
-const result = await firecrawl.scrape('https://www.amazon.com/dp/B08N5WRWNW', {
+const result = await firecrawl.scrape('https://example.com/products/wireless-headphones', {
     formats: ['product']
 });
 

--- a/snippets/v2/scrape/product/base/js.mdx
+++ b/snippets/v2/scrape/product/base/js.mdx
@@ -1,0 +1,15 @@
+```js Node
+import { Firecrawl } from 'firecrawl';
+
+const firecrawl = new Firecrawl({
+  // No API key needed to get started — add one for higher rate limits:
+  // apiKey: "fc-YOUR-API-KEY",
+});
+
+const result = await firecrawl.scrape('https://www.amazon.com/dp/B08N5WRWNW', {
+    formats: ['product']
+});
+
+console.log(result.product);
+```
+

--- a/snippets/v2/scrape/product/base/output.mdx
+++ b/snippets/v2/scrape/product/base/output.mdx
@@ -1,0 +1,59 @@
+```json Output
+{
+  "success": true,
+  "data": {
+    "product": {
+      "title": "Echo Dot (4th Gen) Smart Speaker with Alexa",
+      "brand": "Amazon",
+      "category": "Electronics > Smart Home > Speakers",
+      "url": "https://www.amazon.com/dp/B08N5WRWNW",
+      "description": "Meet the Echo Dot - Our most popular smart speaker with a fabric design. It is our most compact smart speaker that fits perfectly into small spaces.",
+      "images": [
+        {
+          "url": "https://m.media-amazon.com/images/I/714Rq4k05UL._AC_SL1000_.jpg",
+          "alt": "Echo Dot (4th Gen)"
+        }
+      ],
+      "price": {
+        "amount": 49.99,
+        "currency": "USD",
+        "formatted": "$49.99"
+      },
+      "originalPrice": {
+        "amount": 59.99,
+        "currency": "USD",
+        "formatted": "$59.99"
+      },
+      "availability": {
+        "inStock": true,
+        "text": "In Stock"
+      },
+      "variants": [
+        {
+          "id": "B08N5WRWNW-charcoal",
+          "sku": "ECHO-DOT-4-CHARCOAL",
+          "title": "Echo Dot (4th Gen) — Charcoal",
+          "values": {
+            "color": "Charcoal"
+          },
+          "price": {
+            "amount": 49.99,
+            "currency": "USD",
+            "formatted": "$49.99"
+          },
+          "availability": {
+            "inStock": true,
+            "text": "In Stock"
+          },
+          "images": [
+            {
+              "url": "https://m.media-amazon.com/images/I/714Rq4k05UL._AC_SL1000_.jpg"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+

--- a/snippets/v2/scrape/product/base/output.mdx
+++ b/snippets/v2/scrape/product/base/output.mdx
@@ -3,26 +3,26 @@
   "success": true,
   "data": {
     "product": {
-      "title": "Echo Dot (4th Gen) Smart Speaker with Alexa",
-      "brand": "Amazon",
-      "category": "Electronics > Smart Home > Speakers",
-      "url": "https://www.amazon.com/dp/B08N5WRWNW",
-      "description": "Meet the Echo Dot - Our most popular smart speaker with a fabric design. It is our most compact smart speaker that fits perfectly into small spaces.",
+      "title": "Wireless Noise-Cancelling Headphones",
+      "brand": "Acme",
+      "category": "Electronics > Audio > Headphones",
+      "url": "https://example.com/products/wireless-headphones",
+      "description": "Over-ear wireless headphones with active noise cancellation, 30-hour battery life, and plush memory-foam ear cushions for all-day comfort.",
       "images": [
         {
-          "url": "https://m.media-amazon.com/images/I/714Rq4k05UL._AC_SL1000_.jpg",
-          "alt": "Echo Dot (4th Gen)"
+          "url": "https://example.com/images/headphones.jpg",
+          "alt": "Wireless Noise-Cancelling Headphones"
         }
       ],
       "price": {
-        "amount": 49.99,
+        "amount": 199.99,
         "currency": "USD",
-        "formatted": "$49.99"
+        "formatted": "$199.99"
       },
       "originalPrice": {
-        "amount": 59.99,
+        "amount": 249.99,
         "currency": "USD",
-        "formatted": "$59.99"
+        "formatted": "$249.99"
       },
       "availability": {
         "inStock": true,
@@ -30,16 +30,16 @@
       },
       "variants": [
         {
-          "id": "B08N5WRWNW-charcoal",
-          "sku": "ECHO-DOT-4-CHARCOAL",
-          "title": "Echo Dot (4th Gen) — Charcoal",
+          "id": "wireless-headphones-black",
+          "sku": "ACME-WH-BLACK",
+          "title": "Wireless Noise-Cancelling Headphones — Black",
           "values": {
-            "color": "Charcoal"
+            "color": "Black"
           },
           "price": {
-            "amount": 49.99,
+            "amount": 199.99,
             "currency": "USD",
-            "formatted": "$49.99"
+            "formatted": "$199.99"
           },
           "availability": {
             "inStock": true,
@@ -47,7 +47,7 @@
           },
           "images": [
             {
-              "url": "https://m.media-amazon.com/images/I/714Rq4k05UL._AC_SL1000_.jpg"
+              "url": "https://example.com/images/headphones-black.jpg"
             }
           ]
         }
@@ -56,4 +56,3 @@
   }
 }
 ```
-

--- a/snippets/v2/scrape/product/base/python.mdx
+++ b/snippets/v2/scrape/product/base/python.mdx
@@ -7,7 +7,7 @@ firecrawl = Firecrawl(
 )
 
 result = firecrawl.scrape(
-    url='https://www.amazon.com/dp/B08N5WRWNW',
+    url='https://example.com/products/wireless-headphones',
     formats=['product']
 )
 

--- a/snippets/v2/scrape/product/base/python.mdx
+++ b/snippets/v2/scrape/product/base/python.mdx
@@ -1,0 +1,16 @@
+```python Python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(
+  # No API key needed to get started — add one for higher rate limits:
+  # api_key='fc-YOUR_API_KEY',
+)
+
+result = firecrawl.scrape(
+    url='https://www.amazon.com/dp/B08N5WRWNW',
+    formats=['product']
+)
+
+print(result['product'])
+```
+

--- a/snippets/v2/scrape/product/combined/curl.mdx
+++ b/snippets/v2/scrape/product/combined/curl.mdx
@@ -1,0 +1,10 @@
+```bash cURL
+# No API key needed to get started — add -H "Authorization: Bearer $FIRECRAWL_API_KEY" for higher rate limits:
+curl -s -X POST "https://api.firecrawl.dev/v2/scrape" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://www.amazon.com/dp/B08N5WRWNW",
+    "formats": ["markdown", "product"]
+  }'
+```
+

--- a/snippets/v2/scrape/product/combined/curl.mdx
+++ b/snippets/v2/scrape/product/combined/curl.mdx
@@ -3,7 +3,7 @@
 curl -s -X POST "https://api.firecrawl.dev/v2/scrape" \
   -H "Content-Type: application/json" \
   -d '{
-    "url": "https://www.amazon.com/dp/B08N5WRWNW",
+    "url": "https://example.com/products/wireless-headphones",
     "formats": ["markdown", "product"]
   }'
 ```

--- a/snippets/v2/scrape/product/combined/js.mdx
+++ b/snippets/v2/scrape/product/combined/js.mdx
@@ -1,0 +1,16 @@
+```js Node
+import { Firecrawl } from 'firecrawl';
+
+const firecrawl = new Firecrawl({
+  // No API key needed to get started — add one for higher rate limits:
+  // apiKey: "fc-YOUR-API-KEY",
+});
+
+const result = await firecrawl.scrape('https://www.amazon.com/dp/B08N5WRWNW', {
+    formats: ['markdown', 'product']
+});
+
+console.log(result.markdown);
+console.log(result.product);
+```
+

--- a/snippets/v2/scrape/product/combined/js.mdx
+++ b/snippets/v2/scrape/product/combined/js.mdx
@@ -6,7 +6,7 @@ const firecrawl = new Firecrawl({
   // apiKey: "fc-YOUR-API-KEY",
 });
 
-const result = await firecrawl.scrape('https://www.amazon.com/dp/B08N5WRWNW', {
+const result = await firecrawl.scrape('https://example.com/products/wireless-headphones', {
     formats: ['markdown', 'product']
 });
 

--- a/snippets/v2/scrape/product/combined/python.mdx
+++ b/snippets/v2/scrape/product/combined/python.mdx
@@ -7,7 +7,7 @@ firecrawl = Firecrawl(
 )
 
 result = firecrawl.scrape(
-    url='https://www.amazon.com/dp/B08N5WRWNW',
+    url='https://example.com/products/wireless-headphones',
     formats=['markdown', 'product']
 )
 

--- a/snippets/v2/scrape/product/combined/python.mdx
+++ b/snippets/v2/scrape/product/combined/python.mdx
@@ -1,0 +1,17 @@
+```python Python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(
+  # No API key needed to get started — add one for higher rate limits:
+  # api_key='fc-YOUR_API_KEY',
+)
+
+result = firecrawl.scrape(
+    url='https://www.amazon.com/dp/B08N5WRWNW',
+    formats=['markdown', 'product']
+)
+
+print(result['markdown'])
+print(result['product'])
+```
+


### PR DESCRIPTION
## docs: add `product` scrape format (a deterministic `json` variant)

Documents the new `product` scrape format, positioned as a **deterministic variant of `format: ["json"]`** — the same structured output, but without an LLM call or a schema you define, purpose-built for product pages.

### What's documented (matches the existing format-doc convention)
- **`features/scrape.mdx`** — an "Extract product data" section that *leads* with the json relationship, then endpoint examples (Python/Node/cURL), the response, the `product` object structure, how multi-source extraction works, and combining with other formats. The `json` section gets a `<Tip>` pointing to `product` for product pages; the two cross-link.
- **`snippets/v2/scrape/product/{base,combined}/*`** — per-language snippets (neutral example, not a real retailer).
- **`advanced-scraping-guide.mdx`** — formats-table row.
- **`snippets/v2/cli/scrape/formats.mdx`** — CLI formats list.
- **`api-reference/v2-openapi.json`** — `product` schema + format enum (mirrors `branding`).

English source only — localized files are left to the auto-translation pipeline (per repo CLAUDE.md). No new nav page (formats are sections). Pairs with the API/SDK implementation. Supersedes the earlier closed #1.

