### PR TITLE
docs(feedback): split generic and search feedback references

### DIFF
--- a/api-reference/endpoint/feedback.mdx
+++ b/api-reference/endpoint/feedback.mdx
@@ -1,0 +1,25 @@
+---
+title: 'Endpoint Feedback'
+description: 'Submit feedback for a completed v2 endpoint job.'
+openapi: '/api-reference/v2-openapi.json POST /feedback'
+---
+
+Use endpoint feedback to tell Firecrawl whether a completed job result was useful, partial, or bad. This is for endpoint-level output quality on jobs such as `scrape`, `parse`, `map`, and `search`.
+
+The generic feedback schema can carry search-style fields too, but [Search Feedback](/api-reference/endpoint/search-feedback) is the preferred search-specific entry point because it is scoped to a search job ID and highlights valuable sources, missing content, query suggestions, and refund behavior.
+
+### Example Request
+
+```bash
+curl -X POST "https://api.firecrawl.dev/v2/feedback" \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "endpoint": "scrape",
+    "jobId": "550e8400-e29b-41d4-a716-446655440000",
+    "rating": "partial",
+    "issues": ["missing_markdown"],
+    "note": "The pricing table was missing from the markdown output.",
+    "url": "https://example.com/pricing"
+  }'
+```

--- a/api-reference/endpoint/search-feedback.mdx
+++ b/api-reference/endpoint/search-feedback.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Search Feedback'
+description: 'Submit quality feedback for a search job and help improve Firecrawl search results.'
+openapi: '/api-reference/v2-openapi.json POST /search/{jobId}/feedback'
+---
+
+Use search feedback after a `search` result is used or fails to help. Feedback improves result quality and can refund 1 credit for the first feedback submission on a search job, subject to team limits.
+
+### Example Request
+
+```bash
+curl -X POST "https://api.firecrawl.dev/v2/search/550e8400-e29b-41d4-a716-446655440000/feedback" \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "rating": "good",
+    "valuableSources": [
+      {
+        "url": "https://docs.firecrawl.dev/features/search",
+        "reason": "Most up-to-date description of /search."
+      }
+    ],
+    "missingContent": [
+      {
+        "topic": "Pricing for the search endpoint",
+        "description": "No pricing tier table for /search specifically."
+      }
+    ],
+    "querySuggestions": "Boost docs.firecrawl.dev for queries that mention Firecrawl"
+  }'
+```

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -3895,7 +3895,8 @@
         "summary": "Create an interact session",
         "operationId": "createBrowserSession",
         "tags": [
-          "Interact"        ],
+          "Interact"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -4010,7 +4011,8 @@
         "summary": "List interact sessions",
         "operationId": "listBrowserSessions",
         "tags": [
-          "Interact"        ],
+          "Interact"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -4110,7 +4112,8 @@
         "summary": "Execute code in an interact session",
         "operationId": "executeBrowserCode",
         "tags": [
-          "Interact"        ],
+          "Interact"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -4233,7 +4236,8 @@
         "summary": "Delete an interact session",
         "operationId": "deleteBrowserSession",
         "tags": [
-          "Interact"        ],
+          "Interact"
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -4389,27 +4393,28 @@
       }
     },
     "/search/{jobId}/feedback": {
-      "parameters": [
-        {
-          "name": "jobId",
-          "in": "path",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "description": "The search job ID"
-        }
-      ],
       "post": {
         "summary": "Submit feedback for a search job",
         "operationId": "submitSearchFeedback",
         "tags": [
-          "Search"
+          "Search",
+          "Feedback"
         ],
         "security": [
           {
             "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Search job id returned by /search."
           }
         ],
         "requestBody": {
@@ -4428,145 +4433,47 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SearchFeedbackResponse"
+                  "$ref": "#/components/schemas/FeedbackResponse"
                 }
               }
             }
           },
           "400": {
-            "description": "Bad request",
+            "description": "Invalid request body",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": false
-                    },
-                    "code": {
-                      "type": "string"
-                    },
-                    "error": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": false
-                    },
-                    "code": {
-                      "type": "string"
-                    },
-                    "error": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  }
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Payment required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": false
-                    },
-                    "code": {
-                      "type": "string"
-                    },
-                    "error": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  }
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
                 }
               }
             }
           },
           "403": {
-            "description": "Forbidden",
+            "description": "Feedback is not available for this team",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": false
-                    },
-                    "code": {
-                      "type": "string"
-                    },
-                    "error": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  }
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
                 }
               }
             }
           },
           "404": {
-            "description": "Not found",
+            "description": "Search not found for this team",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": false
-                    },
-                    "code": {
-                      "type": "string"
-                    },
-                    "error": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  }
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
+          "409": {
+            "description": "Feedback cannot be recorded for this search",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": false
-                    },
-                    "code": {
-                      "type": "string"
-                    },
-                    "error": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  }
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
                 }
               }
             }
@@ -4576,20 +4483,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": false
-                    },
-                    "code": {
-                      "type": "string"
-                    },
-                    "error": {
-                      "type": "string"
-                    },
-                    "details": {}
-                  }
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
                 }
               }
             }
@@ -5194,6 +5088,92 @@
           },
           "500": {
             "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/feedback": {
+      "post": {
+        "summary": "Submit feedback for a v2 job",
+        "operationId": "submitEndpointFeedback",
+        "tags": [
+          "Feedback"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EndpointFeedbackRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Feedback recorded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Feedback is not available for this team",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Job not found for this team",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Feedback cannot be recorded for this job",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -8338,13 +8318,14 @@
       },
       "SearchFeedbackRequest": {
         "type": "object",
+        "description": "For 'good', include valuableSources. For 'partial', include valuableSources or missingContent. For 'bad', include missingContent or querySuggestions.",
         "properties": {
           "rating": {
             "type": "string",
             "enum": [
               "good",
-              "bad",
-              "partial"
+              "partial",
+              "bad"
             ]
           },
           "valuableSources": {
@@ -8375,8 +8356,8 @@
               "properties": {
                 "topic": {
                   "type": "string",
-                  "minLength": 1,
-                  "maxLength": 200
+                  "maxLength": 200,
+                  "minLength": 1
                 },
                 "description": {
                   "type": "string",
@@ -8397,58 +8378,13 @@
             "default": "api"
           },
           "integration": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           }
         },
         "required": [
           "rating"
-        ],
-        "description": "Substantive feedback is required by rating: good requires valuableSources; partial requires valuableSources or missingContent; bad requires missingContent or querySuggestions."
-      },
-      "SearchFeedbackResponse": {
-        "type": "object",
-        "properties": {
-          "success": {
-            "type": "boolean"
-          },
-          "feedbackId": {
-            "type": "string"
-          },
-          "creditsRefunded": {
-            "type": "number"
-          },
-          "alreadySubmitted": {
-            "type": "boolean"
-          },
-          "dailyCapReached": {
-            "type": "boolean"
-          },
-          "creditsRefundedToday": {
-            "type": "number"
-          },
-          "dailyRefundCap": {
-            "type": "number"
-          },
-          "warning": {
-            "type": "string"
-          },
-          "error": {
-            "type": "string"
-          },
-          "feedbackErrorCode": {
-            "type": "string",
-            "enum": [
-              "SEARCH_NOT_FOUND",
-              "FEEDBACK_WINDOW_EXPIRED",
-              "SEARCH_FAILED",
-              "PREVIEW_TEAM_NOT_ALLOWED",
-              "TEAM_OPTED_OUT",
-              "INVALID_BODY",
-              "DB_DISABLED",
-              "INTERNAL"
-            ]
-          }
-        }
+        ]
       },
       "SupportAskRequest": {
         "type": "object",
@@ -8921,6 +8857,157 @@
             }
           }
         }
+      },
+      "EndpointFeedbackRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SearchFeedbackRequest"
+          },
+          {
+            "type": "object",
+            "description": "Submit feedback for a v2 job. Include at least one substantive signal such as issues, note, valuableSources, missingContent, querySuggestions, url, or pageNumbers.",
+            "properties": {
+              "endpoint": {
+                "type": "string",
+                "enum": [
+                  "search",
+                  "scrape",
+                  "parse",
+                  "map"
+                ]
+              },
+              "jobId": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "issues": {
+                "type": "array",
+                "maxItems": 20,
+                "items": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9][a-z0-9_-]*$",
+                  "maxLength": 80
+                }
+              },
+              "tags": {
+                "type": "array",
+                "maxItems": 20,
+                "items": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9][a-z0-9_-]*$",
+                  "maxLength": 80
+                }
+              },
+              "note": {
+                "type": "string",
+                "maxLength": 4000
+              },
+              "url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "pageNumbers": {
+                "type": "array",
+                "maxItems": 100,
+                "items": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              },
+              "metadata": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Small endpoint-specific metadata object. Must be 8KB or smaller; do not include full endpoint results."
+              },
+              "missingContent": {
+                "type": "array",
+                "maxItems": 50,
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "topic": {
+                      "type": "string",
+                      "maxLength": 200,
+                      "minLength": 1
+                    },
+                    "description": {
+                      "type": "string",
+                      "maxLength": 2000
+                    }
+                  },
+                  "required": [
+                    "topic"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "endpoint",
+              "jobId"
+            ]
+          }
+        ]
+      },
+      "FeedbackResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "feedbackId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "creditsRefunded": {
+            "type": "number"
+          },
+          "alreadySubmitted": {
+            "type": "boolean"
+          },
+          "dailyCapReached": {
+            "type": "boolean"
+          },
+          "creditsRefundedToday": {
+            "type": "number"
+          },
+          "dailyRefundCap": {
+            "type": "number"
+          },
+          "warning": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "success",
+          "feedbackId",
+          "creditsRefunded"
+        ]
+      },
+      "FeedbackErrorResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": false
+          },
+          "error": {
+            "type": "string"
+          },
+          "feedbackErrorCode": {
+            "type": "string"
+          },
+          "details": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "required": [
+          "success",
+          "error"
+        ]
       }
     }
   },

--- a/docs.json
+++ b/docs.json
@@ -419,9 +419,16 @@
                     ]
                   },
                   {
+                    "group": "Feedback Endpoints",
+                    "pages": [
+                      "api-reference/endpoint/feedback"
+                    ]
+                  },
+                  {
                     "group": "Search Endpoints",
                     "pages": [
-                      "api-reference/endpoint/search"
+                      "api-reference/endpoint/search",
+                      "api-reference/endpoint/search-feedback"
                     ]
                   },
                   {

--- a/features/search.mdx
+++ b/features/search.mdx
@@ -579,3 +579,8 @@ To help control costs:
 For more details about the scraping options, refer to the [Scrape Feature documentation](https://docs.firecrawl.dev/features/scrape). Everything except for the FIRE-1 Agent and Change-Tracking features are supported by this Search endpoint.
 
 > Are you an AI agent that needs a Firecrawl API key? See [firecrawl.dev/agent-onboarding/SKILL.md](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for automated onboarding instructions.
+
+
+## Search feedback
+
+When a search result is useful or misses important content, submit feedback with `POST /v2/search/{jobId}/feedback`. The first feedback submission for a search job can refund 1 credit, subject to team limits, and helps improve Firecrawl search quality. See [Search Feedback](/api-reference/endpoint/search-feedback).


### PR DESCRIPTION
## Summary
- adds API reference pages for generic `/v2/feedback` and `/v2/search/{jobId}/feedback`
- registers both pages in navigation
- surfaces search feedback from the Search feature docs
- syncs the OpenAPI docs shape for both feedback endpoints

## Validation
- `python3 -m json.tool docs.json`
- `python3 -m json.tool api-reference/v2-openapi.json`
- reviewed MDX diffs

## Scope
Draft PR split from the grouped surface-parity cleanup; issue-scoped so it can merge independently.