### PR TITLE
docs(adk): remove nonexistent MCP batch tools

### DIFF
--- a/developer-guides/llm-sdks-and-frameworks/google-adk.mdx
+++ b/developer-guides/llm-sdks-and-frameworks/google-adk.mdx
@@ -13,7 +13,7 @@ Firecrawl provides an MCP server that seamlessly integrates with Google's ADK, e
 
 - Efficient web scraping, crawling, and content discovery from any website
 - Advanced search capabilities and intelligent content extraction
-- Deep research and high-volume batch scraping
+- Deep research
 - Flexible deployment (cloud-based or self-hosted)
 - Optimized for modern web environments with streamable HTTP support
 
@@ -86,8 +86,6 @@ root_agent = Agent(
 | Tool | Name | Description |
 |------|------|-------------|
 | Scrape Tool | `firecrawl_scrape` | Scrape content from a single URL with advanced options |
-| Batch Scrape Tool | `firecrawl_batch_scrape` | Scrape multiple URLs efficiently with built-in rate limiting and parallel processing |
-| Check Batch Status | `firecrawl_check_batch_status` | Check the status of a batch operation |
 | Map Tool | `firecrawl_map` | Map a website to discover all indexed URLs on the site |
 | Search Tool | `firecrawl_search` | Search the web and optionally extract content from search results |
 | Crawl Tool | `firecrawl_crawl` | Start an asynchronous crawl with advanced options |
@@ -157,14 +155,14 @@ print(response)
 1. **Use the right tool for the job**:
    - `firecrawl_search` when you need to find relevant pages first
    - `firecrawl_scrape` for single pages
-   - `firecrawl_batch_scrape` for multiple known URLs
    - `firecrawl_crawl` for discovering and scraping entire sites
+   - repeated `firecrawl_scrape` calls when you already have a short list of known URLs
 
 2. **Monitor your usage**: Configure credit thresholds to avoid unexpected usage
 
 3. **Handle errors gracefully**: Configure retry settings based on your use case
 
-4. **Optimize performance**: Use batch operations when scraping multiple URLs
+4. **Optimize performance**: Use `firecrawl_map` before scraping when the agent needs to discover relevant URLs.
 
 ---
 


### PR DESCRIPTION
## Summary
- removes nonexistent MCP batch scrape/status tools from the Google ADK guide
- routes short known URL lists to repeated `firecrawl_scrape` and discovery flows to `firecrawl_map`/`firecrawl_crawl`

## Validation
- reviewed MDX diff

## Scope
Draft PR split from the grouped surface-parity cleanup; issue-scoped so it can merge independently.