### PR TITLE
docs(research): add life-science usage details

### DIFF
--- a/features/research.mdx
+++ b/features/research.mdx
@@ -6,13 +6,15 @@ og:description: "Use Firecrawl's research index for paper retrieval, semantic ex
 icon: "book-open"
 ---
 
-Firecrawl Research is a purpose-built index for scientific and engineering research agents. It exposes a research-specific toolset for searching papers, inspecting paper metadata, reading relevant full-text passages, discovering related papers through structural expansion, and searching over research-related GitHub repos.
+Firecrawl Research is a purpose-built index for scientific, biomedical, life-science, and engineering research agents. It exposes a research-specific toolset for searching papers, inspecting paper metadata, reading relevant full-text passages, discovering related papers through structural expansion, and searching over research-related GitHub repos.
 
 - Find papers by topic, method, benchmark, author, or category
 - Inspect canonical paper metadata and source ids
 - Read the passages in one paper that answer a specific question
 - Expand from strong seed papers to related papers, citers, or references
 - Search GitHub history and READMEs for implementation notes, bugs, and design discussions
+
+For life-science and biomedical workflows, use the same Research Index tools to search papers by topic, inspect canonical ids, read passages to verify methods or results, and expand from strong seed papers to related work.
 
 <Note>
 To give your agent access to the Research Index, we strongly recommend using our [CLI](/sdks/cli) or [MCP](/mcp-server), combined with our [**dedicated research skill**](https://github.com/firecrawl/skills/blob/main/skills/firecrawl-research-index/SKILL.md), which you can install with:
@@ -43,6 +45,7 @@ curl -s "https://api.firecrawl.dev/v2/search/research/papers?query=diffusion%20i
 
 ```bash CLI
 firecrawl research search-papers "diffusion image synthesis" --limit 20
+firecrawl research search-papers "single-cell RNA-seq batch correction" --limit 20
 ```
 
 ```python Python
@@ -82,7 +85,7 @@ Optional filters:
 
 ## Inspect a paper
 
-Use a canonical `paperId` or a source-specific `primaryId`.
+Use a canonical `paperId` or a source-specific `primaryId`, such as `arxiv:`, `pmid:`, `pmcid:`, or `doi:`.
 
 <CodeGroup>
 


### PR DESCRIPTION
## Summary
- Adds life-science / biomedical positioning to the existing Research Index page
- Adds a verified CLI paper-search example for single-cell RNA-seq batch correction
- Clarifies accepted paper id prefixes for inspect/read workflows (`arxiv:`, `pmid:`, `pmcid:`, `doi:`)

## Notes
- Keeps this scoped to the existing Research Index endpoints
- Does not add domain counts, new categories, or a separate life-science endpoint story
- Does not touch localized files

## Verification
- Pulled latest `origin/main` before branching
- Static check: only `features/research.mdx` changed
- Static check: no localized files touched
- Static check: MDX code-fence balance passed
- Live CLI check: `env -u FIRECRAWL_API_KEY npx -y firecrawl-cli@latest research search-papers "single-cell RNA-seq batch correction" --limit 3 --json` returned relevant PMCID batch-correction results

Not tested: Mintlify preview/build because `mint` is not installed locally.