### PR TITLE
docs(menu): document full optionGroups structure with nested modifiers

### DIFF
--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -7773,9 +7773,97 @@
                               },
                               "optionGroups": {
                                 "type": "array",
-                                "description": "Option/modifier groups for the item.",
+                                "description": "Modifier groups for the item (e.g. size, toppings).",
                                 "items": {
-                                  "type": "object"
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "description": "The group identifier."
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "description": "The group name, e.g. \"Size\" or \"Add-ons\"."
+                                    },
+                                    "selectionType": {
+                                      "type": "string",
+                                      "enum": ["single", "multi"],
+                                      "description": "Whether the customer picks one option (\"single\") or many (\"multi\")."
+                                    },
+                                    "required": {
+                                      "type": "boolean",
+                                      "description": "Whether a selection is required."
+                                    },
+                                    "minSelections": {
+                                      "type": "integer",
+                                      "description": "Minimum number of selections required."
+                                    },
+                                    "maxSelections": {
+                                      "type": "integer",
+                                      "nullable": true,
+                                      "description": "Maximum number of selections allowed. Null means unlimited."
+                                    },
+                                    "options": {
+                                      "type": "array",
+                                      "description": "The choices in this group.",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string",
+                                            "description": "The option identifier."
+                                          },
+                                          "name": {
+                                            "type": "string",
+                                            "description": "The option name, e.g. \"Large\" or \"Extra Cheese\"."
+                                          },
+                                          "description": {
+                                            "type": "string",
+                                            "nullable": true,
+                                            "description": "The option description."
+                                          },
+                                          "priceDelta": {
+                                            "type": "object",
+                                            "nullable": true,
+                                            "description": "Price adjustment for choosing this option.",
+                                            "properties": {
+                                              "amount": {
+                                                "type": "number",
+                                                "description": "The numeric price adjustment."
+                                              },
+                                              "currency": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "description": "The currency code."
+                                              },
+                                              "formatted": {
+                                                "type": "string",
+                                                "nullable": true,
+                                                "description": "The price adjustment as displayed on the page."
+                                              }
+                                            }
+                                          },
+                                          "default": {
+                                            "type": "boolean",
+                                            "description": "Whether this option is selected by default."
+                                          },
+                                          "available": {
+                                            "type": "boolean",
+                                            "description": "Whether this option is currently available."
+                                          },
+                                          "optionGroups": {
+                                            "type": "array",
+                                            "description": "Nested modifier groups — present when this option is itself customizable (e.g. a combo slot).",
+                                            "items": {
+                                              "type": "object"
+                                            }
+                                          }
+                                        },
+                                        "required": ["id", "name", "description", "priceDelta", "default", "available", "optionGroups"]
+                                      }
+                                    }
+                                  },
+                                  "required": ["id", "name", "selectionType", "required", "minSelections", "maxSelections", "options"]
                                 }
                               },
                               "identifiers": {

--- a/features/menu.mdx
+++ b/features/menu.mdx
@@ -63,7 +63,21 @@ The `menu` object contains the following properties:
       - `text`: The raw availability text from the page (optional)
     - `dietary`: array of dietary tags, e.g. `["vegetarian"]` (optional)
     - `calories`: The item's calorie count (optional)
-    - `optionGroups`: Array of option/modifier groups for the item (optional)
+    - `optionGroups`: Array of modifier groups for the item. Each group has:
+      - `id`: The group identifier
+      - `name`: The group name, e.g. `"Size"` or `"Add-ons"`
+      - `selectionType`: `"single"` (pick one) or `"multi"` (pick many)
+      - `required`: Whether a selection is required
+      - `minSelections`: Minimum number of selections required
+      - `maxSelections`: Maximum number of selections allowed (optional)
+      - `options`: Array of choices. Each option has:
+        - `id`: The option identifier
+        - `name`: The option name, e.g. `"Large"` or `"Extra Cheese"`
+        - `description`: The option description (optional)
+        - `priceDelta`: Price adjustment for this option — same structure as `price` (optional)
+        - `default`: Whether this option is selected by default
+        - `available`: Whether this option is currently available
+        - `optionGroups`: Nested modifier groups — present when an option is itself customizable, e.g. a combo meal slot where each slot has its own choices. Same structure as the parent `optionGroups`.
     - `identifiers`: merchant-specific identifiers for the item (optional):
       - `merchantItemId`: The merchant's own item ID (optional)
     - `url`: The canonical URL of the item (optional)

--- a/snippets/v2/scrape/menu/base/output.mdx
+++ b/snippets/v2/scrape/menu/base/output.mdx
@@ -4,7 +4,7 @@
   "data": {
     "menu": {
       "isMenu": true,
-      "confidence": 0.85,
+      "confidence": 0.95,
       "merchant": {
         "name": "Joe's Diner",
         "type": "restaurant"
@@ -12,34 +12,103 @@
       "currency": "USD",
       "sections": [
         {
-          "id": "appetizers",
-          "name": "Appetizers",
+          "id": "burgers",
+          "name": "Burgers",
           "description": null,
           "items": [
             {
-              "id": "pretzel-bites",
-              "name": "Pretzel Bites",
-              "description": "warm, salted",
+              "id": "classic-burger",
+              "name": "Classic Burger",
+              "description": "Beef patty with lettuce, tomato, and pickles",
               "images": [
                 {
-                  "url": "https://joesdiner.com/images/pretzel-bites.jpg",
+                  "url": "https://joesdiner.com/images/classic-burger.jpg",
                   "alt": null
                 }
               ],
               "price": {
-                "amount": 7.99,
+                "amount": 12.99,
                 "currency": "USD",
-                "formatted": "$7.99"
+                "formatted": "$12.99"
               },
               "availability": {
                 "inStock": true,
                 "text": null
               },
-              "dietary": ["vegetarian"],
-              "calories": 490,
-              "optionGroups": [],
+              "dietary": [],
+              "calories": 650,
+              "optionGroups": [
+                {
+                  "id": "patty-size",
+                  "name": "Size",
+                  "selectionType": "single",
+                  "required": true,
+                  "minSelections": 1,
+                  "maxSelections": 1,
+                  "options": [
+                    {
+                      "id": "",
+                      "name": "Regular",
+                      "description": null,
+                      "priceDelta": null,
+                      "default": true,
+                      "available": true,
+                      "optionGroups": []
+                    },
+                    {
+                      "id": "",
+                      "name": "Double",
+                      "description": "Two beef patties",
+                      "priceDelta": {
+                        "amount": 3.00,
+                        "currency": "USD",
+                        "formatted": null
+                      },
+                      "default": false,
+                      "available": true,
+                      "optionGroups": []
+                    }
+                  ]
+                },
+                {
+                  "id": "add-ons",
+                  "name": "Add-ons",
+                  "selectionType": "multi",
+                  "required": false,
+                  "minSelections": 0,
+                  "maxSelections": null,
+                  "options": [
+                    {
+                      "id": "",
+                      "name": "Extra Cheese",
+                      "description": null,
+                      "priceDelta": {
+                        "amount": 1.00,
+                        "currency": "USD",
+                        "formatted": null
+                      },
+                      "default": false,
+                      "available": true,
+                      "optionGroups": []
+                    },
+                    {
+                      "id": "",
+                      "name": "Bacon",
+                      "description": null,
+                      "priceDelta": {
+                        "amount": 1.50,
+                        "currency": "USD",
+                        "formatted": null
+                      },
+                      "default": false,
+                      "available": true,
+                      "optionGroups": []
+                    }
+                  ]
+                }
+              ],
               "identifiers": {
-                "merchantItemId": "abc123"
+                "merchantItemId": "burger-001"
               },
               "url": null,
               "sourceUrl": "https://joesdiner.com/menu"


### PR DESCRIPTION
- Expand optionGroups entry in the menu object reference to cover the full group and option shape: selectionType, required, minSelections, maxSelections, and per-option description + recursive optionGroups
- Update output example to show a burger item with two populated modifier groups (size single-required, add-ons multi-optional) with real option fields including priceDelta and description
- Expand the v2-openapi.json inline schema for optionGroups: typed group properties, typed option properties including description, priceDelta, and nested optionGroups