### PR TITLE
docs: Threat Protection feature page

### DIFF
--- a/api-reference/endpoint/threat-protection-test-siem.mdx
+++ b/api-reference/endpoint/threat-protection-test-siem.mdx
@@ -1,0 +1,6 @@
+---
+title: 'Send SIEM Test Event'
+openapi: '/api-reference/v2-openapi.json POST /team/threat-protection/test-siem'
+---
+
+Sends a single test event to the organization's configured [threat protection](/features/threat-protection) SIEM destination and reports the delivery outcome.

--- a/api-reference/endpoint/threat-protection-test-siem.mdx
+++ b/api-reference/endpoint/threat-protection-test-siem.mdx
@@ -1,6 +1,0 @@
----
-title: 'Send SIEM Test Event'
-openapi: '/api-reference/v2-openapi.json POST /team/threat-protection/test-siem'
----
-
-Sends a single test event to the organization's configured [threat protection](/features/threat-protection) SIEM destination and reports the delivery outcome.

--- a/api-reference/endpoint/threat-protection-update.mdx
+++ b/api-reference/endpoint/threat-protection-update.mdx
@@ -1,0 +1,6 @@
+---
+title: 'Update Threat Protection Policy'
+openapi: '/api-reference/v2-openapi.json PUT /team/threat-protection'
+---
+
+Full-document update of your organization's [threat protection](/features/threat-protection) policy. Unspecified fields reset to defaults. Team admins only.

--- a/api-reference/endpoint/threat-protection.mdx
+++ b/api-reference/endpoint/threat-protection.mdx
@@ -1,0 +1,6 @@
+---
+title: 'Get Threat Protection Policy'
+openapi: '/api-reference/v2-openapi.json GET /team/threat-protection'
+---
+
+Returns the effective [threat protection](/features/threat-protection) policy for your organization. Enterprise feature; requires the feature to be enabled for your team.

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -5193,6 +5193,430 @@
           }
         }
       }
+    },
+    "/team/threat-protection": {
+      "get": {
+        "summary": "Get the team's threat protection policy",
+        "operationId": "getThreatProtection",
+        "tags": [
+          "Threat Protection"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Effective threat protection policy for the team's organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "mode": {
+                          "type": "string",
+                          "enum": [
+                            "off",
+                            "normal"
+                          ],
+                          "description": "Threat protection mode. `off` disables checks; `normal` checks domains against Google Web Risk (+2 credits per domain scanned).",
+                          "example": "normal"
+                        },
+                        "riskScoreThreshold": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 100,
+                          "description": "Normalized score (0-100) at or above which a classifier verdict is blocked. Lower is stricter.",
+                          "example": 75
+                        },
+                        "blacklist": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Exact domains or globs (e.g. `*.example.com`) always blocked, without a classifier call.",
+                          "example": [
+                            "*.risky.example"
+                          ]
+                        },
+                        "whitelist": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Exact domains or globs always allowed. Wins over every other rule.",
+                          "example": [
+                            "*.trusted.example"
+                          ]
+                        },
+                        "blockedTlds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Top-level domains to block outright, lowercase without a leading dot.",
+                          "example": [
+                            "zip"
+                          ]
+                        },
+                        "failurePolicy": {
+                          "type": "string",
+                          "enum": [
+                            "open",
+                            "closed"
+                          ],
+                          "description": "Behavior when the classifier is unreachable: `closed` blocks (default), `open` allows.",
+                          "example": "closed"
+                        },
+                        "allowRequestOverrides": {
+                          "type": "boolean",
+                          "description": "Whether individual requests may pass a `threatProtection` object. When false, such requests are rejected with 403.",
+                          "example": true
+                        },
+                        "siem": {
+                          "type": "object",
+                          "nullable": true,
+                          "description": "SIEM push destination. The signing secret is write-only and never returned; `secretSet` reports whether one is stored.",
+                          "properties": {
+                            "url": {
+                              "type": "string",
+                              "format": "uri",
+                              "example": "https://siem.example.com/ingest"
+                            },
+                            "events": {
+                              "type": "string",
+                              "enum": [
+                                "blocked",
+                                "all"
+                              ],
+                              "example": "blocked"
+                            },
+                            "secretSet": {
+                              "type": "boolean",
+                              "example": true
+                            }
+                          }
+                        },
+                        "configured": {
+                          "type": "boolean",
+                          "description": "Whether the organization has saved a policy (vs. serving defaults).",
+                          "example": true
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "nullable": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Threat protection is not enabled for this team, or a request override was sent while overrides are disabled."
+          }
+        }
+      },
+      "put": {
+        "summary": "Update the team's threat protection policy",
+        "description": "Full-document update. Unspecified fields reset to defaults. Enterprise feature, team admins only.",
+        "operationId": "updateThreatProtection",
+        "tags": [
+          "Threat Protection"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "mode"
+                ],
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "off",
+                      "normal"
+                    ],
+                    "description": "Threat protection mode. `off` disables checks; `normal` checks domains against Google Web Risk (+2 credits per domain scanned).",
+                    "example": "normal"
+                  },
+                  "riskScoreThreshold": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "description": "Normalized score (0-100) at or above which a classifier verdict is blocked. Lower is stricter.",
+                    "example": 75
+                  },
+                  "blacklist": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Exact domains or globs (e.g. `*.example.com`) always blocked, without a classifier call.",
+                    "example": [
+                      "*.risky.example"
+                    ]
+                  },
+                  "whitelist": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Exact domains or globs always allowed. Wins over every other rule.",
+                    "example": [
+                      "*.trusted.example"
+                    ]
+                  },
+                  "blockedTlds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Top-level domains to block outright, lowercase without a leading dot.",
+                    "example": [
+                      "zip"
+                    ]
+                  },
+                  "failurePolicy": {
+                    "type": "string",
+                    "enum": [
+                      "open",
+                      "closed"
+                    ],
+                    "description": "Behavior when the classifier is unreachable: `closed` blocks (default), `open` allows.",
+                    "example": "closed"
+                  },
+                  "allowRequestOverrides": {
+                    "type": "boolean",
+                    "description": "Whether individual requests may pass a `threatProtection` object. When false, such requests are rejected with 403.",
+                    "example": true
+                  },
+                  "siem": {
+                    "type": "object",
+                    "nullable": true,
+                    "properties": {
+                      "url": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "secret": {
+                        "type": "string",
+                        "description": "Write-only HMAC signing secret. Omit to keep the stored secret; set `siem` to null to clear it."
+                      },
+                      "events": {
+                        "type": "string",
+                        "enum": [
+                          "blocked",
+                          "all"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "url"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Effective threat protection policy for the team's organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "mode": {
+                          "type": "string",
+                          "enum": [
+                            "off",
+                            "normal"
+                          ],
+                          "description": "Threat protection mode. `off` disables checks; `normal` checks domains against Google Web Risk (+2 credits per domain scanned).",
+                          "example": "normal"
+                        },
+                        "riskScoreThreshold": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 100,
+                          "description": "Normalized score (0-100) at or above which a classifier verdict is blocked. Lower is stricter.",
+                          "example": 75
+                        },
+                        "blacklist": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Exact domains or globs (e.g. `*.example.com`) always blocked, without a classifier call.",
+                          "example": [
+                            "*.risky.example"
+                          ]
+                        },
+                        "whitelist": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Exact domains or globs always allowed. Wins over every other rule.",
+                          "example": [
+                            "*.trusted.example"
+                          ]
+                        },
+                        "blockedTlds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Top-level domains to block outright, lowercase without a leading dot.",
+                          "example": [
+                            "zip"
+                          ]
+                        },
+                        "failurePolicy": {
+                          "type": "string",
+                          "enum": [
+                            "open",
+                            "closed"
+                          ],
+                          "description": "Behavior when the classifier is unreachable: `closed` blocks (default), `open` allows.",
+                          "example": "closed"
+                        },
+                        "allowRequestOverrides": {
+                          "type": "boolean",
+                          "description": "Whether individual requests may pass a `threatProtection` object. When false, such requests are rejected with 403.",
+                          "example": true
+                        },
+                        "siem": {
+                          "type": "object",
+                          "nullable": true,
+                          "description": "SIEM push destination. The signing secret is write-only and never returned; `secretSet` reports whether one is stored.",
+                          "properties": {
+                            "url": {
+                              "type": "string",
+                              "format": "uri",
+                              "example": "https://siem.example.com/ingest"
+                            },
+                            "events": {
+                              "type": "string",
+                              "enum": [
+                                "blocked",
+                                "all"
+                              ],
+                              "example": "blocked"
+                            },
+                            "secretSet": {
+                              "type": "boolean",
+                              "example": true
+                            }
+                          }
+                        },
+                        "configured": {
+                          "type": "boolean",
+                          "description": "Whether the organization has saved a policy (vs. serving defaults).",
+                          "example": true
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "nullable": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid policy document."
+          },
+          "403": {
+            "description": "Threat protection is not enabled for this team, or a request override was sent while overrides are disabled."
+          }
+        }
+      }
+    },
+    "/team/threat-protection/test-siem": {
+      "post": {
+        "summary": "Send a test event to the configured SIEM destination",
+        "operationId": "testThreatProtectionSiem",
+        "tags": [
+          "Threat Protection"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Delivery outcome.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "delivered": {
+                          "type": "boolean",
+                          "example": true
+                        },
+                        "statusCode": {
+                          "type": "integer",
+                          "example": 200
+                        },
+                        "error": {
+                          "type": "string",
+                          "nullable": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "No SIEM destination is configured."
+          },
+          "403": {
+            "description": "Threat protection is not enabled for this team, or a request override was sent while overrides are disabled."
+          }
+        }
+      }
     }
   },
   "components": {

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -5281,30 +5281,6 @@
                           "description": "Whether individual requests may pass a `threatProtection` object. When false, such requests are rejected with 403.",
                           "example": true
                         },
-                        "siem": {
-                          "type": "object",
-                          "nullable": true,
-                          "description": "SIEM push destination. The signing secret is write-only and never returned; `secretSet` reports whether one is stored.",
-                          "properties": {
-                            "url": {
-                              "type": "string",
-                              "format": "uri",
-                              "example": "https://siem.example.com/ingest"
-                            },
-                            "events": {
-                              "type": "string",
-                              "enum": [
-                                "blocked",
-                                "all"
-                              ],
-                              "example": "blocked"
-                            },
-                            "secretSet": {
-                              "type": "boolean",
-                              "example": true
-                            }
-                          }
-                        },
                         "configured": {
                           "type": "boolean",
                           "description": "Whether the organization has saved a policy (vs. serving defaults).",
@@ -5408,30 +5384,6 @@
                     "type": "boolean",
                     "description": "Whether individual requests may pass a `threatProtection` object. When false, such requests are rejected with 403.",
                     "example": true
-                  },
-                  "siem": {
-                    "type": "object",
-                    "nullable": true,
-                    "properties": {
-                      "url": {
-                        "type": "string",
-                        "format": "uri"
-                      },
-                      "secret": {
-                        "type": "string",
-                        "description": "Write-only HMAC signing secret. Omit to keep the stored secret; set `siem` to null to clear it."
-                      },
-                      "events": {
-                        "type": "string",
-                        "enum": [
-                          "blocked",
-                          "all"
-                        ]
-                      }
-                    },
-                    "required": [
-                      "url"
-                    ]
                   }
                 }
               }
@@ -5513,30 +5465,6 @@
                           "description": "Whether individual requests may pass a `threatProtection` object. When false, such requests are rejected with 403.",
                           "example": true
                         },
-                        "siem": {
-                          "type": "object",
-                          "nullable": true,
-                          "description": "SIEM push destination. The signing secret is write-only and never returned; `secretSet` reports whether one is stored.",
-                          "properties": {
-                            "url": {
-                              "type": "string",
-                              "format": "uri",
-                              "example": "https://siem.example.com/ingest"
-                            },
-                            "events": {
-                              "type": "string",
-                              "enum": [
-                                "blocked",
-                                "all"
-                              ],
-                              "example": "blocked"
-                            },
-                            "secretSet": {
-                              "type": "boolean",
-                              "example": true
-                            }
-                          }
-                        },
                         "configured": {
                           "type": "boolean",
                           "description": "Whether the organization has saved a policy (vs. serving defaults).",
@@ -5556,61 +5484,6 @@
           },
           "400": {
             "description": "Invalid policy document."
-          },
-          "403": {
-            "description": "Threat protection is not enabled for this team, or a request override was sent while overrides are disabled."
-          }
-        }
-      }
-    },
-    "/team/threat-protection/test-siem": {
-      "post": {
-        "summary": "Send a test event to the configured SIEM destination",
-        "operationId": "testThreatProtectionSiem",
-        "tags": [
-          "Threat Protection"
-        ],
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Delivery outcome.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": true
-                    },
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "delivered": {
-                          "type": "boolean",
-                          "example": true
-                        },
-                        "statusCode": {
-                          "type": "integer",
-                          "example": 200
-                        },
-                        "error": {
-                          "type": "string",
-                          "nullable": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "No SIEM destination is configured."
           },
           "403": {
             "description": "Threat protection is not enabled for this team, or a request override was sent while overrides are disabled."

--- a/docs.json
+++ b/docs.json
@@ -132,7 +132,8 @@
                           "rate-limits",
                           "partner-credits",
                           "enterprise",
-                          "features/key-restrictions"
+                          "features/key-restrictions",
+                          "features/threat-protection"
                         ]
                       }
                     ]
@@ -685,7 +686,8 @@
                           "rate-limits",
                           "partner-credits",
                           "enterprise",
-                          "features/key-restrictions"
+                          "features/key-restrictions",
+                          "features/threat-protection"
                         ]
                       }
                     ]

--- a/docs.json
+++ b/docs.json
@@ -538,8 +538,7 @@
                       "api-reference/endpoint/token-usage-historical",
                       "api-reference/endpoint/queue-status",
                       "api-reference/endpoint/threat-protection",
-                      "api-reference/endpoint/threat-protection-update",
-                      "api-reference/endpoint/threat-protection-test-siem"
+                      "api-reference/endpoint/threat-protection-update"
                     ]
                   },
                   {

--- a/docs.json
+++ b/docs.json
@@ -536,7 +536,10 @@
                       "api-reference/endpoint/credit-usage-historical",
                       "api-reference/endpoint/token-usage",
                       "api-reference/endpoint/token-usage-historical",
-                      "api-reference/endpoint/queue-status"
+                      "api-reference/endpoint/queue-status",
+                      "api-reference/endpoint/threat-protection",
+                      "api-reference/endpoint/threat-protection-update",
+                      "api-reference/endpoint/threat-protection-test-siem"
                     ]
                   },
                   {

--- a/features/threat-protection.mdx
+++ b/features/threat-protection.mdx
@@ -1,0 +1,111 @@
+---
+title: "Threat Protection"
+description: "Block requests to risky domains across every endpoint, using a policy your organization controls. Enforced server-side, with optional export of every decision to your SIEM."
+og:title: "Threat Protection | Firecrawl"
+og:description: "Block requests to risky domains across every endpoint, using a policy your organization controls. Enforced server-side, with optional export of every decision to your SIEM."
+---
+
+Threat Protection lets your organization block Firecrawl from accessing risky domains. When it is enabled, every URL a request would fetch — a scrape target, a search result, a link discovered during a crawl, a page an agent navigates to — is checked against your organization's policy before any content is retrieved. Domains that fail the policy are refused.
+
+The policy is defined once at the organization level and applies to every endpoint automatically. You can also allow per-request adjustments, or lock the policy so no request can weaken it.
+
+<Note>
+Threat Protection is an enterprise feature and is gated per organization. Contact your Firecrawl account team to have it enabled for your account.
+</Note>
+
+## Modes
+
+Threat Protection has two modes, set at the organization level:
+
+- **Off** (default) — no domain checks are performed.
+- **Normal** — domains are checked against [Google Web Risk](https://cloud.google.com/web-risk), which flags domains associated with malware, social engineering (phishing), and unwanted software. **+2 credits per domain scanned.**
+
+Domain reputation checks are designed to protect your data: for the overwhelming majority of requests the check resolves locally against a regularly synced threat list, so the URLs you scrape are never sent to the classifier, and no verdict about your traffic is ever stored by Firecrawl.
+
+## Policy controls
+
+Beyond the classifier, a policy can include:
+
+- **Custom blacklist** — exact domains or globs (e.g. `*.example.com`) that are always blocked, without a classifier call.
+- **Custom whitelist** — exact domains or globs that are always allowed. The whitelist wins over every other rule, so a domain you trust is never blocked.
+- **Blocked TLDs** — top-level domains to block outright (e.g. `zip`), matched on label boundaries.
+- **Risk score threshold** — the normalized score (0–100) at or above which a classifier verdict is treated as a block. Lower is stricter. The default is `75`.
+- **Failure policy** — what to do when the classifier can't be reached: **block** (`closed`, the default and recommended for a security control) or **allow** (`open`).
+
+Custom domains you blacklist or whitelist are matched using the same host canonicalization as the classifier, so alternate encodings of an address (for example, an integer-form IP) can't be used to slip past a list entry.
+
+## Configuring the policy
+
+Team admins configure Threat Protection from the [organization settings](https://www.firecrawl.dev/app/settings?tab=threat-protection) in the dashboard:
+
+1. Open **Settings → Threat Protection**.
+2. Choose a mode, set your risk score threshold, and add any blacklist, whitelist, or blocked-TLD entries.
+3. Choose whether to allow per-request overrides, and set the failure policy.
+4. Save. Changes take effect within about a minute.
+
+Only team admins can view or change the policy. Everyone else sees a read-only view.
+
+## Per-request overrides
+
+Every endpoint that accepts URLs also accepts an optional `threatProtection` object, so an individual request can tighten (or, if your organization allows it, adjust) the policy for that call:
+
+```json
+{
+  "url": "https://example.com",
+  "threatProtection": {
+    "mode": "normal",
+    "riskScoreThreshold": 50,
+    "blacklist": ["*.risky.example"]
+  }
+}
+```
+
+Overrides are merged onto the organization policy field by field. If your organization has **disabled request overrides**, any request that includes a `threatProtection` object is rejected with a `403` — this lets an administrator guarantee that the organization policy is the floor for every request.
+
+## When a domain is blocked
+
+A blocked request fails with a `403` and a stable error code:
+
+```json
+{
+  "success": false,
+  "code": "unsafe_domain_blocked",
+  "error": "This domain (risky.example) is blocked by your organization's threat protection policy (rule: blacklist). If you believe this is a mistake, contact your organization administrator to adjust the policy (e.g. whitelist the domain)."
+}
+```
+
+Behavior differs slightly by endpoint, matching what is most useful:
+
+- **Scrape, batch scrape, extract, agent** — a blocked target returns the `unsafe_domain_blocked` error for that URL.
+- **Crawl** — a blocked seed URL fails the request; blocked links discovered mid-crawl are skipped and the crawl continues.
+- **Search, map** — blocked domains are removed from the returned results rather than surfaced and refused.
+
+If a request is redirected to a different domain, the destination is re-checked before its content is fetched, so a redirect can't be used to reach a blocked domain.
+
+## Billing
+
+A domain scan costs **+2 credits per domain scanned** in Normal mode, on top of the base cost of the request. A few details:
+
+- Decisions made entirely from your own policy (blacklist, whitelist, or blocked-TLD matches) do not call the classifier and are **not** charged a scan fee.
+- A request that is blocked is still charged for the scan that produced the verdict.
+- Crawls, searches, and maps scan each unique domain they encounter, so the scan fees scale with the number of distinct domains, not the number of pages.
+
+## Exporting decisions to your SIEM
+
+Every threat protection decision — allowed and blocked alike — can be delivered to your organization's SIEM as a structured JSON event over HTTPS. Configure a destination URL and a signing secret in the dashboard; events are batched, signed with an HMAC-SHA256 signature you can verify, and you can choose to receive **only blocked decisions** or **all checks**.
+
+Because Firecrawl does not retain threat protection decisions itself, a SIEM destination is the way to keep an audit trail. If your organization requires one, configure the SIEM destination before enabling enforcement.
+
+## Error reference
+
+| Status | When |
+| --- | --- |
+| `403` | A request targets a domain blocked by the policy (`code: unsafe_domain_blocked`). |
+| `403` | A request includes a `threatProtection` override while overrides are disabled for the organization. |
+| `403` | Threat Protection options are used on a team without the feature enabled. |
+
+## Notes
+
+- The policy is organization-wide: it applies to every API key and every endpoint automatically.
+- The whitelist always wins, so an explicitly trusted domain is never blocked by the classifier or a TLD rule.
+- With the failure policy set to `closed` (the default), a classifier outage causes affected requests to be blocked rather than silently allowed.

--- a/features/threat-protection.mdx
+++ b/features/threat-protection.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Threat Protection"
-description: "Block requests to risky domains across every endpoint, using a policy your organization controls. Enforced server-side, with optional export of every decision to your SIEM."
+description: "Block requests to risky domains across every endpoint, using a policy your organization controls. Enforced server-side."
 og:title: "Threat Protection | Firecrawl"
-og:description: "Block requests to risky domains across every endpoint, using a policy your organization controls. Enforced server-side, with optional export of every decision to your SIEM."
+og:description: "Block requests to risky domains across every endpoint, using a policy your organization controls. Enforced server-side."
 ---
 
 Threat Protection lets your organization block Firecrawl from accessing risky domains. When it is enabled, every URL a request would fetch — a scrape target, a search result, a link discovered during a crawl, a page an agent navigates to — is checked against your organization's policy before any content is retrieved. Domains that fail the policy are refused.
@@ -89,12 +89,6 @@ A domain scan costs **+2 credits per domain scanned** in Normal mode, on top of 
 - Decisions made entirely from your own policy (blacklist, whitelist, or blocked-TLD matches) do not call the classifier and are **not** charged a scan fee.
 - A request that is blocked is still charged for the scan that produced the verdict.
 - Crawls, searches, and maps scan each unique domain they encounter, so the scan fees scale with the number of distinct domains, not the number of pages.
-
-## Exporting decisions to your SIEM
-
-Every threat protection decision — allowed and blocked alike — can be delivered to your organization's SIEM as a structured JSON event over HTTPS. Configure a destination URL and a signing secret in the dashboard; events are batched, signed with an HMAC-SHA256 signature you can verify, and you can choose to receive **only blocked decisions** or **all checks**.
-
-Because Firecrawl does not retain threat protection decisions itself, a SIEM destination is the way to keep an audit trail. If your organization requires one, configure the SIEM destination before enabling enforcement.
 
 ## Error reference
 

--- a/features/threat-protection.mdx
+++ b/features/threat-protection.mdx
@@ -41,7 +41,7 @@ Team admins configure Threat Protection from the [organization settings](https:/
 1. Open **Settings → Threat Protection**.
 2. Choose a mode, set your risk score threshold, and add any blacklist, whitelist, or blocked-TLD entries.
 3. Choose whether to allow per-request overrides, and set the failure policy.
-4. Save. Changes take effect within about a minute.
+4. Save. Changes take effect immediately — the next request is evaluated against the new policy.
 
 Only team admins can view or change the policy. Everyone else sees a read-only view.
 


### PR DESCRIPTION
Adds a feature page for Threat Protection (enterprise domain risk blocking) and links it under **Plans and Billing** in the navigation, next to Key Restrictions.

## Contents
- Modes (Off / Normal — Google Web Risk, +2 credits per domain scanned)
- Organization policy controls: custom blacklist/whitelist (globs), blocked TLDs, risk score threshold, failure policy
- Per-request `threatProtection` overrides and the organization override lockout
- Per-endpoint behavior (scrape/batch/extract/agent vs crawl vs search/map) and redirect re-checking
- Billing semantics (per domain scanned; local-only decisions not charged)
- `unsafe_domain_blocked` error reference
- Exporting decisions to a SIEM

## Notes
- English source pages only (`features/threat-protection.mdx` + the two English nav trees in `docs.json`); localized pages are autogenerated.
- `docs.json` validated as JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)