### PR TITLE
docs(monitor): add eligibility disclaimer to bounty CTA card

### DIFF
--- a/snippets/monitor-feedback-cta.mdx
+++ b/snippets/monitor-feedback-cta.mdx
@@ -15,4 +15,10 @@
   >
     Start the interview
   </a>
+  <p
+    className="firecrawl-cta-description"
+    style={{ fontSize: "12px", fontStyle: "italic", margin: "12px 0 0 0" }}
+  >
+    Include your email to be eligible. Interviews are reviewed for quality at the end of each week.
+  </p>
 </div>


### PR DESCRIPTION
## What

Adds an eligibility disclaimer to the `/monitor` bounty card.

The card is a shared snippet (`snippets/monitor-feedback-cta.mdx`) rendered on all four monitor docs pages, so this one edit updates every card:
- `features/monitoring.mdx`
- `features/monitoring-page.mdx`
- `features/monitoring-website.mdx`
- `features/monitoring-web-scale.mdx`

## Disclaimer copy

> Include your email to be eligible. Interviews are reviewed for quality at the end of each week.

Rendered as a small italic fine-print line below the "Start the interview" button. It reuses the `firecrawl-cta-description` class so it inherits the existing light and dark mode colors, with an inline override for smaller italic text.

## Note

Converted the `--` in the requested copy to a period, per the repo prose style (no em or en dashes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
