### PR TITLE
docs(search): document the highlights parameter (on by default)

### DIFF
--- a/agent-source-of-truth/curl.mdx
+++ b/agent-source-of-truth/curl.mdx
@@ -125,6 +125,10 @@ Successful responses include `success`, `data`, optional `warning`, `id`, and `c
   - Type: boolean (default false)
   - Use when: you want to drop URLs that cannot be scraped by other endpoints.
 
+- `highlights`
+  - Type: boolean (default true)
+  - Use when: you want to keep the search provider's original descriptions (set it to false). On by default — replaces each result's description with query-relevant highlights from Firecrawl's index when available.
+
 - `timeout`
   - Type: integer (milliseconds, default 60000)
   - Use when: you need a request timeout in milliseconds.

--- a/agent-source-of-truth/elixir.mdx
+++ b/agent-source-of-truth/elixir.mdx
@@ -117,6 +117,10 @@ Use search to discover relevant pages from a query, then pick URLs to scrape or 
   - Type: boolean
   - Use when: you want to drop URLs that cannot be scraped by other endpoints.
 
+- `highlights`
+  - Type: boolean
+  - Use when: you want to keep the search provider's original descriptions (set it to false). On by default — replaces each result's description with query-relevant highlights from Firecrawl's index when available.
+
 - `timeout`
   - Type: integer
   - Use when: you need a request timeout in milliseconds.

--- a/agent-source-of-truth/java.mdx
+++ b/agent-source-of-truth/java.mdx
@@ -140,6 +140,10 @@ SearchData results = client.search("site:docs.firecrawl.dev crawl webhooks", opt
   - Type: Boolean
   - Use when: you want to drop URLs that cannot be scraped by other endpoints.
 
+- `options.highlights`
+  - Type: Boolean
+  - Use when: you want to keep the search provider's original descriptions (set it to false). On by default — replaces each result's description with query-relevant highlights from Firecrawl's index when available.
+
 - `options.timeout`
   - Type: Integer
   - Use when: you need a request timeout in milliseconds.

--- a/agent-source-of-truth/node.mdx
+++ b/agent-source-of-truth/node.mdx
@@ -125,6 +125,10 @@ const results = await client.search("site:docs.firecrawl.dev crawl webhooks", {
   - Type: boolean
   - Use when: you want to drop URLs that cannot be scraped by other endpoints.
 
+- `options.highlights`
+  - Type: boolean
+  - Use when: you want to keep the search provider's original descriptions (set it to false). On by default — replaces each result's description with query-relevant highlights from Firecrawl's index when available.
+
 - `options.timeout`
   - Type: number
   - Use when: you need a request timeout in milliseconds.

--- a/agent-source-of-truth/python.mdx
+++ b/agent-source-of-truth/python.mdx
@@ -134,6 +134,10 @@ results = client.search(
   - Type: bool
   - Use when: you want to drop URLs that cannot be scraped by other endpoints.
 
+- `highlights`
+  - Type: bool
+  - Use when: you want to keep the search provider's original descriptions (set it to false). On by default — replaces each result's description with query-relevant highlights from Firecrawl's index when available.
+
 - `timeout`
   - Type: int
   - Use when: you need a request timeout in milliseconds.

--- a/agent-source-of-truth/rust.mdx
+++ b/agent-source-of-truth/rust.mdx
@@ -129,6 +129,10 @@ let results = client
   - Type: bool
   - Use when: you want to drop URLs that cannot be scraped by other endpoints.
 
+- `options.highlights`
+  - Type: bool
+  - Use when: you want to keep the search provider's original descriptions (set it to false). On by default — replaces each result's description with query-relevant highlights from Firecrawl's index when available.
+
 - `options.timeout`
   - Type: u32
   - Use when: you need a request timeout in milliseconds.

--- a/api-reference/v1-openapi.json
+++ b/api-reference/v1-openapi.json
@@ -2110,6 +2110,11 @@
                     "description": "Excludes URLs from the search results that are invalid for other Firecrawl endpoints. This helps reduce errors if you are piping data from search into other Firecrawl API endpoints.",
                     "default": false
                   },
+                  "highlights": {
+                    "type": "boolean",
+                    "description": "Replaces each result's description with query-relevant highlights pulled from Firecrawl's index of the page (when available). Falls back to the search provider's description when the page isn't indexed or highlights can't be generated in time. Set to false to always keep the provider's description.",
+                    "default": true
+                  },
                   "scrapeOptions": {
                     "allOf": [
                       {

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -3570,6 +3570,11 @@
                     "description": "Excludes URLs from the search results that are invalid for other Firecrawl endpoints. This helps reduce errors if you are piping data from search into other Firecrawl API endpoints.",
                     "default": false
                   },
+                  "highlights": {
+                    "type": "boolean",
+                    "description": "Replaces each result's description with query-relevant highlights pulled from Firecrawl's index of the page (when available). Falls back to the search provider's description when the page isn't indexed or highlights can't be generated in time. Set to false to always keep the provider's description.",
+                    "default": true
+                  },
                   "enterprise": {
                     "type": "array",
                     "items": {

--- a/features/search.mdx
+++ b/features/search.mdx
@@ -496,6 +496,58 @@ curl -X POST https://api.firecrawl.dev/v2/search \
 
 </CodeGroup>
 
+### Result Highlights
+
+By default, Search replaces each result's `description` with query-relevant highlights pulled from Firecrawl's index of the page, giving you snippets that actually answer your query instead of the page's generic meta description. When a page isn't in the index, or highlights can't be generated within the internal latency budget, the result keeps the search provider's original description — you always get a description either way.
+
+Set `highlights: false` to always keep the provider's original descriptions:
+
+<CodeGroup>
+
+```python Python
+from firecrawl import Firecrawl
+
+# Initialize the client with your API key
+firecrawl = Firecrawl(api_key="fc-YOUR_API_KEY")
+
+# Opt out of highlights
+search_result = firecrawl.search(
+    "firecrawl web scraping",
+    limit=10,
+    highlights=False
+)
+```
+
+```js JavaScript
+import { Firecrawl } from 'firecrawl';
+
+// Initialize the client with your API key
+const firecrawl = new Firecrawl({apiKey: "fc-YOUR_API_KEY"});
+
+// Opt out of highlights
+const searchResult = await firecrawl.search("firecrawl web scraping", {
+  limit: 10,
+  highlights: false
+});
+```
+
+```bash cURL
+curl -X POST https://api.firecrawl.dev/v2/search \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
+  -d '{
+    "query": "firecrawl web scraping",
+    "limit": 10,
+    "highlights": false
+  }'
+```
+
+</CodeGroup>
+
+<Note>
+Highlights apply to `web` and `news` results. News results carry the highlight in their `snippet` field instead of `description`.
+</Note>
+
 ## Zero Data Retention (ZDR)
 
 For teams with strict data handling requirements, Firecrawl offers Zero Data Retention (ZDR) options for the `/search` endpoint via the `enterprise` parameter. ZDR search is available on Enterprise plans — visit [firecrawl.dev/enterprise](https://www.firecrawl.dev/enterprise) to get started.


### PR DESCRIPTION
Parallel to firecrawl/firecrawl#3958, which turns search result highlights on by default for v1 and v2 `/search` (hard 300ms internal budget, falls back to the provider description on index miss or timeout) and exposes `highlights` in all SDKs.

## What

- **`api-reference/v2-openapi.json` + `api-reference/v1-openapi.json`**: added the `highlights` boolean (default `true`) to the search request schemas, so the API reference pages pick it up.
- **`features/search.mdx`**: new "Result Highlights" section under Advanced Search Options — explains the default-on behavior, the fallback guarantee, and shows the `highlights: false` opt-out in Python/JS/cURL; notes that news results carry the highlight in `snippet`.
- **`agent-source-of-truth/{curl,node,python,java,rust,elixir}.mdx`**: added the `highlights` option to each search options list, matching each file's naming convention.

English files only — es/fr/pt-BR/ja/zh are autogenerated and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)