### PR TITLE
docs(browser): clarify interact as the agent surface

### DIFF
--- a/api-reference/endpoint/browser-delete.mdx
+++ b/api-reference/endpoint/browser-delete.mdx
@@ -9,13 +9,12 @@ openapi: '/api-reference/v2-openapi.json DELETE /interact/{sessionId}'
 | Header | Value |
 |--------|-------|
 | `Authorization` | `Bearer <API_KEY>` |
-| `Content-Type` | `application/json` |
 
-## Request Body
+## Path Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `id` | string | Yes | The session ID to destroy |
+| `sessionId` | string | Yes | The Interact session ID to destroy |
 
 ## Response
 
@@ -26,12 +25,8 @@ openapi: '/api-reference/v2-openapi.json DELETE /interact/{sessionId}'
 ### Example Request
 
 ```bash
-curl -X DELETE "https://api.firecrawl.dev/v2/interact" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "id": "550e8400-e29b-41d4-a716-446655440000"
-  }'
+curl -X DELETE "https://api.firecrawl.dev/v2/interact/550e8400-e29b-41d4-a716-446655440000" \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY"
 ```
 
 ### Example Response

--- a/features/browser.mdx
+++ b/features/browser.mdx
@@ -39,15 +39,20 @@ import ListPython from "/snippets/v2/browser/list/python.mdx";
 import ClosePython from "/snippets/v2/browser/close/python.mdx";
 
 <Info>
-Browser Sandbox is now [Interact](/features/interact), which offers the same features plus it can be controlled via prompts.
+For agent workflows, use [Interact](/features/interact). Interact is the supported CLI/MCP path and can be driven with prompts or code after a scrape; MCP also supports opening from a URL directly.
 </Info>
 
-Firecrawl Browser Sandbox gives your agents a secure browser environment where agents can interact with the web. Fill out forms, click buttons, authenticate, and more.
+| Surface | Use it for | Entry point | Agent surface |
+|---|---|---|---|
+| Browser Sandbox | Standalone browser sessions for API/SDK users that need a sandbox, CDP URL, live view, or persistent session lifecycle | `POST /v2/interact` | API and SDKs; hidden CLI browser command is legacy |
+| Interact | Acting on a scraped page; MCP can also open from a URL with `firecrawl_interact` URL mode | `POST /v2/scrape/{scrapeId}/interact`, CLI `interact` after scrape, or MCP `firecrawl_interact` | Recommended for CLI/MCP agent workflows |
+
+Firecrawl Browser Sandbox gives API and SDK users a secure browser environment where agents can interact with the web. Fill out forms, click buttons, authenticate, and more.
 No local setup, no Chromium installs, no driver compatibility issues. Agent browser and playwright are pre-installed.
 
-Available via [API](/api-reference/endpoint/browser-create), [CLI](/sdks/cli#browser) (Bash / agent-browser, Python, Node), [Node SDK](/sdks/node#browser), [Python SDK](/sdks/python#browser), [Vercel AI SDK](/developer-guides/llm-sdks-and-frameworks/vercel-ai-sdk), and [MCP Server](/mcp-server).
+Available via [API](/api-reference/endpoint/browser-create), [Node SDK](/sdks/node#browser), [Python SDK](/sdks/python#browser), and [Vercel AI SDK](/developer-guides/llm-sdks-and-frameworks/vercel-ai-sdk). The hidden `firecrawl browser` CLI command is legacy; CLI and MCP agent flows should use scrape + interact instead.
 
-To add browser support to an AI coding agent (Claude Code, Codex, Open Code, Cursor, etc.), install the Firecrawl skill:
+To add Interact support to an AI coding agent (Claude Code, Codex, Open Code, Cursor, etc.), install the Firecrawl skill:
 
 ```bash
 npx -y firecrawl-cli@latest init --all --browser
@@ -161,6 +166,10 @@ The sandbox filesystem is ephemeral — downloaded files are lost when the sessi
 
 [agent-browser](https://github.com/vercel-labs/agent-browser) is a headless browser CLI pre-installed in every sandbox. Instead of writing Playwright code, agents send simple bash commands. The CLI auto-injects `--cdp` so agent-browser connects to your active session automatically.
 
+<Note>
+The `firecrawl browser` CLI examples below are for legacy Browser Sandbox sessions. For CLI/MCP agent workflows, prefer `firecrawl interact` or the MCP `firecrawl_interact` tool.
+</Note>
+
 ### Shorthand
 
 The fastest way to use browser. Both the shorthand and `execute` send commands to agent-browser automatically. The shorthand just skips `execute` and auto-launches a session if needed:
@@ -197,7 +206,7 @@ Use `language: "bash"` to run agent-browser commands via the API or SDKs:
 <CodeGroup>
 
 ```bash cURL
-curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
+curl -X POST "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID/execute" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/sdks/cli.mdx
+++ b/sdks/cli.mdx
@@ -96,6 +96,11 @@ Output when ready:
 
 ## Commands
 
+<Note>
+The hidden `firecrawl browser` command is deprecated for agent workflows. Use `firecrawl scrape <url>` first, then `firecrawl interact ...` with the resulting scrape session.
+</Note>
+
+
 ### Scrape
 
 Scrape a single URL and extract its content in various formats.

--- a/snippets/v2/browser/close/curl.mdx
+++ b/snippets/v2/browser/close/curl.mdx
@@ -1,6 +1,4 @@
 ```bash cURL
-curl -X DELETE "https://api.firecrawl.dev/v2/browser" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"id": "YOUR_SESSION_ID"}'
+curl -X DELETE "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID" \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY"
 ```

--- a/snippets/v2/browser/execute/curl-bash.mdx
+++ b/snippets/v2/browser/execute/curl-bash.mdx
@@ -1,24 +1,24 @@
 ```bash cURL (Bash / agent-browser)
 # Navigate to a page
-curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
+curl -X POST "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID/execute" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{ "code": "agent-browser open https://example.com", "language": "bash" }'
 
 # Get accessibility snapshot with @ref IDs
-curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
+curl -X POST "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID/execute" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{ "code": "agent-browser snapshot", "language": "bash" }'
 
 # Interact using @ref IDs from the snapshot
-curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
+curl -X POST "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID/execute" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{ "code": "agent-browser click @e5", "language": "bash" }'
 
 # Extract page content as markdown
-curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
+curl -X POST "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID/execute" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{ "code": "agent-browser scrape", "language": "bash" }'

--- a/snippets/v2/browser/execute/curl.mdx
+++ b/snippets/v2/browser/execute/curl.mdx
@@ -1,6 +1,6 @@
 ```bash cURL
 # Execute Playwright Python code
-curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
+curl -X POST "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID/execute" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -9,7 +9,7 @@ curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
   }'
 
 # Execute Playwright JavaScript code
-curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
+curl -X POST "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID/execute" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/snippets/v2/browser/launch/curl.mdx
+++ b/snippets/v2/browser/launch/curl.mdx
@@ -1,5 +1,5 @@
 ```bash cURL
-curl -X POST "https://api.firecrawl.dev/v2/browser" \
+curl -X POST "https://api.firecrawl.dev/v2/interact" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/snippets/v2/browser/list/curl.mdx
+++ b/snippets/v2/browser/list/curl.mdx
@@ -1,8 +1,8 @@
 ```bash cURL
-curl -X GET "https://api.firecrawl.dev/v2/browser" \
+curl -X GET "https://api.firecrawl.dev/v2/interact" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY"
 
 # Filter by status
-curl -X GET "https://api.firecrawl.dev/v2/browser?status=active" \
+curl -X GET "https://api.firecrawl.dev/v2/interact?status=active" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY"
 ```

--- a/snippets/v2/browser/persistent/curl.mdx
+++ b/snippets/v2/browser/persistent/curl.mdx
@@ -1,5 +1,5 @@
 ```bash cURL
-curl -X POST "https://api.firecrawl.dev/v2/browser" \
+curl -X POST "https://api.firecrawl.dev/v2/interact" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/snippets/v2/browser/quickstart/curl.mdx
+++ b/snippets/v2/browser/quickstart/curl.mdx
@@ -1,11 +1,11 @@
 ```bash cURL
 # 1. Launch a session
-curl -X POST "https://api.firecrawl.dev/v2/browser" \
+curl -X POST "https://api.firecrawl.dev/v2/interact" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json"
 
 # 2. Execute code
-curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
+curl -X POST "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID/execute" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -13,6 +13,6 @@ curl -X POST "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID/execute" \
   }'
 
 # 3. Close
-curl -X DELETE "https://api.firecrawl.dev/v2/browser/YOUR_SESSION_ID" \
+curl -X DELETE "https://api.firecrawl.dev/v2/interact/YOUR_SESSION_ID" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY"
 ```


### PR DESCRIPTION
## Summary
- clarifies Browser Sandbox as API/SDK-oriented while CLI/MCP agent workflows should use Interact
- marks hidden `firecrawl browser` CLI as legacy for agent workflows
- updates browser cURL snippets to the `/v2/interact` alias used by the current endpoint docs
- fixes browser delete docs to use `DELETE /v2/interact/{sessionId}` with a path param

## Validation
- reviewed MDX/snippet diffs

## Scope
Draft PR split from the grouped surface-parity cleanup; issue-scoped so it can merge independently.