### PR TITLE
docs(mcp): document interact instead of browser tools

### DIFF
--- a/mcp-server.mdx
+++ b/mcp-server.mdx
@@ -15,7 +15,6 @@ A Model Context Protocol (MCP) server implementation that integrates [Firecrawl]
 - Parse local files such as PDFs, DOCX, XLSX, and HTML
 - Interact with pages — click, navigate, and operate
 - Deep research with autonomous agent
-- Browser session management
 - Cloud and self-hosted support
 - Streamable HTTP support
 
@@ -737,115 +736,30 @@ Check the status of an agent job and retrieve results when complete. Poll every 
 
 **Returns:** Status, progress, and results (if completed) of the agent job.
 
-### 10. Create Browser Session (`firecrawl_browser_create`)
+### 10. Interact with a Page (`firecrawl_interact`)
 
-Create a persistent browser session for code execution via CDP (Chrome DevTools Protocol).
+Interact with a page in a live browser session: click buttons, fill forms, extract dynamic content, or navigate deeper.
+
+Use one of two targeting modes:
+
+- Pass `url` to open and interact with a fresh page in one MCP call.
+- Pass `scrapeId` from a previous `firecrawl_scrape` call to reuse the already-loaded page.
+
+Do not pass both `url` and `scrapeId`. Provide either `prompt` or `code`. `scrapeOptions` can only be used with `url` mode.
+
+**URL mode example:**
 
 ```json
 {
-  "name": "firecrawl_browser_create",
+  "name": "firecrawl_interact",
   "arguments": {
-    "ttl": 120,
-    "activityTtl": 60
+    "url": "https://example.com/products",
+    "prompt": "Click on the first product and tell me its price"
   }
 }
 ```
 
-#### Browser Create Options:
-
-- `ttl`: Total session lifetime in seconds (30-3600, optional)
-- `activityTtl`: Idle timeout in seconds (10-3600, optional)
-
-**Best for:** Running code (Python/JS) that interacts with a live browser page, multi-step browser automation, sessions with profiles that survive across multiple tool calls.
-
-**Returns:** Session ID, CDP URL, and live view URL.
-
-### 11. Execute Code in Browser (`firecrawl_browser_execute`)
-
-Execute code in an active browser session. Supports agent-browser commands (bash), Python, or JavaScript.
-
-```json
-{
-  "name": "firecrawl_browser_execute",
-  "arguments": {
-    "sessionId": "session-id-here",
-    "code": "agent-browser open https://example.com",
-    "language": "bash"
-  }
-}
-```
-
-Python example with Playwright:
-
-```json
-{
-  "name": "firecrawl_browser_execute",
-  "arguments": {
-    "sessionId": "session-id-here",
-    "code": "await page.goto('https://example.com')\ntitle = await page.title()\nprint(title)",
-    "language": "python"
-  }
-}
-```
-
-#### Browser Execute Options:
-
-- `sessionId`: The browser session ID (required)
-- `code`: The code to execute (required)
-- `language`: `bash`, `python`, or `node` (optional, defaults to `bash`)
-
-**Common agent-browser commands (bash):**
-- `agent-browser open <url>` -- Navigate to URL
-- `agent-browser snapshot` -- Get accessibility tree with clickable refs
-- `agent-browser click @e5` -- Click element by ref from snapshot
-- `agent-browser type @e3 "text"` -- Type into element
-- `agent-browser screenshot [path]` -- Take screenshot
-- `agent-browser scroll down` -- Scroll page
-- `agent-browser wait 2000` -- Wait 2 seconds
-
-**Returns:** Execution result including stdout, stderr, and exit code.
-
-### 12. Delete Browser Session (`firecrawl_browser_delete`)
-
-Destroy a browser session.
-
-```json
-{
-  "name": "firecrawl_browser_delete",
-  "arguments": {
-    "sessionId": "session-id-here"
-  }
-}
-```
-
-#### Browser Delete Options:
-
-- `sessionId`: The browser session ID to destroy (required)
-
-**Returns:** Success confirmation.
-
-### 13. List Browser Sessions (`firecrawl_browser_list`)
-
-List browser sessions, optionally filtered by status.
-
-```json
-{
-  "name": "firecrawl_browser_list",
-  "arguments": {
-    "status": "active"
-  }
-}
-```
-
-#### Browser List Options:
-
-- `status`: Filter by session status -- `active` or `destroyed` (optional)
-
-**Returns:** Array of browser sessions.
-
-### 14. Interact with Scraped Page (`firecrawl_interact`)
-
-Interact with a previously scraped page in a live browser session. Scrape a page first with `firecrawl_scrape`, then use the returned `scrapeId` (from the scrape response metadata) to click buttons, fill forms, extract dynamic content, or navigate deeper. The response includes a `liveViewUrl` and `interactiveLiveViewUrl` you can open in your browser to watch or control the session in real time.
+**Scrape reuse example:**
 
 ```json
 {
@@ -859,17 +773,19 @@ Interact with a previously scraped page in a live browser session. Scrape a page
 
 #### Interact Tool Options:
 
-- `scrapeId`: The scrape job ID from a previous `firecrawl_scrape` call (required)
-- `prompt`: Natural language instruction describing the action to take (provide `prompt` or `code`)
-- `code`: Code to execute in the browser session (provide `code` or `prompt`)
-- `language`: `bash`, `python`, or `node` (optional, defaults to `node`, only used with `code`)
-- `timeout`: Execution timeout in seconds, 1–300 (optional, defaults to 30)
+- `url`: Page to interact with; opens the session for you. Use this or `scrapeId`.
+- `scrapeId`: Scrape job ID from a previous `firecrawl_scrape` call. Use this or `url`.
+- `prompt`: Natural language instruction describing the action to take. Provide `prompt` or `code`.
+- `code`: Code to execute in the browser session. Provide `code` or `prompt`.
+- `language`: `bash`, `python`, or `node` (optional, defaults to `node`, only used with `code`).
+- `timeout`: Execution timeout in seconds, 1–300 (optional, defaults to 30).
+- `scrapeOptions`: Optional scrape controls used only with `url` mode.
 
 **Best for:** Multi-step workflows on a single page — searching a site, clicking through results, filling forms, extracting data that requires interaction.
 
-**Returns:** Interaction result including `liveViewUrl` and `interactiveLiveViewUrl`.
+**Returns:** Interaction result including output and live view URLs.
 
-### 15. Stop Interact Session (`firecrawl_interact_stop`)
+### 11. Stop Interact Session (`firecrawl_interact_stop`)
 
 Stop an interact session for a scraped page. Call this when you are done interacting to free resources.
 


### PR DESCRIPTION
## Summary
- removes stale `firecrawl_browser_*` tool docs from the MCP page
- documents `firecrawl_interact` as the supported MCP browser-capable path with `url` or `scrapeId`
- keeps old browser CRUD tools out of MCP docs to preserve the lighter agent surface

## Validation
- reviewed MDX diff

## Scope
Draft PR split from the grouped surface-parity cleanup; issue-scoped so it can merge independently.