### PR TITLE
docs(adk): remove unsupported MCP retry and credit env vars

### DIFF
--- a/developer-guides/llm-sdks-and-frameworks/google-adk.mdx
+++ b/developer-guides/llm-sdks-and-frameworks/google-adk.mdx
@@ -109,15 +109,6 @@ root_agent = Agent(
 - Example: `https://firecrawl.your-domain.com`
 - If not provided, the cloud API will be used
 
-**Retry configuration**:
-- `FIRECRAWL_RETRY_MAX_ATTEMPTS`: Maximum retry attempts (default: 3)
-- `FIRECRAWL_RETRY_INITIAL_DELAY`: Initial delay in milliseconds (default: 1000)
-- `FIRECRAWL_RETRY_MAX_DELAY`: Maximum delay in milliseconds (default: 10000)
-- `FIRECRAWL_RETRY_BACKOFF_FACTOR`: Exponential backoff multiplier (default: 2)
-
-**Credit usage monitoring**:
-- `FIRECRAWL_CREDIT_WARNING_THRESHOLD`: Warning threshold (default: 1000)
-- `FIRECRAWL_CREDIT_CRITICAL_THRESHOLD`: Critical threshold (default: 100)
 
 ## Example: Web Research Agent
 
@@ -160,9 +151,9 @@ print(response)
    - `firecrawl_batch_scrape` for multiple known URLs
    - `firecrawl_crawl` for discovering and scraping entire sites
 
-2. **Monitor your usage**: Configure credit thresholds to avoid unexpected usage
+2. **Monitor your usage**: Use your Firecrawl dashboard and API responses to track credit usage.
 
-3. **Handle errors gracefully**: Configure retry settings based on your use case
+3. **Handle errors gracefully**: Surface MCP/API errors to the user and retry only when your agent workflow can do so safely.
 
 4. **Optimize performance**: Use batch operations when scraping multiple URLs
 


### PR DESCRIPTION
## Summary
- removes unsupported `FIRECRAWL_RETRY_*` and `FIRECRAWL_CREDIT_*` MCP env vars from the Google ADK guide
- changes usage/error guidance to dashboard/API-response monitoring and workflow-owned retry behavior

## Validation
- reviewed MDX diff

## Scope
Draft PR split from the grouped surface-parity cleanup; issue-scoped so it can merge independently.