### PR TITLE
feat(monitoring): monitor feedback CTA (clean preview)

### DIFF
--- a/features/monitoring-page.mdx
+++ b/features/monitoring-page.mdx
@@ -11,10 +11,13 @@ import CreateScrapeCURL from "/snippets/v2/monitor/create/scrape/curl.mdx";
 import CreateScrapeNode from "/snippets/v2/monitor/create/scrape/js.mdx";
 import CreateScrapePython from "/snippets/v2/monitor/create/scrape/python.mdx";
 import TargetScrape from "/snippets/v2/monitor/target/scrape.mdx";
+import MonitorFeedbackCTA from "/snippets/monitor-feedback-cta.mdx";
 
 Page monitoring watches URLs you already know about. Each check scrapes every URL in the target, diffs it against the last retained snapshot, and reports whether the page is `same`, `changed`, `new`, `removed`, or `error`. It's the right choice for pricing pages, changelogs, docs pages, job posts, status pages, or any known URL where a small change matters.
 
 This page covers the `scrape` target. Scheduling, goals and judging, change tracking, notifications, and pricing are shared across all monitor types. See the [Monitoring overview](/features/monitoring).
+
+<MonitorFeedbackCTA src="docs-monitor-page" />
 
 ## Create a page monitor
 

--- a/features/monitoring-web-scale.mdx
+++ b/features/monitoring-web-scale.mdx
@@ -7,6 +7,8 @@ og:description: "Run always-on web searches and alert when new matching results 
 icon: "globe"
 ---
 
+import MonitorFeedbackCTA from "/snippets/monitor-feedback-cta.mdx";
+
 Entire web-scale monitoring is an always-on search that watches the web and pings you or your agent the moment something comes online.
 
 Page and website monitors watch URLs you name. An **entire web-scale** monitor watches the whole web. Instead of diffing pages you already know about, you give it `queries` to run plus a `goal`, and Firecrawl runs the queries on every check and alerts on **new** results the judge finds relevant to the goal. It's discovery rather than diffing.
@@ -16,6 +18,8 @@ Each check runs the same cycle: take the goal and its `queries`, apply a recency
 <Note>
   Page and crawl monitors diff content on URLs you name; web-scale monitors discover new results across the web. Same scheduling, judge, and notifications underneath.
 </Note>
+
+<MonitorFeedbackCTA src="docs-monitor-web" />
 
 ## Search target
 

--- a/features/monitoring-website.mdx
+++ b/features/monitoring-website.mdx
@@ -11,10 +11,13 @@ import CreateCrawlCURL from "/snippets/v2/monitor/create/crawl/curl.mdx";
 import CreateCrawlNode from "/snippets/v2/monitor/create/crawl/js.mdx";
 import CreateCrawlPython from "/snippets/v2/monitor/create/crawl/python.mdx";
 import TargetCrawl from "/snippets/v2/monitor/target/crawl.mdx";
+import MonitorFeedbackCTA from "/snippets/monitor-feedback-cta.mdx";
 
 Website monitoring watches a whole site instead of a fixed list of URLs. Each check runs a crawl for the target `url`, scrapes every discovered page, and reconciles the result against the last retained snapshot. That catches added, changed, and removed pages, not just edits to pages you already named. It's the right choice for docs sites, blogs, changelogs, help centers, and competitor sites.
 
 This page covers the `crawl` target. Scheduling, goals and judging, change tracking, notifications, and pricing are shared across all monitor types. See the [Monitoring overview](/features/monitoring).
+
+<MonitorFeedbackCTA src="docs-monitor-website" />
 
 ## Create a website monitor
 

--- a/features/monitoring.mdx
+++ b/features/monitoring.mdx
@@ -26,10 +26,13 @@ import CheckOutputMixed from "/snippets/v2/monitor/check/output/mixed.mdx";
 import DiffMarkdown from "/snippets/v2/monitor/diff/markdown.mdx";
 import DiffJson from "/snippets/v2/monitor/diff/json.mdx";
 import DiffMixed from "/snippets/v2/monitor/diff/mixed.mdx";
+import MonitorFeedbackCTA from "/snippets/monitor-feedback-cta.mdx";
 
 Firecrawl monitoring runs recurring checks and notifies you or your agent when something changes or appears. Use `/monitor` to [watch known pages](/features/monitoring-page), [crawl a website on a schedule](/features/monitoring-website), or [run an always-on web search](/features/monitoring-web-scale) for new results that match a goal.
 
 All monitor types share the same workflow: choose one or more targets, set a schedule, add an optional plain-language goal, and receive webhook or email notifications when something matters. This page covers shared configuration. For target-specific setup and examples, go to the [Page](/features/monitoring-page), [Website](/features/monitoring-website), or [Entire web-scale](/features/monitoring-web-scale) monitoring page.
+
+<MonitorFeedbackCTA src="docs-monitor-overview" />
 
 <CardGroup cols={3}>
   <Card title="Page monitoring" icon="file-lines" href="/features/monitoring-page">

--- a/features/monitoring.mdx
+++ b/features/monitoring.mdx
@@ -32,8 +32,6 @@ Firecrawl monitoring runs recurring checks and notifies you or your agent when s
 
 All monitor types share the same workflow: choose one or more targets, set a schedule, add an optional plain-language goal, and receive webhook or email notifications when something matters. This page covers shared configuration. For target-specific setup and examples, go to the [Page](/features/monitoring-page), [Website](/features/monitoring-website), or [Entire web-scale](/features/monitoring-web-scale) monitoring page.
 
-<MonitorFeedbackCTA src="docs-monitor-overview" />
-
 <CardGroup cols={3}>
   <Card title="Page monitoring" icon="file-lines" href="/features/monitoring-page">
     Watch one or more known URLs, diff each scrape against the last snapshot, and alert on meaningful page changes.
@@ -47,6 +45,8 @@ All monitor types share the same workflow: choose one or more targets, set a sch
 </CardGroup>
 
 Each check records page-level results as `same`, `new`, `changed`, `removed`, or `error`. You can receive a webhook as each monitored page finishes, a webhook for every completed check, email summaries when changes or errors happen, or any combination of those notifications.
+
+<MonitorFeedbackCTA src="docs-monitor-overview" />
 
 ## Targets
 

--- a/snippets/monitor-feedback-cta.mdx
+++ b/snippets/monitor-feedback-cta.mdx
@@ -1,0 +1,18 @@
+<div className="firecrawl-cta-box" style={{ background: "transparent" }}>
+  <div style={{ display: "flex", alignItems: "center", marginBottom: "12px" }}>
+    <Icon icon="sack-dollar" color="#ff4d00" size={22} />
+  </div>
+  <div className="firecrawl-cta-title">
+    <span style={{ color: "#ff4d00" }}>Bounty: 5,000 credit reward</span>
+    <span style={{ fontWeight: 400 }}> for solid /monitor feedback</span>
+  </div>
+  <p className="firecrawl-cta-description">
+    To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with the Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human/agent-friendly (just paste the link into your agentic harness!).
+  </p>
+  <a
+    href={"https://www.firecrawl.dev/interview?study=20260701-monitor-feedback&src=" + (props.src || "docs-monitor")}
+    className="firecrawl-cta-btn-primary firecrawl-cta-btn-inline"
+  >
+    Start the interview
+  </a>
+</div>

--- a/snippets/monitor-feedback-cta.mdx
+++ b/snippets/monitor-feedback-cta.mdx
@@ -7,7 +7,7 @@
     <span style={{ fontWeight: 400 }}> for solid /monitor feedback</span>
   </div>
   <p className="firecrawl-cta-description">
-    To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with the Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human/agent-friendly (just paste the link into your agentic harness!).
+    To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with our Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human/agent-friendly (just paste the link into your agentic harness!).
   </p>
   <a
     href={"https://www.firecrawl.dev/interview?study=20260701-monitor-feedback&src=" + (props.src || "docs-monitor")}

--- a/style.css
+++ b/style.css
@@ -103,6 +103,11 @@ nav ul li:has(a[href="https://github.com/firecrawl/firecrawl"])
     text-decoration: none !important;
 }
 
+/* Auto-width variant so a CTA button hugs its label instead of filling the box */
+.firecrawl-cta-btn-inline {
+    display: inline-block;
+}
+
 .firecrawl-cta-btn-secondary {
     display: block;
     text-align: center;


### PR DESCRIPTION
Clean single-commit version of #1094 (the monitor feedback CTA), on a fresh branch so Mintlify mints a new preview deployment. The original PR's preview was wedged on an old build; the content here is identical and verified (MDX compiles).

Bounty-framed CTA on the four monitor docs pages, sack-dollar icon, 5,000-credit reward, per-page `src` attribution. Once the preview here renders, merge whichever PR you prefer and close the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)