### PR TITLE
docs(ai-onboarding): fix interact endpoint path

### DIFF
--- a/ai-onboarding.mdx
+++ b/ai-onboarding.mdx
@@ -192,7 +192,7 @@ All three skill categories use the same install. The difference is what happens 
 
     - `POST https://api.firecrawl.dev/v2/search` — discover pages by query
     - `POST https://api.firecrawl.dev/v2/scrape` — extract clean markdown from a URL
-    - `POST https://api.firecrawl.dev/v2/interact` — interact with a scraped page
+    - `POST https://api.firecrawl.dev/v2/scrape/{scrapeId}/interact` — interact with a scraped page
     - `POST https://api.firecrawl.dev/v2/crawl` — bulk-extract an entire site
     - `POST https://api.firecrawl.dev/v2/map` — discover URLs on a domain
     - `POST https://api.firecrawl.dev/v2/agent` — run autonomous web data gathering
@@ -317,10 +317,11 @@ Firecrawl gives agents five core tools for working with the web. Each tool maps 
 
     ```bash
     # REST API
-    curl -X POST https://api.firecrawl.dev/v2/interact \
+    # scrapeId comes from the scrape response (data.metadata.scrapeId)
+    curl -X POST https://api.firecrawl.dev/v2/scrape/SCRAPE_ID/interact \
       -H "Authorization: Bearer fc-YOUR_API_KEY" \
       -H "Content-Type: application/json" \
-      -d '{"scrapeId": "scrape-id-from-scrape", "prompt": "Click the pricing tab and extract the plan names"}'
+      -d '{"prompt": "Click the pricing tab and extract the plan names"}'
     ```
 
     **When to use:** Continuing from a scrape, navigating dynamic pages, filling forms, and extracting data after page actions.


### PR DESCRIPTION
## Summary

`ai-onboarding.mdx` told agents to interact with a scraped page by calling the bare `POST /v2/interact` with `scrapeId` in the body. That endpoint is the **standalone browser-session create** (documented under `api-reference/endpoint/browser-create`). Interacting with a scraped page is `POST /v2/scrape/{scrapeId}/interact`, with the `scrapeId` in the **path** — matching the canonical interact quickstart.

Fixes two spots:
- REST API endpoint list: `/v2/interact` → `/v2/scrape/{scrapeId}/interact`
- REST curl example: posts to the path-based endpoint with just `{"prompt": ...}`, plus a comment noting `scrapeId` comes from `data.metadata.scrapeId`

## Scope

- English source only (`ai-onboarding.mdx`). Per repo CLAUDE.md, translations are managed separately (locadex) and were not touched.
- The `browser-*` api-reference pages correctly document the standalone `/v2/interact` session and are intentionally left as-is.

## Test plan

- [x] Endpoint matches canonical `snippets/v2/interact/quickstart` flow (`/v2/scrape/$SCRAPE_ID/interact`)
- [x] `git diff --check` clean
- [x] Bare `/v2/interact` references elsewhere verified correct (standalone session) and untouched