### PR TITLE
feat(research): feedback bounty CTA on the Research Index page

### DIFF
--- a/features/research.mdx
+++ b/features/research.mdx
@@ -6,6 +6,8 @@ og:description: "Use Firecrawl's research index for paper retrieval, semantic ex
 icon: "book-open"
 ---
 
+import ResearchFeedbackCTA from "/snippets/research-feedback-cta.mdx";
+
 Firecrawl Research is a purpose-built index for scientific and engineering research agents. It exposes a research-specific toolset for searching papers, inspecting paper metadata, reading relevant full-text passages, discovering related papers through structural expansion, and searching over research-related GitHub repos.
 
 - Find papers by topic, method, benchmark, author, or category
@@ -20,6 +22,8 @@ To give your agent access to the Research Index, we strongly recommend using our
 npx skills add firecrawl/skills@firecrawl-research-index
 ```
 </Note>
+
+<ResearchFeedbackCTA src="docs-research" />
 
 ## Endpoints
 

--- a/snippets/research-feedback-cta.mdx
+++ b/snippets/research-feedback-cta.mdx
@@ -1,0 +1,24 @@
+<div className="firecrawl-cta-box" style={{ background: "transparent" }}>
+  <div style={{ display: "flex", alignItems: "center", marginBottom: "12px" }}>
+    <Icon icon="sack-dollar" color="#ff4d00" size={22} />
+  </div>
+  <div className="firecrawl-cta-title">
+    <span style={{ color: "#ff4d00" }}>Bounty: 5,000 credit reward</span>
+    <span style={{ fontWeight: 400 }}> for solid /search/research (GitHub) feedback</span>
+  </div>
+  <p className="firecrawl-cta-description">
+    To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with our Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human/agent-friendly (just paste the link into your agentic harness!).
+  </p>
+  <a
+    href={"https://www.firecrawl.dev/interview?study=20260629-fri-github-usage&src=" + (props.src || "docs-research")}
+    className="firecrawl-cta-btn-primary firecrawl-cta-btn-inline"
+  >
+    Start the interview
+  </a>
+  <p
+    className="firecrawl-cta-description"
+    style={{ fontSize: "12px", fontStyle: "italic", margin: "12px 0 0 0" }}
+  >
+    Include your email to be eligible. Interviews are reviewed for quality at the end of each week.
+  </p>
+</div>

--- a/snippets/research-feedback-cta.mdx
+++ b/snippets/research-feedback-cta.mdx
@@ -4,7 +4,7 @@
   </div>
   <div className="firecrawl-cta-title">
     <span style={{ color: "#ff4d00" }}>Bounty: 5,000 credit reward</span>
-    <span style={{ fontWeight: 400 }}> for solid /search/research (GitHub) feedback</span>
+    <span style={{ fontWeight: 400 }}> for solid feedback on /search/research (GitHub)</span>
   </div>
   <p className="firecrawl-cta-description">
     To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with our Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human/agent-friendly (just paste the link into your agentic harness!).


### PR DESCRIPTION
Second feedback bounty CTA, cloning the monitor card that has been converting well.

## What
- New shared snippet `snippets/research-feedback-cta.mdx`: identical styling and copy structure to the monitor card (sack-dollar icon, orange bounty title, same qualify body, same button, same weekly-review fine print), with the title scoped to **/search/research (GitHub)**.
- Placed on `features/research.mdx` directly **below the "install the research skill" Note** (the blue box), above the Endpoints section.
- Links to the live `20260629-fri-github-usage` study (merged in firecrawl-web #2702, verified responding on prod) with `src=docs-research` attribution.

## Notes
- Separate snippet rather than generalizing the monitor one, so each card's copy can evolve independently and the live monitor pages carry zero risk.
- English base page only; the `zh/` mirrors are managed by the translation pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)