### PR TITLE
docs: reconcile agent-facing surface contracts

### DIFF
--- a/api-reference/endpoint/activity.mdx
+++ b/api-reference/endpoint/activity.mdx
@@ -10,4 +10,4 @@ Lists your recent API activity from the last 24 hours. Use this to discover job 
 | `scrape` | `GET /v2/scrape/{id}` |
 | `crawl` | `GET /v2/crawl/{id}` |
 | `batch_scrape` | `GET /v2/batch/scrape/{id}` |
-| `agent` | `GET /v2/extract/{id}` |
+| `agent` | `GET /v2/agent/{jobId}` |

--- a/api-reference/endpoint/browser-delete.mdx
+++ b/api-reference/endpoint/browser-delete.mdx
@@ -9,13 +9,12 @@ openapi: '/api-reference/v2-openapi.json DELETE /interact/{sessionId}'
 | Header | Value |
 |--------|-------|
 | `Authorization` | `Bearer <API_KEY>` |
-| `Content-Type` | `application/json` |
 
-## Request Body
+## Path Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `id` | string | Yes | The session ID to destroy |
+| `sessionId` | string | Yes | The Interact session ID to destroy |
 
 ## Response
 
@@ -26,12 +25,8 @@ openapi: '/api-reference/v2-openapi.json DELETE /interact/{sessionId}'
 ### Example Request
 
 ```bash
-curl -X DELETE "https://api.firecrawl.dev/v2/interact" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "id": "550e8400-e29b-41d4-a716-446655440000"
-  }'
+curl -X DELETE "https://api.firecrawl.dev/v2/interact/550e8400-e29b-41d4-a716-446655440000" \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY"
 ```
 
 ### Example Response

--- a/api-reference/endpoint/feedback.mdx
+++ b/api-reference/endpoint/feedback.mdx
@@ -1,0 +1,25 @@
+---
+title: 'Endpoint Feedback'
+description: 'Submit feedback for a completed v2 endpoint job.'
+openapi: '/api-reference/v2-openapi.json POST /feedback'
+---
+
+Use endpoint feedback to tell Firecrawl whether a completed job result was useful, partial, or bad. This is for endpoint-level output quality on jobs such as `scrape`, `parse`, `map`, and `search`.
+
+The generic feedback schema can carry search-style fields too, but [Search Feedback](/api-reference/endpoint/search-feedback) is the preferred search-specific entry point because it is scoped to a search job ID and highlights valuable sources, missing content, query suggestions, and refund behavior.
+
+### Example Request
+
+```bash
+curl -X POST "https://api.firecrawl.dev/v2/feedback" \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "endpoint": "scrape",
+    "jobId": "550e8400-e29b-41d4-a716-446655440000",
+    "rating": "partial",
+    "issues": ["missing_markdown"],
+    "note": "The pricing table was missing from the markdown output.",
+    "url": "https://example.com/pricing"
+  }'
+```

--- a/api-reference/endpoint/search-feedback.mdx
+++ b/api-reference/endpoint/search-feedback.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Search Feedback'
+description: 'Submit quality feedback for a search job and help improve Firecrawl search results.'
+openapi: '/api-reference/v2-openapi.json POST /search/{jobId}/feedback'
+---
+
+Use search feedback after a `search` result is used or fails to help. Feedback improves result quality and can refund 1 credit for the first feedback submission on a search job, subject to team limits.
+
+### Example Request
+
+```bash
+curl -X POST "https://api.firecrawl.dev/v2/search/550e8400-e29b-41d4-a716-446655440000/feedback" \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "rating": "good",
+    "valuableSources": [
+      {
+        "url": "https://docs.firecrawl.dev/features/search",
+        "reason": "Most up-to-date description of /search."
+      }
+    ],
+    "missingContent": [
+      {
+        "topic": "Pricing for the search endpoint",
+        "description": "No pricing tier table for /search specifically."
+      }
+    ],
+    "querySuggestions": "Boost docs.firecrawl.dev for queries that mention Firecrawl"
+  }'
+```

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -3895,7 +3895,8 @@
         "summary": "Create an interact session",
         "operationId": "createBrowserSession",
         "tags": [
-          "Interact"        ],
+          "Interact"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -4010,7 +4011,8 @@
         "summary": "List interact sessions",
         "operationId": "listBrowserSessions",
         "tags": [
-          "Interact"        ],
+          "Interact"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -4110,7 +4112,8 @@
         "summary": "Execute code in an interact session",
         "operationId": "executeBrowserCode",
         "tags": [
-          "Interact"        ],
+          "Interact"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -4233,7 +4236,8 @@
         "summary": "Delete an interact session",
         "operationId": "deleteBrowserSession",
         "tags": [
-          "Interact"        ],
+          "Interact"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -4389,27 +4393,28 @@
       }
     },
     "/search/{jobId}/feedback": {
-      "parameters": [
-        {
-          "name": "jobId",
-          "in": "path",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "description": "The search job ID"
-        }
-      ],
       "post": {
         "summary": "Submit feedback for a search job",
         "operationId": "submitSearchFeedback",
         "tags": [
-          "Search"
+          "Search",
+          "Feedback"
         ],
         "security": [
           {
             "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Search job id returned by /search."
           }
         ],
         "requestBody": {
@@ -4428,145 +4433,47 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SearchFeedbackResponse"
+                  "$ref": "#/components/schemas/FeedbackResponse"
                 }
               }
             }
           },
           "400": {
-            "description": "Bad request",
+            "description": "Invalid request body",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": false
-                    },
-                    "code": {
-                      "type": "string"
-                    },
-                    "error": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": false
-                    },
-                    "code": {
-                      "type": "string"
-                    },
-                    "error": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  }
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Payment required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": false
-                    },
-                    "code": {
-                      "type": "string"
-                    },
-                    "error": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  }
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
                 }
               }
             }
           },
           "403": {
-            "description": "Forbidden",
+            "description": "Feedback is not available for this team",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": false
-                    },
-                    "code": {
-                      "type": "string"
-                    },
-                    "error": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  }
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
                 }
               }
             }
           },
           "404": {
-            "description": "Not found",
+            "description": "Search not found for this team",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": false
-                    },
-                    "code": {
-                      "type": "string"
-                    },
-                    "error": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  }
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
+          "409": {
+            "description": "Feedback cannot be recorded for this search",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": false
-                    },
-                    "code": {
-                      "type": "string"
-                    },
-                    "error": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  }
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
                 }
               }
             }
@@ -4576,20 +4483,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": false
-                    },
-                    "code": {
-                      "type": "string"
-                    },
-                    "error": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  }
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
                 }
               }
             }
@@ -5194,6 +5088,92 @@
           },
           "500": {
             "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/feedback": {
+      "post": {
+        "summary": "Submit feedback for a v2 job",
+        "operationId": "submitEndpointFeedback",
+        "tags": [
+          "Feedback"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EndpointFeedbackRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Feedback recorded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Feedback is not available for this team",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Job not found for this team",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Feedback cannot be recorded for this job",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -8338,13 +8318,14 @@
       },
       "SearchFeedbackRequest": {
         "type": "object",
+        "description": "For 'good', include valuableSources. For 'partial', include valuableSources or missingContent. For 'bad', include missingContent or querySuggestions.",
         "properties": {
           "rating": {
             "type": "string",
             "enum": [
               "good",
-              "bad",
-              "partial"
+              "partial",
+              "bad"
             ]
           },
           "valuableSources": {
@@ -8375,8 +8356,8 @@
               "properties": {
                 "topic": {
                   "type": "string",
-                  "minLength": 1,
-                  "maxLength": 200
+                  "maxLength": 200,
+                  "minLength": 1
                 },
                 "description": {
                   "type": "string",
@@ -8397,58 +8378,13 @@
             "default": "api"
           },
           "integration": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           }
         },
         "required": [
           "rating"
-        ],
-        "description": "Substantive feedback is required by rating: good requires valuableSources; partial requires valuableSources or missingContent; bad requires missingContent or querySuggestions."
-      },
-      "SearchFeedbackResponse": {
-        "type": "object",
-        "properties": {
-          "success": {
-            "type": "boolean"
-          },
-          "feedbackId": {
-            "type": "string"
-          },
-          "creditsRefunded": {
-            "type": "number"
-          },
-          "alreadySubmitted": {
-            "type": "boolean"
-          },
-          "dailyCapReached": {
-            "type": "boolean"
-          },
-          "creditsRefundedToday": {
-            "type": "number"
-          },
-          "dailyRefundCap": {
-            "type": "number"
-          },
-          "warning": {
-            "type": "string"
-          },
-          "error": {
-            "type": "string"
-          },
-          "feedbackErrorCode": {
-            "type": "string",
-            "enum": [
-              "SEARCH_NOT_FOUND",
-              "FEEDBACK_WINDOW_EXPIRED",
-              "SEARCH_FAILED",
-              "PREVIEW_TEAM_NOT_ALLOWED",
-              "TEAM_OPTED_OUT",
-              "INVALID_BODY",
-              "DB_DISABLED",
-              "INTERNAL"
-            ]
-          }
-        }
+        ]
       },
       "SupportAskRequest": {
         "type": "object",
@@ -8921,6 +8857,157 @@
             }
           }
         }
+      },
+      "EndpointFeedbackRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SearchFeedbackRequest"
+          },
+          {
+            "type": "object",
+            "description": "Submit feedback for a v2 job. Include at least one substantive signal such as issues, note, valuableSources, missingContent, querySuggestions, url, or pageNumbers.",
+            "properties": {
+              "endpoint": {
+                "type": "string",
+                "enum": [
+                  "search",
+                  "scrape",
+                  "parse",
+                  "map"
+                ]
+              },
+              "jobId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "issues": {
+                "type": "array",
+                "maxItems": 20,
+                "items": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9][a-z0-9_-]*$",
+                  "maxLength": 80
+                }
+              },
+              "tags": {
+                "type": "array",
+                "maxItems": 20,
+                "items": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9][a-z0-9_-]*$",
+                  "maxLength": 80
+                }
+              },
+              "note": {
+                "type": "string",
+                "maxLength": 4000
+              },
+              "url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "pageNumbers": {
+                "type": "array",
+                "maxItems": 100,
+                "items": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              },
+              "metadata": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Small endpoint-specific metadata object. Must be 8KB or smaller; do not include full endpoint results."
+              },
+              "missingContent": {
+                "type": "array",
+                "maxItems": 50,
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "topic": {
+                      "type": "string",
+                      "maxLength": 200,
+                      "minLength": 1
+                    },
+                    "description": {
+                      "type": "string",
+                      "maxLength": 2000
+                    }
+                  },
+                  "required": [
+                    "topic"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "endpoint",
+              "jobId"
+            ]
+          }
+        ]
+      },
+      "FeedbackResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "feedbackId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "creditsRefunded": {
+            "type": "number"
+          },
+          "alreadySubmitted": {
+            "type": "boolean"
+          },
+          "dailyCapReached": {
+            "type": "boolean"
+          },
+          "creditsRefundedToday": {
+            "type": "number"
+          },
+          "dailyRefundCap": {
+            "type": "number"
+          },
+          "warning": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "success",
+          "feedbackId",
+          "creditsRefunded"
+        ]
+      },
+      "FeedbackErrorResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": false
+          },
+          "error": {
+            "type": "string"
+          },
+          "feedbackErrorCode": {
+            "type": "string"
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "required": [
+          "success",
+          "error"
+        ]
       }
     }
   },

--- a/developer-guides/llm-sdks-and-frameworks/google-adk.mdx
+++ b/developer-guides/llm-sdks-and-frameworks/google-adk.mdx
@@ -13,7 +13,7 @@ Firecrawl provides an MCP server that seamlessly integrates with Google's ADK, e
 
 - Efficient web scraping, crawling, and content discovery from any website
 - Advanced search capabilities and intelligent content extraction
-- Deep research and high-volume batch scraping
+- Deep research
 - Flexible deployment (cloud-based or self-hosted)
 - Optimized for modern web environments with streamable HTTP support
 
@@ -86,8 +86,6 @@ root_agent = Agent(
 | Tool | Name | Description |
 |------|------|-------------|
 | Scrape Tool | `firecrawl_scrape` | Scrape content from a single URL with advanced options |
-| Batch Scrape Tool | `firecrawl_batch_scrape` | Scrape multiple URLs efficiently with built-in rate limiting and parallel processing |
-| Check Batch Status | `firecrawl_check_batch_status` | Check the status of a batch operation |
 | Map Tool | `firecrawl_map` | Map a website to discover all indexed URLs on the site |
 | Search Tool | `firecrawl_search` | Search the web and optionally extract content from search results |
 | Crawl Tool | `firecrawl_crawl` | Start an asynchronous crawl with advanced options |
@@ -109,15 +107,6 @@ root_agent = Agent(
 - Example: `https://firecrawl.your-domain.com`
 - If not provided, the cloud API will be used
 
-**Retry configuration**:
-- `FIRECRAWL_RETRY_MAX_ATTEMPTS`: Maximum retry attempts (default: 3)
-- `FIRECRAWL_RETRY_INITIAL_DELAY`: Initial delay in milliseconds (default: 1000)
-- `FIRECRAWL_RETRY_MAX_DELAY`: Maximum delay in milliseconds (default: 10000)
-- `FIRECRAWL_RETRY_BACKOFF_FACTOR`: Exponential backoff multiplier (default: 2)
-
-**Credit usage monitoring**:
-- `FIRECRAWL_CREDIT_WARNING_THRESHOLD`: Warning threshold (default: 1000)
-- `FIRECRAWL_CREDIT_CRITICAL_THRESHOLD`: Critical threshold (default: 100)
 
 ## Example: Web Research Agent
 
@@ -157,14 +146,14 @@ print(response)
 1. **Use the right tool for the job**:
    - `firecrawl_search` when you need to find relevant pages first
    - `firecrawl_scrape` for single pages
-   - `firecrawl_batch_scrape` for multiple known URLs
    - `firecrawl_crawl` for discovering and scraping entire sites
+   - repeated `firecrawl_scrape` calls when you already have a short list of known URLs
 
-2. **Monitor your usage**: Configure credit thresholds to avoid unexpected usage
+2. **Monitor your usage**: Use your Firecrawl dashboard and API responses to track credit usage.
 
-3. **Handle errors gracefully**: Configure retry settings based on your use case
+3. **Handle errors gracefully**: Surface MCP/API errors to the user and retry only when your agent workflow can do so safely.
 
-4. **Optimize performance**: Use batch operations when scraping multiple URLs
+4. **Optimize performance**: Use `firecrawl_map` before scraping when the agent needs to discover relevant URLs.
 
 ---
 

--- a/docs.json
+++ b/docs.json
@@ -419,9 +419,16 @@
                     ]
                   },
                   {
+                    "group": "Feedback Endpoints",
+                    "pages": [
+                      "api-reference/endpoint/feedback"
+                    ]
+                  },
+                  {
                     "group": "Search Endpoints",
                     "pages": [
-                      "api-reference/endpoint/search"
+                      "api-reference/endpoint/search",
+                      "api-reference/endpoint/search-feedback"
                     ]
                   },
                   {

--- a/features/browser.mdx
+++ b/features/browser.mdx
@@ -39,15 +39,20 @@ import ListPython from "/snippets/v2/browser/list/python.mdx";
 import ClosePython from "/snippets/v2/browser/close/python.mdx";
 
 <Info>
-Browser Sandbox is now [Interact](/features/interact), which offers the same features plus it can be controlled via prompts.
+For agent workflows, use [Interact](/features/interact). Interact is the supported CLI/MCP path and can be driven with prompts or code after a scrape, or directly from a URL where supported.
 </Info>
 
-Firecrawl Browser Sandbox gives your agents a secure browser environment where agents can interact with the web. Fill out forms, click buttons, authenticate, and more.
+| Surface | Use it for | Entry point | Agent surface |
+|---|---|---|---|
+| Browser Sandbox | Standalone browser sessions for API/SDK users that need a sandbox, CDP URL, live view, or persistent session lifecycle | `POST /v2/interact` | API and SDKs; hidden CLI browser command is legacy |
+| Interact | Acting on a scraped page, or opening a URL through the supported agent path | `POST /v2/scrape/{scrapeId}/interact` or CLI/MCP `interact` | Recommended for CLI/MCP agent workflows |
+
+Firecrawl Browser Sandbox gives API and SDK users a secure browser environment where agents can interact with the web. Fill out forms, click buttons, authenticate, and more.
 No local setup, no Chromium installs, no driver compatibility issues. Agent browser and playwright are pre-installed.
 
-Available via [API](/api-reference/endpoint/browser-create), [CLI](/sdks/cli#browser) (Bash / agent-browser, Python, Node), [Node SDK](/sdks/node#browser), [Python SDK](/sdks/python#browser), [Vercel AI SDK](/developer-guides/llm-sdks-and-frameworks/vercel-ai-sdk), and [MCP Server](/mcp-server).
+Available via [API](/api-reference/endpoint/browser-create), [Node SDK](/sdks/node#browser), [Python SDK](/sdks/python#browser), and [Vercel AI SDK](/developer-guides/llm-sdks-and-frameworks/vercel-ai-sdk). The hidden `firecrawl browser` CLI command is legacy; CLI and MCP agent flows should use scrape + interact instead.
 
-To add browser support to an AI coding agent (Claude Code, Codex, Open Code, Cursor, etc.), install the Firecrawl skill:
+To add Interact support to an AI coding agent (Claude Code, Codex, Open Code, Cursor, etc.), install the Firecrawl skill:
 
 ```bash
 npx -y firecrawl-cli@latest init --all --browser
@@ -161,6 +166,10 @@ The sandbox filesystem is ephemeral — downloaded files are lost when the sessi
 
 [agent-browser](https://github.com/vercel-labs/agent-browser) is a headless browser CLI pre-installed in every sandbox. Instead of writing Playwright code, agents send simple bash commands. The CLI auto-injects `--cdp` so agent-browser connects to your active session automatically.
 
+<Note>
+The `firecrawl browser` CLI examples below are for legacy Browser Sandbox sessions. For CLI/MCP agent workflows, prefer `firecrawl interact` or the MCP `firecrawl_interact` tool.
+</Note>
+
 ### Shorthand
 
 The fastest way to use browser. Both the shorthand and `execute` send commands to agent-browser automatically. The shorthand just skips `execute` and auto-launches a session if needed:
@@ -197,7 +206,7 @@ Use `language: "bash"` to run agent-browser commands via the API or SDKs:
 <CodeGroup>
 
 ```bash cURL
-curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
+curl -X POST "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID/execute" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/features/search.mdx
+++ b/features/search.mdx
@@ -579,3 +579,8 @@ To help control costs:
 For more details about the scraping options, refer to the [Scrape Feature documentation](https://docs.firecrawl.dev/features/scrape). Everything except for the FIRE-1 Agent and Change-Tracking features are supported by this Search endpoint.
 
 > Are you an AI agent that needs a Firecrawl API key? See [firecrawl.dev/agent-onboarding/SKILL.md](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for automated onboarding instructions.
+
+
+## Search feedback
+
+When a search result is useful or misses important content, submit feedback with `POST /v2/search/{jobId}/feedback`. The first feedback submission for a search job can refund 1 credit, subject to team limits, and helps improve Firecrawl search quality. See [Search Feedback](/api-reference/endpoint/search-feedback).

--- a/mcp-server.mdx
+++ b/mcp-server.mdx
@@ -15,7 +15,6 @@ A Model Context Protocol (MCP) server implementation that integrates [Firecrawl]
 - Parse local files such as PDFs, DOCX, XLSX, and HTML
 - Interact with pages — click, navigate, and operate
 - Deep research with autonomous agent
-- Browser session management
 - Cloud and self-hosted support
 - Streamable HTTP support
 
@@ -24,7 +23,7 @@ A Model Context Protocol (MCP) server implementation that integrates [Firecrawl]
 You can either use our remote hosted URL or run the server locally. Get your API key from [https://firecrawl.dev/app/api-keys](https://www.firecrawl.dev/app/api-keys)
 
 <Note>
-**No API key? Scrape, search, interact, and parse work on the remote keyless URL.** Connect to `https://mcp.firecrawl.dev/v2/mcp` to use the keyless free tier — free, but rate-limited per IP, and unavailable for other tools (crawl, extract, map, etc.). Set `FIRECRAWL_API_KEY` to unlock every tool plus higher limits. See [Rate Limits](/rate-limits#keyless-no-api-key).
+**No API key?** Connect to `https://mcp.firecrawl.dev/v2/mcp` to use the remote keyless free tier. It is free and rate-limited per IP; see [Rate Limits](/rate-limits#keyless-no-api-key) for the current keyless tool list. Set `FIRECRAWL_API_KEY` to unlock every MCP tool plus higher limits.
 </Note>
 
 ### Remote hosted URL
@@ -35,7 +34,7 @@ With an API key (unlocks every tool plus higher limits):
 https://mcp.firecrawl.dev/{FIRECRAWL_API_KEY}/v2/mcp
 ```
 
-Or connect without an API key to get started — scrape, search, interact, and parse work on the remote keyless free tier (rate-limited per IP):
+Or connect without an API key to get started on the remote keyless free tier (rate-limited per IP; see [Rate Limits](/rate-limits#keyless-no-api-key) for the current tool list):
 
 ```bash
 https://mcp.firecrawl.dev/v2/mcp
@@ -314,7 +313,7 @@ This will start the server on `http://localhost:3000/v2/mcp` which you can use i
 
 ### Environment Variables
 
-#### Required for Cloud API
+#### Cloud and self-hosted API
 
 - `FIRECRAWL_API_KEY`: Your Firecrawl API key
   - Required when using cloud API (default)
@@ -323,51 +322,19 @@ This will start the server on `http://localhost:3000/v2/mcp` which you can use i
   - Example: `https://firecrawl.your-domain.com`
   - If not provided, the cloud API will be used (requires API key)
 
-#### Optional Configuration
-
-##### Retry Configuration
-
-- `FIRECRAWL_RETRY_MAX_ATTEMPTS`: Maximum number of retry attempts (default: 3)
-- `FIRECRAWL_RETRY_INITIAL_DELAY`: Initial delay in milliseconds before first retry (default: 1000)
-- `FIRECRAWL_RETRY_MAX_DELAY`: Maximum delay in milliseconds between retries (default: 10000)
-- `FIRECRAWL_RETRY_BACKOFF_FACTOR`: Exponential backoff multiplier (default: 2)
-
-##### Credit Usage Monitoring
-
-- `FIRECRAWL_CREDIT_WARNING_THRESHOLD`: Credit usage warning threshold (default: 1000)
-- `FIRECRAWL_CREDIT_CRITICAL_THRESHOLD`: Credit usage critical threshold (default: 100)
-
 ### Configuration Examples
 
-For cloud API usage with custom retry and credit monitoring:
+For cloud API usage:
 
 ```bash
-# Required for cloud API
 export FIRECRAWL_API_KEY=your-api-key
-
-# Optional retry configuration
-export FIRECRAWL_RETRY_MAX_ATTEMPTS=5        # Increase max retry attempts
-export FIRECRAWL_RETRY_INITIAL_DELAY=2000    # Start with 2s delay
-export FIRECRAWL_RETRY_MAX_DELAY=30000       # Maximum 30s delay
-export FIRECRAWL_RETRY_BACKOFF_FACTOR=3      # More aggressive backoff
-
-# Optional credit monitoring
-export FIRECRAWL_CREDIT_WARNING_THRESHOLD=2000    # Warning at 2000 credits
-export FIRECRAWL_CREDIT_CRITICAL_THRESHOLD=500    # Critical at 500 credits
 ```
 
 For self-hosted instance:
 
 ```bash
-# Required for self-hosted
 export FIRECRAWL_API_URL=https://firecrawl.your-domain.com
-
-# Optional authentication for self-hosted
 export FIRECRAWL_API_KEY=your-api-key  # If your instance requires auth
-
-# Custom retry configuration
-export FIRECRAWL_RETRY_MAX_ATTEMPTS=10
-export FIRECRAWL_RETRY_INITIAL_DELAY=500     # Start with faster retries
 ```
 
 ### Custom configuration with Claude Desktop
@@ -381,67 +348,24 @@ Add this to your `claude_desktop_config.json`:
       "command": "npx",
       "args": ["-y", "firecrawl-mcp"],
       "env": {
-        "FIRECRAWL_API_KEY": "YOUR_API_KEY_HERE",
-
-        "FIRECRAWL_RETRY_MAX_ATTEMPTS": "5",
-        "FIRECRAWL_RETRY_INITIAL_DELAY": "2000",
-        "FIRECRAWL_RETRY_MAX_DELAY": "30000",
-        "FIRECRAWL_RETRY_BACKOFF_FACTOR": "3",
-
-        "FIRECRAWL_CREDIT_WARNING_THRESHOLD": "2000",
-        "FIRECRAWL_CREDIT_CRITICAL_THRESHOLD": "500"
+        "FIRECRAWL_API_KEY": "YOUR_API_KEY_HERE"
       }
     }
   }
 }
 ```
 
-### System Configuration
+### Hosted MCP vs local MCP
 
-The server includes several configurable parameters that can be set via environment variables. Here are the default values if not configured:
+The hosted MCP server is optimized for safe remote use. Some options that are available when running the MCP server locally are narrowed or unavailable remotely:
 
-```typescript
-const CONFIG = {
-  retry: {
-    maxAttempts: 3, // Number of retry attempts for rate-limited requests
-    initialDelay: 1000, // Initial delay before first retry (in milliseconds)
-    maxDelay: 10000, // Maximum delay between retries (in milliseconds)
-    backoffFactor: 2, // Multiplier for exponential backoff
-  },
-  credit: {
-    warningThreshold: 1000, // Warn when credit usage reaches this level
-    criticalThreshold: 100, // Critical alert when credit usage reaches this level
-  },
-};
-```
+- Hosted keyless mode exposes only the keyless-supported tools and is rate-limited per IP.
+- Local-only file reads are available only when you run the MCP server locally.
+- Webhooks and local file paths should be configured from a local or self-hosted MCP server when the agent needs access to local resources.
 
-These configurations control:
+### Rate Limiting
 
-1. **Retry Behavior**
-
-   - Automatically retries failed requests due to rate limits
-   - Uses exponential backoff to avoid overwhelming the API
-   - Example: With default settings, retries will be attempted at:
-     - 1st retry: 1 second delay
-     - 2nd retry: 2 seconds delay
-     - 3rd retry: 4 seconds delay (capped at maxDelay)
-
-2. **Credit Usage Monitoring**
-   - Tracks API credit consumption for cloud API usage
-   - Provides warnings at specified thresholds
-   - Helps prevent unexpected service interruption
-   - Example: With default settings:
-     - Warning at 1000 credits remaining
-     - Critical alert at 100 credits remaining
-
-### Rate Limiting and Batch Processing
-
-The server utilizes Firecrawl's built-in rate limiting and batch processing capabilities:
-
-- Automatic rate limit handling with exponential backoff
-- Efficient parallel processing for batch operations
-- Smart request queuing and throttling
-- Automatic retries for transient errors
+Rate limits are enforced by Firecrawl. Use an API key for higher limits and access to the full tool set.
 
 ## Available Tools
 
@@ -737,115 +661,30 @@ Check the status of an agent job and retrieve results when complete. Poll every 
 
 **Returns:** Status, progress, and results (if completed) of the agent job.
 
-### 10. Create Browser Session (`firecrawl_browser_create`)
+### 10. Interact with a Page (`firecrawl_interact`)
 
-Create a persistent browser session for code execution via CDP (Chrome DevTools Protocol).
+Interact with a page in a live browser session: click buttons, fill forms, extract dynamic content, or navigate deeper.
+
+Use one of two targeting modes:
+
+- Pass `url` to open and interact with a fresh page in one MCP call.
+- Pass `scrapeId` from a previous `firecrawl_scrape` call to reuse the already-loaded page.
+
+Do not pass both `url` and `scrapeId`. Provide either `prompt` or `code`. `scrapeOptions` can only be used with `url` mode.
+
+**URL mode example:**
 
 ```json
 {
-  "name": "firecrawl_browser_create",
+  "name": "firecrawl_interact",
   "arguments": {
-    "ttl": 120,
-    "activityTtl": 60
+    "url": "https://example.com/products",
+    "prompt": "Click on the first product and tell me its price"
   }
 }
 ```
 
-#### Browser Create Options:
-
-- `ttl`: Total session lifetime in seconds (30-3600, optional)
-- `activityTtl`: Idle timeout in seconds (10-3600, optional)
-
-**Best for:** Running code (Python/JS) that interacts with a live browser page, multi-step browser automation, sessions with profiles that survive across multiple tool calls.
-
-**Returns:** Session ID, CDP URL, and live view URL.
-
-### 11. Execute Code in Browser (`firecrawl_browser_execute`)
-
-Execute code in an active browser session. Supports agent-browser commands (bash), Python, or JavaScript.
-
-```json
-{
-  "name": "firecrawl_browser_execute",
-  "arguments": {
-    "sessionId": "session-id-here",
-    "code": "agent-browser open https://example.com",
-    "language": "bash"
-  }
-}
-```
-
-Python example with Playwright:
-
-```json
-{
-  "name": "firecrawl_browser_execute",
-  "arguments": {
-    "sessionId": "session-id-here",
-    "code": "await page.goto('https://example.com')\ntitle = await page.title()\nprint(title)",
-    "language": "python"
-  }
-}
-```
-
-#### Browser Execute Options:
-
-- `sessionId`: The browser session ID (required)
-- `code`: The code to execute (required)
-- `language`: `bash`, `python`, or `node` (optional, defaults to `bash`)
-
-**Common agent-browser commands (bash):**
-- `agent-browser open <url>` -- Navigate to URL
-- `agent-browser snapshot` -- Get accessibility tree with clickable refs
-- `agent-browser click @e5` -- Click element by ref from snapshot
-- `agent-browser type @e3 "text"` -- Type into element
-- `agent-browser screenshot [path]` -- Take screenshot
-- `agent-browser scroll down` -- Scroll page
-- `agent-browser wait 2000` -- Wait 2 seconds
-
-**Returns:** Execution result including stdout, stderr, and exit code.
-
-### 12. Delete Browser Session (`firecrawl_browser_delete`)
-
-Destroy a browser session.
-
-```json
-{
-  "name": "firecrawl_browser_delete",
-  "arguments": {
-    "sessionId": "session-id-here"
-  }
-}
-```
-
-#### Browser Delete Options:
-
-- `sessionId`: The browser session ID to destroy (required)
-
-**Returns:** Success confirmation.
-
-### 13. List Browser Sessions (`firecrawl_browser_list`)
-
-List browser sessions, optionally filtered by status.
-
-```json
-{
-  "name": "firecrawl_browser_list",
-  "arguments": {
-    "status": "active"
-  }
-}
-```
-
-#### Browser List Options:
-
-- `status`: Filter by session status -- `active` or `destroyed` (optional)
-
-**Returns:** Array of browser sessions.
-
-### 14. Interact with Scraped Page (`firecrawl_interact`)
-
-Interact with a previously scraped page in a live browser session. Scrape a page first with `firecrawl_scrape`, then use the returned `scrapeId` (from the scrape response metadata) to click buttons, fill forms, extract dynamic content, or navigate deeper. The response includes a `liveViewUrl` and `interactiveLiveViewUrl` you can open in your browser to watch or control the session in real time.
+**Scrape reuse example:**
 
 ```json
 {
@@ -859,17 +698,19 @@ Interact with a previously scraped page in a live browser session. Scrape a page
 
 #### Interact Tool Options:
 
-- `scrapeId`: The scrape job ID from a previous `firecrawl_scrape` call (required)
-- `prompt`: Natural language instruction describing the action to take (provide `prompt` or `code`)
-- `code`: Code to execute in the browser session (provide `code` or `prompt`)
-- `language`: `bash`, `python`, or `node` (optional, defaults to `node`, only used with `code`)
-- `timeout`: Execution timeout in seconds, 1–300 (optional, defaults to 30)
+- `url`: Page to interact with; opens the session for you. Use this or `scrapeId`.
+- `scrapeId`: Scrape job ID from a previous `firecrawl_scrape` call. Use this or `url`.
+- `prompt`: Natural language instruction describing the action to take. Provide `prompt` or `code`.
+- `code`: Code to execute in the browser session. Provide `code` or `prompt`.
+- `language`: `bash`, `python`, or `node` (optional, defaults to `node`, only used with `code`).
+- `timeout`: Execution timeout in seconds, 1–300 (optional, defaults to 30).
+- `scrapeOptions`: Optional scrape controls used only with `url` mode.
 
 **Best for:** Multi-step workflows on a single page — searching a site, clicking through results, filling forms, extracting data that requires interaction.
 
-**Returns:** Interaction result including `liveViewUrl` and `interactiveLiveViewUrl`.
+**Returns:** Interaction result including output and live view URLs.
 
-### 15. Stop Interact Session (`firecrawl_interact_stop`)
+### 11. Stop Interact Session (`firecrawl_interact_stop`)
 
 Stop an interact session for a scraped page. Call this when you are done interacting to free resources.
 
@@ -894,7 +735,6 @@ The server includes comprehensive logging:
 
 - Operation status and progress
 - Performance metrics
-- Credit usage monitoring
 - Rate limit tracking
 - Error conditions
 
@@ -904,19 +744,16 @@ Example log messages:
 [INFO] Firecrawl MCP Server initialized successfully
 [INFO] Starting scrape for URL: https://example.com
 [INFO] Starting crawl for URL: https://example.com
-[WARNING] Credit usage has reached warning threshold
-[ERROR] Rate limit exceeded, retrying in 2s...
+[ERROR] Rate limit exceeded
 ```
 
 ## Error Handling
 
 The server provides robust error handling:
 
-- Automatic retries for transient errors
-- Rate limit handling with backoff
+- Rate limit errors from the Firecrawl API
 - Detailed error messages
-- Credit usage warnings
-- Network resilience
+- Network errors from the underlying transport
 
 Example error response:
 
@@ -925,7 +762,7 @@ Example error response:
   "content": [
     {
       "type": "text",
-      "text": "Error: Rate limit exceeded. Retrying in 2 seconds..."
+      "text": "Error: Rate limit exceeded"
     }
   ],
   "isError": true

--- a/rate-limits.mdx
+++ b/rate-limits.mdx
@@ -106,7 +106,7 @@ Rate limits are measured in requests per minute and are primarily in place to pr
 
 ### Keyless (no API key)
 
-Scrape, search, and interact can be used **without an API key** when the request comes from an official Firecrawl client — the [MCP server](/mcp-server), the [CLI](/sdks/cli), or an SDK. No other endpoints (crawl, extract, map, batch scrape, etc.) are available without a key.
+Scrape, search, interact, parse, and research can be used **without an API key** when the request comes from an official Firecrawl client — the [MCP server](/mcp-server), the [CLI](/sdks/cli), or an SDK. Research keyless access is available on Firecrawl Cloud where the research index is enabled. No other endpoints (crawl, extract, map, batch scrape, etc.) are available without a key.
 
 Keyless usage is free and capped per IP address per day by **two limits**, and exceeding either returns a `429`:
 

--- a/sdks/cli.mdx
+++ b/sdks/cli.mdx
@@ -50,7 +50,7 @@ You can also manually install the Firecrawl CLI globally using npm:
 Before using the CLI, you need to authenticate with your Firecrawl API key.
 
 <Note>
-**`scrape`, `search`, and `interact` work without logging in.** With no API key configured, these commands fall back to the keyless free tier — free, but rate-limited per IP. All other commands (crawl, map, agent, etc.) require an API key. [Sign up for a free key](https://firecrawl.dev) for 1,000 credits and higher limits; the CLI uses it automatically once configured. See [Rate Limits](/rate-limits#keyless-no-api-key).
+**Some CLI commands work without logging in.** With no API key configured, supported commands fall back to the keyless free tier — free, but rate-limited per IP. See [Rate Limits](/rate-limits#keyless-no-api-key) for the current keyless command list and caveats. [Sign up for a free key](https://firecrawl.dev) for 1,000 credits and higher limits; the CLI uses it automatically once configured.
 </Note>
 
 ### Login
@@ -95,6 +95,11 @@ Output when ready:
 - **Credits**: Remaining API credits. Each scrape/crawl consumes credits.
 
 ## Commands
+
+<Note>
+The hidden `firecrawl browser` command is deprecated for agent workflows. Use `firecrawl scrape` followed by `firecrawl interact`, or use `firecrawl interact <url>` when starting from a URL.
+</Note>
+
 
 ### Scrape
 

--- a/snippets/v2/browser/close/curl.mdx
+++ b/snippets/v2/browser/close/curl.mdx
@@ -1,6 +1,4 @@
 ```bash cURL
-curl -X DELETE "https://api.firecrawl.dev/v2/browser" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"id": "YOUR_SESSION_ID"}'
+curl -X DELETE "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID" \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY"
 ```

--- a/snippets/v2/browser/execute/curl-bash.mdx
+++ b/snippets/v2/browser/execute/curl-bash.mdx
@@ -1,24 +1,24 @@
 ```bash cURL (Bash / agent-browser)
 # Navigate to a page
-curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
+curl -X POST "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID/execute" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{ "code": "agent-browser open https://example.com", "language": "bash" }'
 
 # Get accessibility snapshot with @ref IDs
-curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
+curl -X POST "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID/execute" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{ "code": "agent-browser snapshot", "language": "bash" }'
 
 # Interact using @ref IDs from the snapshot
-curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
+curl -X POST "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID/execute" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{ "code": "agent-browser click @e5", "language": "bash" }'
 
 # Extract page content as markdown
-curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
+curl -X POST "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID/execute" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{ "code": "agent-browser scrape", "language": "bash" }'

--- a/snippets/v2/browser/execute/curl.mdx
+++ b/snippets/v2/browser/execute/curl.mdx
@@ -1,6 +1,6 @@
 ```bash cURL
 # Execute Playwright Python code
-curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
+curl -X POST "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID/execute" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -9,7 +9,7 @@ curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
   }'
 
 # Execute Playwright JavaScript code
-curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
+curl -X POST "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID/execute" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/snippets/v2/browser/launch/curl.mdx
+++ b/snippets/v2/browser/launch/curl.mdx
@@ -1,5 +1,5 @@
 ```bash cURL
-curl -X POST "https://api.firecrawl.dev/v2/browser" \
+curl -X POST "https://api.firecrawl.dev/v2/interact" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/snippets/v2/browser/list/curl.mdx
+++ b/snippets/v2/browser/list/curl.mdx
@@ -1,8 +1,8 @@
 ```bash cURL
-curl -X GET "https://api.firecrawl.dev/v2/browser" \
+curl -X GET "https://api.firecrawl.dev/v2/interact" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY"
 
 # Filter by status
-curl -X GET "https://api.firecrawl.dev/v2/browser?status=active" \
+curl -X GET "https://api.firecrawl.dev/v2/interact?status=active" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY"
 ```

--- a/snippets/v2/browser/persistent/curl.mdx
+++ b/snippets/v2/browser/persistent/curl.mdx
@@ -1,5 +1,5 @@
 ```bash cURL
-curl -X POST "https://api.firecrawl.dev/v2/browser" \
+curl -X POST "https://api.firecrawl.dev/v2/interact" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/snippets/v2/browser/quickstart/curl.mdx
+++ b/snippets/v2/browser/quickstart/curl.mdx
@@ -1,11 +1,11 @@
 ```bash cURL
 # 1. Launch a session
-curl -X POST "https://api.firecrawl.dev/v2/browser" \
+curl -X POST "https://api.firecrawl.dev/v2/interact" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json"
 
 # 2. Execute code
-curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
+curl -X POST "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID/execute" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -13,6 +13,6 @@ curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
   }'
 
 # 3. Close
-curl -X DELETE "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID" \
+curl -X DELETE "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY"
 ```


### PR DESCRIPTION
## Summary
- remove stale MCP browser/batch/retry/credit guidance from agent-facing docs
- document the current MCP `firecrawl_interact` URL-or-scrapeId contract without restoring browser tools
- add missing feedback endpoint docs/navigation and align OpenAPI search feedback
- fix concrete endpoint path mismatches for browser delete and agent activity
- clarify keyless support across docs/CLI, including research where enabled

## Validation
- `python3 -m json.tool docs.json`
- `python3 -m json.tool api-reference/v2-openapi.json`
- grep for removed stale symbols: `firecrawl_browser_`, `FIRECRAWL_RETRY_`, `FIRECRAWL_CREDIT_`, `firecrawl_batch_scrape`, `firecrawl_check_batch_status`
- `git diff --check`

## Notes
- Draft PR for review.
- Localized copies intentionally not edited; regenerate through localization.
