### PR TITLE
feat(monitoring): feedback-assistant CTA on monitor docs

### DIFF
--- a/features/monitoring-page.mdx
+++ b/features/monitoring-page.mdx
@@ -17,6 +17,8 @@ Page monitoring watches URLs you already know about. Each check scrapes every UR
 
 This page covers the `scrape` target. Scheduling, goals and judging, change tracking, notifications, and pricing are shared across all monitor types. See the [Monitoring overview](/features/monitoring).
 
+<MonitorFeedbackCTA src="docs-monitor-page" />
+
 ## Create a page monitor
 
 Create a monitor with a `scrape` target that lists one or more explicit URLs:
@@ -53,5 +55,3 @@ By default a page monitor diffs the page's markdown. To alert only when a **spec
 - [Notifications](/features/monitoring#notifications): webhook and email delivery.
 - [Check results](/features/monitoring#check-results): inspect each check and its per-page diffs.
 - [Pricing](/features/monitoring#pricing): 1 credit per URL per check, plus optional judging.
-
-<MonitorFeedbackCTA src="docs-monitor-page" />

--- a/features/monitoring-page.mdx
+++ b/features/monitoring-page.mdx
@@ -11,6 +11,7 @@ import CreateScrapeCURL from "/snippets/v2/monitor/create/scrape/curl.mdx";
 import CreateScrapeNode from "/snippets/v2/monitor/create/scrape/js.mdx";
 import CreateScrapePython from "/snippets/v2/monitor/create/scrape/python.mdx";
 import TargetScrape from "/snippets/v2/monitor/target/scrape.mdx";
+import MonitorFeedbackCTA from "/snippets/monitor-feedback-cta.mdx";
 
 Page monitoring watches URLs you already know about. Each check scrapes every URL in the target, diffs it against the last retained snapshot, and reports whether the page is `same`, `changed`, `new`, `removed`, or `error`. It's the right choice for pricing pages, changelogs, docs pages, job posts, status pages, or any known URL where a small change matters.
 
@@ -52,3 +53,5 @@ By default a page monitor diffs the page's markdown. To alert only when a **spec
 - [Notifications](/features/monitoring#notifications): webhook and email delivery.
 - [Check results](/features/monitoring#check-results): inspect each check and its per-page diffs.
 - [Pricing](/features/monitoring#pricing): 1 credit per URL per check, plus optional judging.
+
+<MonitorFeedbackCTA src="docs-monitor-page" />

--- a/features/monitoring-web-scale.mdx
+++ b/features/monitoring-web-scale.mdx
@@ -7,6 +7,8 @@ og:description: "Run always-on web searches and alert when new matching results 
 icon: "globe"
 ---
 
+import MonitorFeedbackCTA from "/snippets/monitor-feedback-cta.mdx";
+
 Entire web-scale monitoring is an always-on search that watches the web and pings you or your agent the moment something comes online.
 
 Page and website monitors watch URLs you name. An **entire web-scale** monitor watches the whole web. Instead of diffing pages you already know about, you give it `queries` to run plus a `goal`, and Firecrawl runs the queries on every check and alerts on **new** results the judge finds relevant to the goal. It's discovery rather than diffing.
@@ -261,3 +263,5 @@ Editing the monitor's `goal` or `queries` bumps its `goalVersion`, which invalid
 - [Notifications](/features/monitoring#notifications): webhook and email delivery.
 - [Check results](/features/monitoring#check-results): inspect each check and its results.
 - [Pricing](/features/monitoring#pricing): 2 credits per 10 results per check, plus 1 credit per judged result.
+
+<MonitorFeedbackCTA src="docs-monitor-web" />

--- a/features/monitoring-web-scale.mdx
+++ b/features/monitoring-web-scale.mdx
@@ -19,6 +19,8 @@ Each check runs the same cycle: take the goal and its `queries`, apply a recency
   Page and crawl monitors diff content on URLs you name; web-scale monitors discover new results across the web. Same scheduling, judge, and notifications underneath.
 </Note>
 
+<MonitorFeedbackCTA src="docs-monitor-web" />
+
 ## Search target
 
 A search target uses `type: "search"` and replaces `urls` with the queries to run and how to score the results:
@@ -263,5 +265,3 @@ Editing the monitor's `goal` or `queries` bumps its `goalVersion`, which invalid
 - [Notifications](/features/monitoring#notifications): webhook and email delivery.
 - [Check results](/features/monitoring#check-results): inspect each check and its results.
 - [Pricing](/features/monitoring#pricing): 2 credits per 10 results per check, plus 1 credit per judged result.
-
-<MonitorFeedbackCTA src="docs-monitor-web" />

--- a/features/monitoring-website.mdx
+++ b/features/monitoring-website.mdx
@@ -17,6 +17,8 @@ Website monitoring watches a whole site instead of a fixed list of URLs. Each ch
 
 This page covers the `crawl` target. Scheduling, goals and judging, change tracking, notifications, and pricing are shared across all monitor types. See the [Monitoring overview](/features/monitoring).
 
+<MonitorFeedbackCTA src="docs-monitor-website" />
+
 ## Create a website monitor
 
 Create a monitor with a `crawl` target to diff every page discovered by a crawl on each check:
@@ -62,5 +64,3 @@ To alert on specific structured fields across the crawled pages, add a `changeTr
 - [Notifications](/features/monitoring#notifications): webhook and email delivery.
 - [Check results](/features/monitoring#check-results): inspect each check and its per-page diffs.
 - [Pricing](/features/monitoring#pricing): 1 credit per discovered page per check, plus optional judging.
-
-<MonitorFeedbackCTA src="docs-monitor-website" />

--- a/features/monitoring-website.mdx
+++ b/features/monitoring-website.mdx
@@ -11,6 +11,7 @@ import CreateCrawlCURL from "/snippets/v2/monitor/create/crawl/curl.mdx";
 import CreateCrawlNode from "/snippets/v2/monitor/create/crawl/js.mdx";
 import CreateCrawlPython from "/snippets/v2/monitor/create/crawl/python.mdx";
 import TargetCrawl from "/snippets/v2/monitor/target/crawl.mdx";
+import MonitorFeedbackCTA from "/snippets/monitor-feedback-cta.mdx";
 
 Website monitoring watches a whole site instead of a fixed list of URLs. Each check runs a crawl for the target `url`, scrapes every discovered page, and reconciles the result against the last retained snapshot. That catches added, changed, and removed pages, not just edits to pages you already named. It's the right choice for docs sites, blogs, changelogs, help centers, and competitor sites.
 
@@ -61,3 +62,5 @@ To alert on specific structured fields across the crawled pages, add a `changeTr
 - [Notifications](/features/monitoring#notifications): webhook and email delivery.
 - [Check results](/features/monitoring#check-results): inspect each check and its per-page diffs.
 - [Pricing](/features/monitoring#pricing): 1 credit per discovered page per check, plus optional judging.
+
+<MonitorFeedbackCTA src="docs-monitor-website" />

--- a/features/monitoring.mdx
+++ b/features/monitoring.mdx
@@ -26,6 +26,7 @@ import CheckOutputMixed from "/snippets/v2/monitor/check/output/mixed.mdx";
 import DiffMarkdown from "/snippets/v2/monitor/diff/markdown.mdx";
 import DiffJson from "/snippets/v2/monitor/diff/json.mdx";
 import DiffMixed from "/snippets/v2/monitor/diff/mixed.mdx";
+import MonitorFeedbackCTA from "/snippets/monitor-feedback-cta.mdx";
 
 Firecrawl monitoring runs recurring checks and notifies you or your agent when something changes or appears. Use `/monitor` to [watch known pages](/features/monitoring-page), [crawl a website on a schedule](/features/monitoring-website), or [run an always-on web search](/features/monitoring-web-scale) for new results that match a goal.
 
@@ -283,3 +284,5 @@ Monitors don't introduce a separate per-monitor fee. Each check pays for the und
 - [Get monitor check](/api-reference/endpoint/monitor-check-get)
 - [Monitor page webhook payload](/api-reference/endpoint/webhook-monitor-page)
 - [Monitor check completed webhook payload](/api-reference/endpoint/webhook-monitor-check-completed)
+
+<MonitorFeedbackCTA src="docs-monitor-overview" />

--- a/features/monitoring.mdx
+++ b/features/monitoring.mdx
@@ -32,6 +32,8 @@ Firecrawl monitoring runs recurring checks and notifies you or your agent when s
 
 All monitor types share the same workflow: choose one or more targets, set a schedule, add an optional plain-language goal, and receive webhook or email notifications when something matters. This page covers shared configuration. For target-specific setup and examples, go to the [Page](/features/monitoring-page), [Website](/features/monitoring-website), or [Entire web-scale](/features/monitoring-web-scale) monitoring page.
 
+<MonitorFeedbackCTA src="docs-monitor-overview" />
+
 <CardGroup cols={3}>
   <Card title="Page monitoring" icon="file-lines" href="/features/monitoring-page">
     Watch one or more known URLs, diff each scrape against the last snapshot, and alert on meaningful page changes.
@@ -284,5 +286,3 @@ Monitors don't introduce a separate per-monitor fee. Each check pays for the und
 - [Get monitor check](/api-reference/endpoint/monitor-check-get)
 - [Monitor page webhook payload](/api-reference/endpoint/webhook-monitor-page)
 - [Monitor check completed webhook payload](/api-reference/endpoint/webhook-monitor-check-completed)
-
-<MonitorFeedbackCTA src="docs-monitor-overview" />

--- a/snippets/monitor-feedback-cta.mdx
+++ b/snippets/monitor-feedback-cta.mdx
@@ -22,20 +22,24 @@
   <div style={{ fontSize: "0.95rem", fontWeight: 400, lineHeight: 1.5, marginTop: "8px" }}>
     Complete, thoughtful interviews with concrete usage examples <strong>earn 10,000 credits</strong>.
   </div>
-  <a
-    href={"https://www.firecrawl.dev/interview?study=20260701-monitor-feedback&src=" + (props.src || "docs-monitor")}
-    style={{
-      display: "inline-block",
-      marginTop: "14px",
-      padding: "8px 16px",
-      borderRadius: "8px",
-      background: "#fa5d19",
-      color: "#fff",
-      fontWeight: 600,
-      fontSize: "0.9rem",
-      textDecoration: "none",
-    }}
-  >
-    Start the interview
-  </a>
+  <div style={{ marginTop: "14px" }}>
+    <a
+      href={"https://www.firecrawl.dev/interview?study=20260701-monitor-feedback&src=" + (props.src || "docs-monitor")}
+      style={{ textDecoration: "none" }}
+    >
+      <span
+        style={{
+          display: "inline-block",
+          padding: "9px 18px",
+          borderRadius: "8px",
+          background: "#fa5d19",
+          color: "#ffffff",
+          fontWeight: 600,
+          fontSize: "0.9rem",
+        }}
+      >
+        Start the interview
+      </span>
+    </a>
+  </div>
 </div>

--- a/snippets/monitor-feedback-cta.mdx
+++ b/snippets/monitor-feedback-cta.mdx
@@ -5,13 +5,13 @@
     <Icon icon="robot" color="#ff4d00" size={20} />
   </div>
   <div className="firecrawl-cta-title">
-    Have /monitor feedback? <span style={{ color: "#ff4d00" }}>Skip the call, task your agent.</span>
+    Earn <span style={{ color: "#ff4d00" }}>10,000 credits</span> for /monitor feedback
   </div>
   <p className="firecrawl-cta-description">
-    An async interview with the Firecrawl Feedback Assistant. Only a few minutes, stop at any time, and your agent can take it (unless you prefer to). Just paste the link in your agentic harness.
+    Skip the call, task your agent. An async interview with the Firecrawl Feedback Assistant: only a few minutes, stop at any time, and your agent can take it (unless you prefer to). Just paste the link in your agentic harness.
   </p>
   <p className="firecrawl-cta-description">
-    Complete, thoughtful interviews with concrete usage examples <strong>earn 10,000 credits</strong>.
+    Complete, thoughtful interviews with concrete usage examples qualify.
   </p>
   <a
     href={"https://www.firecrawl.dev/interview?study=20260701-monitor-feedback&src=" + (props.src || "docs-monitor")}

--- a/snippets/monitor-feedback-cta.mdx
+++ b/snippets/monitor-feedback-cta.mdx
@@ -7,7 +7,7 @@
     <span style={{ fontWeight: 400 }}> for solid /monitor feedback</span>
   </div>
   <p className="firecrawl-cta-description">
-    To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with the Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human & agent-friendly (just paste the link into your agentic harness!).
+    To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with the Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human and agent-friendly (just paste the link into your agentic harness!).
   </p>
   <a
     href={"https://www.firecrawl.dev/interview?study=20260701-monitor-feedback&src=" + (props.src || "docs-monitor")}

--- a/snippets/monitor-feedback-cta.mdx
+++ b/snippets/monitor-feedback-cta.mdx
@@ -17,11 +17,14 @@
       <Icon icon="robot" color="#fa5d19" size={20} />
     </span>
     <span style={{ fontWeight: 700, fontSize: "1.05rem", color: "#fa5d19" }}>
-      Give monitor feedback, skip the call
+      Have feedback? Skip the call, task your agent.
     </span>
   </div>
   <div style={{ fontSize: "0.95rem", lineHeight: 1.5 }}>
-    An async interview with the Firecrawl Feedback Assistant. Stop anytime, a few minutes, and your agent can take it. Standout interviews earn a <strong>10,000 credit bounty</strong>.<sup>*</sup>
+    An async feedback interview with the Firecrawl Feedback Assistant. Only a few minutes, stop any time, and your agent can take it (unless you prefer to). Just paste the link in your agentic harness.
+  </div>
+  <div style={{ fontSize: "0.95rem", fontWeight: 700, marginTop: "8px" }}>
+    Standout interviews earn a 10,000 credit bounty.<sup>*</sup>
   </div>
   <div style={{ fontSize: "0.75rem", opacity: 0.6, marginTop: "8px" }}>
     *For complete/thoughtful interviews with concrete usage examples

--- a/snippets/monitor-feedback-cta.mdx
+++ b/snippets/monitor-feedback-cta.mdx
@@ -1,9 +1,10 @@
 <div className="firecrawl-cta-box" style={{ background: "transparent" }}>
   <div style={{ display: "flex", alignItems: "center", marginBottom: "12px" }}>
-    <Icon icon="bullseye" color="#ff4d00" size={22} />
+    <Icon icon="sack-dollar" color="#ff4d00" size={22} />
   </div>
   <div className="firecrawl-cta-title">
-    Bounty: <span style={{ color: "#ff4d00" }}>10,000 credit reward</span> for solid /monitor feedback
+    <span style={{ color: "#ff4d00" }}>Bounty: 10,000 credit reward</span>
+    <span style={{ fontWeight: 400 }}> for solid /monitor feedback</span>
   </div>
   <p className="firecrawl-cta-description">
     To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with the Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human & agent-friendly (just paste the link into your agentic harness!).

--- a/snippets/monitor-feedback-cta.mdx
+++ b/snippets/monitor-feedback-cta.mdx
@@ -1,45 +1,22 @@
-<div
-  style={{
-    border: "2px solid #fa5d19",
-    borderRadius: "12px",
-    padding: "16px 20px",
-    margin: "1.5rem 0",
-  }}
->
-  <div style={{ display: "flex", alignItems: "center", gap: "10px", marginBottom: "8px" }}>
-    <span style={{ display: "inline-flex", alignItems: "center", gap: "4px", flexShrink: 0 }}>
-      <Icon icon="robot" color="#fa5d19" size={20} />
-      <Icon icon="right-left" color="#fa5d19" size={12} />
-      <Icon icon="robot" color="#fa5d19" size={20} />
-    </span>
-    <span style={{ fontWeight: 700, fontSize: "1.05rem", color: "#fa5d19" }}>
-      Have /monitor feedback? Skip the call, task your agent.
-    </span>
+<div className="firecrawl-cta-box">
+  <div style={{ display: "flex", alignItems: "center", gap: "4px", marginBottom: "12px" }}>
+    <Icon icon="robot" color="#ff4d00" size={20} />
+    <Icon icon="right-left" color="#ff4d00" size={12} />
+    <Icon icon="robot" color="#ff4d00" size={20} />
   </div>
-  <div style={{ fontSize: "0.95rem", fontWeight: 400, lineHeight: 1.5 }}>
+  <div className="firecrawl-cta-title">Have /monitor feedback? Skip the call, task your agent.</div>
+  <p className="firecrawl-cta-description">
     An async interview with the Firecrawl Feedback Assistant. Only a few minutes, stop at any time, and your agent can take it (unless you prefer to). Just paste the link in your agentic harness.
-  </div>
-  <div style={{ fontSize: "0.95rem", fontWeight: 400, lineHeight: 1.5, marginTop: "8px" }}>
+  </p>
+  <p className="firecrawl-cta-description">
     Complete, thoughtful interviews with concrete usage examples <strong>earn 10,000 credits</strong>.
-  </div>
-  <div style={{ marginTop: "14px" }}>
+  </p>
+  <div className="firecrawl-cta-buttons">
     <a
       href={"https://www.firecrawl.dev/interview?study=20260701-monitor-feedback&src=" + (props.src || "docs-monitor")}
-      style={{ textDecoration: "none" }}
+      className="firecrawl-cta-btn-primary"
     >
-      <span
-        style={{
-          display: "inline-block",
-          padding: "9px 18px",
-          borderRadius: "8px",
-          background: "#fa5d19",
-          color: "#ffffff",
-          fontWeight: 600,
-          fontSize: "0.9rem",
-        }}
-      >
-        Start the interview
-      </span>
+      Start the interview
     </a>
   </div>
 </div>

--- a/snippets/monitor-feedback-cta.mdx
+++ b/snippets/monitor-feedback-cta.mdx
@@ -3,7 +3,7 @@
     <Icon icon="sack-dollar" color="#ff4d00" size={22} />
   </div>
   <div className="firecrawl-cta-title">
-    <span style={{ color: "#ff4d00" }}>Bounty: 10,000 credit reward</span>
+    <span style={{ color: "#ff4d00" }}>Bounty: 5,000 credit reward</span>
     <span style={{ fontWeight: 400 }}> for solid /monitor feedback</span>
   </div>
   <p className="firecrawl-cta-description">

--- a/snippets/monitor-feedback-cta.mdx
+++ b/snippets/monitor-feedback-cta.mdx
@@ -21,7 +21,7 @@
     </span>
   </div>
   <div style={{ fontSize: "0.95rem", lineHeight: 1.5 }}>
-    An async feedback interview with the Firecrawl Feedback Assistant. Only a few minutes, stop any time, and your agent can take it (unless you prefer to). Just paste the link in your agentic harness.
+    An async interview with the Firecrawl Feedback Assistant. Only a few minutes, stop at any time, and your agent can take it (unless you prefer to). Just paste the link in your agentic harness.
   </div>
   <div style={{ fontSize: "0.95rem", fontWeight: 700, marginTop: "8px" }}>
     Standout interviews earn a 10,000 credit bounty.<sup>*</sup>

--- a/snippets/monitor-feedback-cta.mdx
+++ b/snippets/monitor-feedback-cta.mdx
@@ -1,17 +1,12 @@
 <div className="firecrawl-cta-box" style={{ background: "transparent" }}>
-  <div style={{ display: "flex", alignItems: "center", gap: "4px", marginBottom: "12px" }}>
-    <Icon icon="robot" color="#ff4d00" size={20} />
-    <Icon icon="right-left" color="#ff4d00" size={12} />
-    <Icon icon="robot" color="#ff4d00" size={20} />
+  <div style={{ display: "flex", alignItems: "center", marginBottom: "12px" }}>
+    <Icon icon="bullseye" color="#ff4d00" size={22} />
   </div>
   <div className="firecrawl-cta-title">
-    Earn <span style={{ color: "#ff4d00" }}>10,000 credits</span> for /monitor feedback
+    Bounty: <span style={{ color: "#ff4d00" }}>10,000 credit reward</span> for solid /monitor feedback
   </div>
   <p className="firecrawl-cta-description">
-    Skip the call, task your agent. An async interview with the Firecrawl Feedback Assistant: only a few minutes, stop at any time, and your agent can take it (unless you prefer to). Just paste the link in your agentic harness.
-  </p>
-  <p className="firecrawl-cta-description">
-    Complete, thoughtful interviews with concrete usage examples qualify.
+    To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with the Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human & agent-friendly (just paste the link into your agentic harness!).
   </p>
   <a
     href={"https://www.firecrawl.dev/interview?study=20260701-monitor-feedback&src=" + (props.src || "docs-monitor")}

--- a/snippets/monitor-feedback-cta.mdx
+++ b/snippets/monitor-feedback-cta.mdx
@@ -11,16 +11,19 @@
   }}
 >
   <div style={{ display: "flex", alignItems: "center", gap: "10px", marginBottom: "6px" }}>
-    <Icon icon="microphone-lines" color="#fa5d19" size={22} />
-    <span style={{ fontWeight: 700, fontSize: "1.1rem", color: "#fa5d19" }}>
-      Skip the call. Send your agent.
+    <span style={{ display: "inline-flex", alignItems: "center", gap: "4px", flexShrink: 0 }}>
+      <Icon icon="robot" color="#fa5d19" size={20} />
+      <Icon icon="right-left" color="#fa5d19" size={12} />
+      <Icon icon="robot" color="#fa5d19" size={20} />
+    </span>
+    <span style={{ fontWeight: 700, fontSize: "1.05rem", color: "#fa5d19" }}>
+      Give monitor feedback, skip the call
     </span>
   </div>
   <div style={{ fontSize: "0.95rem", lineHeight: 1.5 }}>
-    An async, AI-run interview: stop anytime, a few minutes tops. Standout
-    interviews earn a <strong>10,000 credit bounty</strong>.<sup>*</sup>
+    An async interview with the Firecrawl Feedback Assistant. Stop anytime, a few minutes, and your agent can take it. Standout interviews earn a <strong>10,000 credit bounty</strong>.<sup>*</sup>
   </div>
   <div style={{ fontSize: "0.75rem", opacity: 0.6, marginTop: "8px" }}>
-    *For thoughtful, complete interviews.
+    *For complete/thoughtful interviews with concrete usage examples
   </div>
 </a>

--- a/snippets/monitor-feedback-cta.mdx
+++ b/snippets/monitor-feedback-cta.mdx
@@ -1,0 +1,8 @@
+<Card
+  title="Help shape monitor"
+  icon="comments"
+  href={"https://www.firecrawl.dev/interview?study=20260701-monitor-feedback&src=" + (props.src || "docs-monitor")}
+>
+  Using monitor? Tell us what works and what is missing, you or your agent. It
+  takes a few minutes, and thoughtful, complete interviews earn 10,000 credits.
+</Card>

--- a/snippets/monitor-feedback-cta.mdx
+++ b/snippets/monitor-feedback-cta.mdx
@@ -1,16 +1,12 @@
-<a
-  href={"https://www.firecrawl.dev/interview?study=20260701-monitor-feedback&src=" + (props.src || "docs-monitor")}
+<div
   style={{
-    display: "block",
     border: "2px solid #fa5d19",
     borderRadius: "12px",
     padding: "16px 20px",
     margin: "1.5rem 0",
-    textDecoration: "none",
-    color: "inherit",
   }}
 >
-  <div style={{ display: "flex", alignItems: "center", gap: "10px", marginBottom: "6px" }}>
+  <div style={{ display: "flex", alignItems: "center", gap: "10px", marginBottom: "8px" }}>
     <span style={{ display: "inline-flex", alignItems: "center", gap: "4px", flexShrink: 0 }}>
       <Icon icon="robot" color="#fa5d19" size={20} />
       <Icon icon="right-left" color="#fa5d19" size={12} />
@@ -20,13 +16,26 @@
       Have /monitor feedback? Skip the call, task your agent.
     </span>
   </div>
-  <div style={{ fontSize: "0.95rem", lineHeight: 1.5 }}>
+  <div style={{ fontSize: "0.95rem", fontWeight: 400, lineHeight: 1.5 }}>
     An async interview with the Firecrawl Feedback Assistant. Only a few minutes, stop at any time, and your agent can take it (unless you prefer to). Just paste the link in your agentic harness.
   </div>
-  <div style={{ fontSize: "0.95rem", fontWeight: 700, marginTop: "8px" }}>
-    Standout interviews earn a 10,000 credit bounty.<sup>*</sup>
+  <div style={{ fontSize: "0.95rem", fontWeight: 400, lineHeight: 1.5, marginTop: "8px" }}>
+    Complete, thoughtful interviews with concrete usage examples <strong>earn 10,000 credits</strong>.
   </div>
-  <div style={{ fontSize: "0.75rem", opacity: 0.6, marginTop: "8px" }}>
-    *For complete/thoughtful interviews with concrete usage examples
-  </div>
-</a>
+  <a
+    href={"https://www.firecrawl.dev/interview?study=20260701-monitor-feedback&src=" + (props.src || "docs-monitor")}
+    style={{
+      display: "inline-block",
+      marginTop: "14px",
+      padding: "8px 16px",
+      borderRadius: "8px",
+      background: "#fa5d19",
+      color: "#fff",
+      fontWeight: 600,
+      fontSize: "0.9rem",
+      textDecoration: "none",
+    }}
+  >
+    Start the interview
+  </a>
+</div>

--- a/snippets/monitor-feedback-cta.mdx
+++ b/snippets/monitor-feedback-cta.mdx
@@ -1,8 +1,26 @@
-<Card
-  title="Help shape monitor"
-  icon="comments"
+<a
   href={"https://www.firecrawl.dev/interview?study=20260701-monitor-feedback&src=" + (props.src || "docs-monitor")}
+  style={{
+    display: "block",
+    border: "2px solid #fa5d19",
+    borderRadius: "12px",
+    padding: "16px 20px",
+    margin: "1.5rem 0",
+    textDecoration: "none",
+    color: "inherit",
+  }}
 >
-  Using monitor? Tell us what works and what is missing, you or your agent. It
-  takes a few minutes, and thoughtful, complete interviews earn 10,000 credits.
-</Card>
+  <div style={{ display: "flex", alignItems: "center", gap: "10px", marginBottom: "6px" }}>
+    <Icon icon="microphone-lines" color="#fa5d19" size={22} />
+    <span style={{ fontWeight: 700, fontSize: "1.1rem", color: "#fa5d19" }}>
+      Skip the call. Send your agent.
+    </span>
+  </div>
+  <div style={{ fontSize: "0.95rem", lineHeight: 1.5 }}>
+    An async, AI-run interview: stop anytime, a few minutes tops. Standout
+    interviews earn a <strong>10,000 credit bounty</strong>.<sup>*</sup>
+  </div>
+  <div style={{ fontSize: "0.75rem", opacity: 0.6, marginTop: "8px" }}>
+    *For thoughtful, complete interviews.
+  </div>
+</a>

--- a/snippets/monitor-feedback-cta.mdx
+++ b/snippets/monitor-feedback-cta.mdx
@@ -7,7 +7,7 @@
     <span style={{ fontWeight: 400 }}> for solid /monitor feedback</span>
   </div>
   <p className="firecrawl-cta-description">
-    To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with the Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human and agent-friendly (just paste the link into your agentic harness!).
+    To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with the Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human/agent-friendly (just paste the link into your agentic harness!).
   </p>
   <a
     href={"https://www.firecrawl.dev/interview?study=20260701-monitor-feedback&src=" + (props.src || "docs-monitor")}

--- a/snippets/monitor-feedback-cta.mdx
+++ b/snippets/monitor-feedback-cta.mdx
@@ -1,22 +1,22 @@
-<div className="firecrawl-cta-box">
+<div className="firecrawl-cta-box" style={{ background: "transparent" }}>
   <div style={{ display: "flex", alignItems: "center", gap: "4px", marginBottom: "12px" }}>
     <Icon icon="robot" color="#ff4d00" size={20} />
     <Icon icon="right-left" color="#ff4d00" size={12} />
     <Icon icon="robot" color="#ff4d00" size={20} />
   </div>
-  <div className="firecrawl-cta-title">Have /monitor feedback? Skip the call, task your agent.</div>
+  <div className="firecrawl-cta-title">
+    Have /monitor feedback? <span style={{ color: "#ff4d00" }}>Skip the call, task your agent.</span>
+  </div>
   <p className="firecrawl-cta-description">
     An async interview with the Firecrawl Feedback Assistant. Only a few minutes, stop at any time, and your agent can take it (unless you prefer to). Just paste the link in your agentic harness.
   </p>
   <p className="firecrawl-cta-description">
     Complete, thoughtful interviews with concrete usage examples <strong>earn 10,000 credits</strong>.
   </p>
-  <div className="firecrawl-cta-buttons">
-    <a
-      href={"https://www.firecrawl.dev/interview?study=20260701-monitor-feedback&src=" + (props.src || "docs-monitor")}
-      className="firecrawl-cta-btn-primary"
-    >
-      Start the interview
-    </a>
-  </div>
+  <a
+    href={"https://www.firecrawl.dev/interview?study=20260701-monitor-feedback&src=" + (props.src || "docs-monitor")}
+    className="firecrawl-cta-btn-primary firecrawl-cta-btn-inline"
+  >
+    Start the interview
+  </a>
 </div>

--- a/snippets/monitor-feedback-cta.mdx
+++ b/snippets/monitor-feedback-cta.mdx
@@ -17,7 +17,7 @@
       <Icon icon="robot" color="#fa5d19" size={20} />
     </span>
     <span style={{ fontWeight: 700, fontSize: "1.05rem", color: "#fa5d19" }}>
-      Have feedback? Skip the call, task your agent.
+      Have /monitor feedback? Skip the call, task your agent.
     </span>
   </div>
   <div style={{ fontSize: "0.95rem", lineHeight: 1.5 }}>

--- a/style.css
+++ b/style.css
@@ -103,6 +103,11 @@ nav ul li:has(a[href="https://github.com/firecrawl/firecrawl"])
     text-decoration: none !important;
 }
 
+/* Auto-width variant so a CTA button hugs its label instead of filling the box */
+.firecrawl-cta-btn-inline {
+    display: inline-block;
+}
+
 .firecrawl-cta-btn-secondary {
     display: block;
     text-align: center;


### PR DESCRIPTION
Adds a passive "pull" CTA to the four monitor docs pages so readers (humans **or** their agents) can give feedback via the Firecrawl Feedback Assistant.

## What
- New shared snippet `snippets/monitor-feedback-cta.mdx`: a "Help shape monitor" Card linking to the monitor feedback study. Single-source, so copy changes in one place.
- Included at the end of the four English monitor pages: overview, page, website, web-scale.
- **Per-page attribution:** each include passes a `src` (`docs-monitor-overview` / `page` / `website` / `web`) so responses can be traced to the page (and therefore the mode) that drove them.
- Copy invites **humans and agents** (matching the pages' existing "you or your agent" phrasing) and surfaces the **10,000 credit** reward.

## Link
`https://www.firecrawl.dev/interview?study=20260701-monitor-feedback&src=<page>`

## Dependencies / sequencing
- The interview link resolves once the **study PR (firecrawl-web #2683)** is merged and deployed. That study has been tested and works.
- The `src` tag is **harmless until a small firecrawl-web capture lands** (reads `&src=`, stores it on the session). Until then the CTA works fine; `src` just isn't recorded yet.

## Notes for review
- Build-safe: the snippet defaults `src` to `docs-monitor` if the prop doesn't resolve, so worst case is a generic tag, never a broken link. Please glance at the **Mintlify preview** to confirm the Card renders (snippet props aren't used elsewhere in this repo yet).
- English base pages only; localized `ja/` mirrors intentionally untouched (per repo guideline).

## Possible follow-ups (not in this PR)
- A persistent slim pill (needs site-wide custom JS scoped to monitor paths).
- An injection-safe code-sample comment for agents (passive invitation, no imperative), if you want it in the copyable examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)