### PR TITLE
docs(keyless): centralize CLI keyless availability

### DIFF
--- a/rate-limits.mdx
+++ b/rate-limits.mdx
@@ -106,7 +106,7 @@ Rate limits are measured in requests per minute and are primarily in place to pr
 
 ### Keyless (no API key)
 
-Scrape, search, and interact can be used **without an API key** when the request comes from an official Firecrawl client — the [MCP server](/mcp-server), the [CLI](/sdks/cli), or an SDK. No other endpoints (crawl, extract, map, batch scrape, etc.) are available without a key.
+Scrape, search, interact, and parse can be used **without an API key** when the request comes from an official Firecrawl client — the [MCP server](/mcp-server), the [CLI](/sdks/cli), or an SDK. Research endpoints can also be used without an API key on Firecrawl Cloud where the research index is enabled. No other endpoints (crawl, extract, map, batch scrape, etc.) are available without a key.
 
 Keyless usage is free and capped per IP address per day by **two limits**, and exceeding either returns a `429`:
 

--- a/sdks/cli.mdx
+++ b/sdks/cli.mdx
@@ -50,7 +50,7 @@ You can also manually install the Firecrawl CLI globally using npm:
 Before using the CLI, you need to authenticate with your Firecrawl API key.
 
 <Note>
-**`scrape`, `search`, and `interact` work without logging in.** With no API key configured, these commands fall back to the keyless free tier — free, but rate-limited per IP. All other commands (crawl, map, agent, etc.) require an API key. [Sign up for a free key](https://firecrawl.dev) for 1,000 credits and higher limits; the CLI uses it automatically once configured. See [Rate Limits](/rate-limits#keyless-no-api-key).
+**Some CLI commands work without logging in.** With no API key configured, supported commands fall back to the keyless free tier — free, but rate-limited per IP. See [Rate Limits](/rate-limits#keyless-no-api-key) for the current keyless command list and caveats. [Sign up for a free key](https://firecrawl.dev) for 1,000 credits and higher limits; the CLI uses it automatically once configured.
 </Note>
 
 ### Login


### PR DESCRIPTION
## Summary
- updates the keyless rate-limit copy to include parse and Cloud/config-gated research
- changes CLI auth docs to point at the canonical keyless list instead of hardcoding a stale subset

## Validation
- reviewed MDX diffs

## Scope
Draft PR split from the grouped surface-parity cleanup; issue-scoped so it can merge independently.