### PR TITLE
fix(docs): use canonical llms.txt link

### DIFF
--- a/api-reference/v2-introduction.mdx
+++ b/api-reference/v2-introduction.mdx
@@ -4,7 +4,7 @@ description: 'Firecrawl API Reference (v2)'
 ---
 
 <Note>
-  **For AI agents:** Use [llms.txt](/llms.txt) for a full index of all documentation.
+  **For AI agents:** Use [llms.txt](https://docs.firecrawl.dev/llms.txt) for a full index of all documentation.
 </Note>
 
 The Firecrawl API gives you programmatic access to web data. All endpoints share a common base URL, authentication scheme, and response format described on this page.

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -6,7 +6,7 @@ og:description: "Search the web, scrape any page, and interact with it — all t
 ---
 
 <Note>
-  **For AI agents:** Use [llms.txt](/llms.txt) for a full index of all documentation.
+  **For AI agents:** Use [llms.txt](https://docs.firecrawl.dev/llms.txt) for a full index of all documentation.
 </Note>
 
 import SearchPython from "/snippets/v2/search/base/python.mdx";


### PR DESCRIPTION
## Summary

Updates the AI agents note in the main and API reference introductions to link to the canonical `https://docs.firecrawl.dev/llms.txt` URL. This avoids the localization pipeline rewriting the global `llms.txt` asset to locale-prefixed paths like `/es/llms.txt`.