### PR TITLE
docs(ai-onboarding): add keyless free tier as fallback credential path

### DIFF
--- a/ai-onboarding.mdx
+++ b/ai-onboarding.mdx
@@ -47,6 +47,8 @@ Firecrawl users can get an API key in two ways. Most users should sign in throug
   </Card>
 </CardGroup>
 
+**Can't sign in or get a key?** When your agent cannot obtain an API key and the human cannot sign up, you can still use the keyless free tier to search, scrape, and interact without an API key. It is rate-limited and meant as a fallback, so move to a free account or API key as soon as one is available. See [Keyless (no API key)](/rate-limits#keyless-no-api-key) for details.
+
 Once you have an API key, continue with [Skills + CLI](#skills-cli) below.
 
 ## Skills + CLI


### PR DESCRIPTION
## Why

Introduces a keyless free tier fallback in the agent onboarding flow: agents can use search, scrape, and interact without an API key when no key is available. The docs `Get credentials` flow only described the two key-based paths (dashboard/CLI and WorkOS ID-JAG), leaving an agent that cannot obtain a key and cannot get the human to sign up with no documented option. This aligns the docs with that behavior while keeping account/API key as the preferred path.

## Summary

- `ai-onboarding.mdx`: add a short fallback note in `Get credentials`, after the dashboard/CLI and WorkOS ID-JAG cards, explaining that the keyless free tier can be used to search, scrape, and interact without an API key when no key and no sign-up are possible. Frames it as a fallback and points to the existing `/rate-limits#keyless-no-api-key` section for details.
- Dashboard/CLI and ID-JAG remain the preferred paths; no credit counts or rate-limit mechanics are restated (those live on the rate-limits page).

### Scope notes
- Did not add an `llms.txt` change: this repo has no editable `llms.txt`. The `docs.json` link points to the Mintlify auto-generated `https://docs.firecrawl.dev/llms.txt`, which has no source file here.
- Did not reference "Path F" by name. The note links the verified `rate-limits#keyless-no-api-key` anchor instead and leaves the existing `SKILL.md` references in the section intact.
- Did not touch localized files, the agent callout boilerplate on other pages, or pages that already document keyless (rate-limits, mcp-server, sdks/cli, MCP OAuth guides).