### PR TITLE
docs: surface life sciences in research index

### DIFF
--- a/api-reference/endpoint/research-search-papers.mdx
+++ b/api-reference/endpoint/research-search-papers.mdx
@@ -3,6 +3,6 @@ title: "Search Papers"
 openapi: "/api-reference/v2-openapi.json GET /search/research/papers"
 ---
 
-Search papers by topic, method, benchmark, author, category, biomedical concept, or life-science research question. Results include canonical `paperId`, preferred `primaryId`, source ids, title, abstract, score, and optional ranking signals.
+Search papers by topic, method, benchmark, author, or category. Results include canonical `paperId`, preferred `primaryId`, source ids, title, abstract, score, and optional ranking signals.
 
 For a workflow overview, see the [Research Index guide](/features/research).

--- a/api-reference/endpoint/research-search-papers.mdx
+++ b/api-reference/endpoint/research-search-papers.mdx
@@ -3,6 +3,6 @@ title: "Search Papers"
 openapi: "/api-reference/v2-openapi.json GET /search/research/papers"
 ---
 
-Search papers by topic, method, benchmark, author, or category. Results include canonical `paperId`, preferred `primaryId`, source ids, title, abstract, score, and optional ranking signals.
+Search papers by topic, method, benchmark, author, category, biomedical concept, or life-science research question. Results include canonical `paperId`, preferred `primaryId`, source ids, title, abstract, score, and optional ranking signals.
 
 For a workflow overview, see the [Research Index guide](/features/research).

--- a/features/research.mdx
+++ b/features/research.mdx
@@ -6,11 +6,11 @@ og:description: "Use Firecrawl's research index for paper retrieval, semantic ex
 icon: "book-open"
 ---
 
-Firecrawl Research is a purpose-built index for scientific and engineering research agents. It exposes a research-specific toolset for searching papers, inspecting paper metadata, reading relevant full-text passages, discovering related papers through structural expansion, and searching over research-related GitHub repos.
+Firecrawl Research is a purpose-built index for scientific, engineering, and life-science research agents. It exposes a research-specific toolset for searching papers, inspecting paper metadata, reading relevant full-text passages, discovering related papers through structural expansion, and searching over research-related GitHub repos.
 
-- Find papers by topic, method, benchmark, author, or category
+- Find papers by topic, method, benchmark, author, category, or biomedical concept
 - Inspect canonical paper metadata and source ids
-- Read the passages in one paper that answer a specific question
+- Read the passages in one paper that answer a specific question about drug discovery, clinical trials, biology, genomics, or another research topic
 - Expand from strong seed papers to related papers, citers, or references
 - Search GitHub history and READMEs for implementation notes, bugs, and design discussions
 
@@ -72,6 +72,12 @@ console.log(result);
 ```
 
 </CodeGroup>
+
+Life-science queries work the same way for topics such as drug discovery, clinical trials, biology, genomics, and biomedical research:
+
+```bash cURL
+curl -s "https://api.firecrawl.dev/v2/search/research/papers?query=CRISPR%20gene%20editing%20therapy&k=20"
+```
 
 Optional filters:
 

--- a/features/research.mdx
+++ b/features/research.mdx
@@ -6,7 +6,7 @@ og:description: "Use Firecrawl's research index for paper retrieval, semantic ex
 icon: "book-open"
 ---
 
-Firecrawl Research is a purpose-built index for scientific and engineering research agents. It exposes a research-specific toolset for searching papers, inspecting paper metadata, reading relevant full-text passages, discovering related papers through structural expansion, and searching over research-related GitHub repos.
+Firecrawl Research is a purpose-built index for life-sciences and engineering research agents. It exposes a research-specific toolset for searching papers, inspecting paper metadata, reading relevant full-text passages, discovering related papers through structural expansion, and searching over research-related GitHub repos.
 
 - Find papers by topic, method, benchmark, author, or category
 - Inspect canonical paper metadata and source ids

--- a/features/research.mdx
+++ b/features/research.mdx
@@ -6,11 +6,11 @@ og:description: "Use Firecrawl's research index for paper retrieval, semantic ex
 icon: "book-open"
 ---
 
-Firecrawl Research is a purpose-built index for scientific, engineering, and life-science research agents. It exposes a research-specific toolset for searching papers, inspecting paper metadata, reading relevant full-text passages, discovering related papers through structural expansion, and searching over research-related GitHub repos.
+Firecrawl Research is a purpose-built index for scientific and engineering research agents. It exposes a research-specific toolset for searching papers, inspecting paper metadata, reading relevant full-text passages, discovering related papers through structural expansion, and searching over research-related GitHub repos.
 
-- Find papers by topic, method, benchmark, author, category, or biomedical concept
+- Find papers by topic, method, benchmark, author, or category
 - Inspect canonical paper metadata and source ids
-- Read the passages in one paper that answer a specific question about drug discovery, clinical trials, biology, genomics, or another research topic
+- Read the passages in one paper that answer a specific question
 - Expand from strong seed papers to related papers, citers, or references
 - Search GitHub history and READMEs for implementation notes, bugs, and design discussions
 

--- a/features/research.mdx
+++ b/features/research.mdx
@@ -43,6 +43,7 @@ curl -s "https://api.firecrawl.dev/v2/search/research/papers?query=diffusion%20i
 
 ```bash CLI
 firecrawl research search-papers "diffusion image synthesis" --limit 20
+firecrawl research search-papers "single-cell RNA-seq batch correction" --limit 20
 ```
 
 ```python Python
@@ -88,7 +89,7 @@ Optional filters:
 
 ## Inspect a paper
 
-Use a canonical `paperId` or a source-specific `primaryId`.
+Use a canonical `paperId` or a source-specific `primaryId`, such as `arxiv:`, `pmid:`, `pmcid:`, or `doi:`.
 
 <CodeGroup>
 


### PR DESCRIPTION
## Why

The Research Index docs should make it clear that agents can use the paper search endpoint for life-science literature, without repositioning the page as biopharma-specific or naming sources/corpus size.

## Summary

- Broadened the Research Index overview to include life-science research agents.
- Added neutral life-science discoverability terms such as biomedical concepts, drug discovery, clinical trials, biology, and genomics.
- Added a small cURL example showing a life-science search query while preserving the existing diffusion/arXiv examples.
- Added a CLI example for agent usage: `firecrawl research search-papers "single-cell RNA-seq batch correction" --limit 20`.
- Clarified accepted paper id prefixes for inspect/read workflows: `arxiv:`, `pmid:`, `pmcid:`, and `doi:`.
- Updated the Search Papers API summary to include biomedical concepts and life-science research questions.

## Test Plan

- `git diff --check -- features/research.mdx api-reference/endpoint/research-search-papers.mdx`
- Confirmed only `features/research.mdx` and `api-reference/endpoint/research-search-papers.mdx` are touched.
- Confirmed no localized files are touched.
- Confirmed no new corpus count/source-family claims such as 40M, million, PubMed, publisher, database, source collection, source family, or corpus size.
- Confirmed MDX code-fence balance.
- Live cURL check: `https://api.firecrawl.dev/v2/search/research/papers?query=CRISPR%20gene%20editing%20therapy&k=3` returned relevant PMCID/PMID gene-therapy results.
- Live CLI check: `env -u FIRECRAWL_API_KEY npx -y firecrawl-cli@latest research search-papers "single-cell RNA-seq batch correction" --limit 3 --json` returned relevant PMCID batch-correction results.

Note: Mintlify preview/build was not run locally because `mint` is not installed.