### PR TITLE
docs(mcp): link keyless copy to canonical limits

### DIFF
--- a/mcp-server.mdx
+++ b/mcp-server.mdx
@@ -24,7 +24,7 @@ A Model Context Protocol (MCP) server implementation that integrates [Firecrawl]
 You can either use our remote hosted URL or run the server locally. Get your API key from [https://firecrawl.dev/app/api-keys](https://www.firecrawl.dev/app/api-keys)
 
 <Note>
-**No API key? Scrape, search, interact, and parse work on the remote keyless URL.** Connect to `https://mcp.firecrawl.dev/v2/mcp` to use the keyless free tier — free, but rate-limited per IP, and unavailable for other tools (crawl, extract, map, etc.). Set `FIRECRAWL_API_KEY` to unlock every tool plus higher limits. See [Rate Limits](/rate-limits#keyless-no-api-key).
+**No API key?** Connect to `https://mcp.firecrawl.dev/v2/mcp` to use the remote keyless free tier. It is free and rate-limited per IP; see [Rate Limits](/rate-limits#keyless-no-api-key) for the current keyless tool list. Set `FIRECRAWL_API_KEY` to unlock every MCP tool plus higher limits.
 </Note>
 
 ### Remote hosted URL
@@ -35,7 +35,7 @@ With an API key (unlocks every tool plus higher limits):
 https://mcp.firecrawl.dev/{FIRECRAWL_API_KEY}/v2/mcp
 ```
 
-Or connect without an API key to get started — scrape, search, interact, and parse work on the remote keyless free tier (rate-limited per IP):
+Or connect without an API key to get started on the remote keyless free tier (rate-limited per IP; see [Rate Limits](/rate-limits#keyless-no-api-key) for the current tool list):
 
 ```bash
 https://mcp.firecrawl.dev/v2/mcp


### PR DESCRIPTION
## Summary
- stops hardcoding the MCP keyless tool subset on the install page
- points hosted keyless users to the canonical Rate Limits keyless matrix

## Validation
- reviewed MDX diff

## Scope
Draft PR split from the grouped surface-parity cleanup; issue-scoped so it can merge independently.