### PR TITLE
docs(activity): fix agent retrieval endpoint

### DIFF
--- a/api-reference/endpoint/activity.mdx
+++ b/api-reference/endpoint/activity.mdx
@@ -10,4 +10,4 @@ Lists your recent API activity from the last 24 hours. Use this to discover job 
 | `scrape` | `GET /v2/scrape/{id}` |
 | `crawl` | `GET /v2/crawl/{id}` |
 | `batch_scrape` | `GET /v2/batch/scrape/{id}` |
-| `agent` | `GET /v2/extract/{id}` |
+| `agent` | `GET /v2/agent/{jobId}` |


### PR DESCRIPTION
## Summary
- fixes the Activity table agent retrieval endpoint from `/v2/extract/{id}` to `/v2/agent/{jobId}`

## Validation
- reviewed the one-line MDX diff

## Scope
Draft PR split from #1075 so feedback docs and activity endpoint cleanup can merge independently.