### PR TITLE
docs: security features sweep — IP Restrictions page, threat protection billing fix, OpenAPI override schema

### DIFF
--- a/api-reference/v1-openapi.json
+++ b/api-reference/v1-openapi.json
@@ -1002,6 +1002,9 @@
                         }
                       }
                     }
+                  },
+                  "threatProtection": {
+                    "$ref": "#/components/schemas/ThreatProtectionOverride"
                   }
                 },
                 "required": ["url"]
@@ -1131,6 +1134,9 @@
                     "type": "boolean",
                     "default": false,
                     "description": "If invalid URLs are specified in the urls array, they will be ignored. Instead of them failing the entire request, an extract using the remaining valid URLs will be performed, and the invalid URLs will be returned in the invalidURLs field of the response."
+                  },
+                  "threatProtection": {
+                    "$ref": "#/components/schemas/ThreatProtectionOverride"
                   }
                 },
                 "required": ["urls"]
@@ -2140,6 +2146,9 @@
                     ],
                     "description": "Options for scraping search results",
                     "default": {}
+                  },
+                  "threatProtection": {
+                    "$ref": "#/components/schemas/ThreatProtectionOverride"
                   }
                 },
                 "required": ["query"]
@@ -2801,6 +2810,9 @@
             "type": "boolean",
             "description": "If true, the page will be stored in the Firecrawl index and cache. Setting this to false is useful if your scraping activity may have data protection concerns. Using some parameters associated with sensitive scraping (actions, headers) will force this parameter to be false.",
             "default": true
+          },
+          "threatProtection": {
+            "$ref": "#/components/schemas/ThreatProtectionOverride"
           }
         }
       },
@@ -3516,6 +3528,54 @@
           "expiresAt": {
             "type": "string",
             "format": "date-time"
+          }
+        }
+      },
+      "ThreatProtectionOverride": {
+        "type": "object",
+        "title": "Threat Protection Override",
+        "description": "Per-request [Threat Protection](https://docs.firecrawl.dev/features/threat-protection) override. Fields you provide replace the corresponding fields of your organization's policy for this request only; omitted fields keep their organization-level values. Requires Threat Protection to be enabled for your team (enterprise feature) — otherwise the request is rejected with a 403. If your organization has disabled request overrides, any request that includes this object is rejected with a 403. If Threat Protection is enforced for your team, `mode` may not be set to `off`.",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": ["off", "normal"],
+            "description": "Domain scanning mode for this request. `normal` checks domains against Google Web Risk (+2 credits per domain scanned)."
+          },
+          "riskScoreThreshold": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Normalized risk score (0–100) at or above which a classifier verdict blocks the domain. Lower is stricter.",
+            "example": 75
+          },
+          "blacklist": {
+            "type": "array",
+            "maxItems": 1000,
+            "items": {
+              "type": "string"
+            },
+            "description": "Domains to always block, as plain domains (`example.com`) or wildcard globs (`*.example.com`). No protocol, path, or port."
+          },
+          "whitelist": {
+            "type": "array",
+            "maxItems": 1000,
+            "items": {
+              "type": "string"
+            },
+            "description": "Domains to always allow, as plain domains or wildcard globs. Wins over every other rule."
+          },
+          "blockedTlds": {
+            "type": "array",
+            "maxItems": 1000,
+            "items": {
+              "type": "string"
+            },
+            "description": "Top-level domains to block outright, lowercase without the leading dot (e.g. `zip`)."
+          },
+          "failurePolicy": {
+            "type": "string",
+            "enum": ["open", "closed"],
+            "description": "What to do when the classifier can't be reached: `closed` blocks the request, `open` allows it."
           }
         }
       }

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -2207,6 +2207,9 @@
                         }
                       }
                     }
+                  },
+                  "threatProtection": {
+                    "$ref": "#/components/schemas/ThreatProtectionOverride"
                   }
                 },
                 "required": [
@@ -2361,6 +2364,9 @@
                     "type": "boolean",
                     "default": true,
                     "description": "If invalid URLs are specified in the urls array, they will be ignored. Instead of them failing the entire request, an extract using the remaining valid URLs will be performed, and the invalid URLs will be returned in the invalidURLs field of the response."
+                  },
+                  "threatProtection": {
+                    "$ref": "#/components/schemas/ThreatProtectionOverride"
                   }
                 },
                 "required": [
@@ -2506,6 +2512,9 @@
                     ],
                     "default": "spark-1-mini",
                     "description": "The model to use for the agent task. spark-1-mini (default) is 60% cheaper, spark-1-pro offers higher accuracy for complex tasks"
+                  },
+                  "threatProtection": {
+                    "$ref": "#/components/schemas/ThreatProtectionOverride"
                   }
                 },
                 "required": [
@@ -3589,6 +3598,9 @@
                     ],
                     "description": "Options for scraping search results",
                     "default": {}
+                  },
+                  "threatProtection": {
+                    "$ref": "#/components/schemas/ThreatProtectionOverride"
                   }
                 },
                 "required": [
@@ -7307,6 +7319,9 @@
             "required": [
               "name"
             ]
+          },
+          "threatProtection": {
+            "$ref": "#/components/schemas/ThreatProtectionOverride"
           }
         }
       },
@@ -9415,6 +9430,60 @@
           "success",
           "error"
         ]
+      },
+      "ThreatProtectionOverride": {
+        "type": "object",
+        "title": "Threat Protection Override",
+        "description": "Per-request [Threat Protection](https://docs.firecrawl.dev/features/threat-protection) override. Fields you provide replace the corresponding fields of your organization's policy for this request only; omitted fields keep their organization-level values. Requires Threat Protection to be enabled for your team (enterprise feature) — otherwise the request is rejected with a 403. If your organization has disabled request overrides, any request that includes this object is rejected with a 403. If Threat Protection is enforced for your team, `mode` may not be set to `off`.",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "off",
+              "normal"
+            ],
+            "description": "Domain scanning mode for this request. `normal` checks domains against Google Web Risk (+2 credits per domain scanned)."
+          },
+          "riskScoreThreshold": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Normalized risk score (0–100) at or above which a classifier verdict blocks the domain. Lower is stricter.",
+            "example": 75
+          },
+          "blacklist": {
+            "type": "array",
+            "maxItems": 1000,
+            "items": {
+              "type": "string"
+            },
+            "description": "Domains to always block, as plain domains (`example.com`) or wildcard globs (`*.example.com`). No protocol, path, or port."
+          },
+          "whitelist": {
+            "type": "array",
+            "maxItems": 1000,
+            "items": {
+              "type": "string"
+            },
+            "description": "Domains to always allow, as plain domains or wildcard globs. Wins over every other rule."
+          },
+          "blockedTlds": {
+            "type": "array",
+            "maxItems": 1000,
+            "items": {
+              "type": "string"
+            },
+            "description": "Top-level domains to block outright, lowercase without the leading dot (e.g. `zip`)."
+          },
+          "failurePolicy": {
+            "type": "string",
+            "enum": [
+              "open",
+              "closed"
+            ],
+            "description": "What to do when the classifier can't be reached: `closed` blocks the request, `open` allows it."
+          }
+        }
       }
     }
   },

--- a/docs.json
+++ b/docs.json
@@ -132,6 +132,7 @@
                           "rate-limits",
                           "partner-credits",
                           "enterprise",
+                          "features/ip-restrictions",
                           "features/key-restrictions",
                           "features/threat-protection"
                         ]
@@ -688,6 +689,7 @@
                           "rate-limits",
                           "partner-credits",
                           "enterprise",
+                          "features/ip-restrictions",
                           "features/key-restrictions",
                           "features/threat-protection"
                         ]

--- a/enterprise.mdx
+++ b/enterprise.mdx
@@ -23,7 +23,7 @@ Enterprise features are provisioned by our team. To enable them or discuss a cus
 - **Single Sign-On (SSO)**: SAML and OIDC single sign-on so your team authenticates through your existing identity provider (Okta, Entra ID, Google Workspace, and more).
 - **SCIM directory sync**: Automatically provision and deprovision users from your directory so access stays in sync with your org.
 - **Static IP allowlisting**: Route your traffic through dedicated, whitelisted IP addresses for allowlisting on your systems.
-- **API key IP restrictions**: Restrict your team's API keys to an allowlist of IP addresses or CIDR ranges so they only work from approved networks.
+- **[IP restrictions](/features/ip-restrictions)**: Restrict your team's API keys to an allowlist of IP addresses or CIDR ranges so they only work from approved networks.
 - **[Key restrictions](/features/key-restrictions)**: Lock individual API keys to specific output formats and endpoints, enforced server-side with no request-level override.
 
 ## Scale & performance

--- a/features/ip-restrictions.mdx
+++ b/features/ip-restrictions.mdx
@@ -1,0 +1,59 @@
+---
+title: "IP Restrictions"
+description: "Restrict your team's API keys to an allowlist of IP addresses or CIDR ranges, so they only work from approved networks. Enforced server-side."
+og:title: "IP Restrictions | Firecrawl"
+og:description: "Restrict your team's API keys to an allowlist of IP addresses or CIDR ranges, so they only work from approved networks. Enforced server-side."
+---
+
+IP Restrictions let your team maintain an allowlist of IP addresses and CIDR ranges that API requests must originate from. The allowlist is enforced server-side during authentication on every authenticated request, so a leaked or exfiltrated API key is useless outside your approved networks.
+
+The allowlist is team-scoped: it applies to all of the team's API keys at once.
+
+<Note>
+IP Restrictions are an enterprise feature and are gated per team. Contact your Firecrawl account team to have them enabled for your account.
+</Note>
+
+<Note>
+This is the *inbound* control — where your requests to Firecrawl may come from. If you are looking for the *outbound* direction (static egress IPs for Firecrawl's traffic to your systems, so you can allowlist Firecrawl), see [Enterprise features](/enterprise).
+</Note>
+
+## What you can allowlist
+
+Entries can be:
+
+- **Single IPv4 addresses** — e.g. `203.0.113.7`
+- **Single IPv6 addresses** — e.g. `2001:db8::1`
+- **CIDR ranges**, IPv4 or IPv6 — e.g. `10.0.0.0/8`, `2001:db8::/32`
+
+Clients connecting over IPv4-mapped IPv6 (`::ffff:203.0.113.7`) are normalized to their IPv4 form before matching, so an IPv4 entry covers them.
+
+The allowlist is enforced only when it is **non-empty**. An empty allowlist means no restriction, so a team can never lock itself out before it has configured any IPs.
+
+## Configuring the allowlist
+
+Team admins manage the allowlist from the [Advanced settings](https://www.firecrawl.dev/app/settings?tab=advanced) in the dashboard. Add or remove entries and save — changes take effect within about a minute.
+
+## Enforcement
+
+The check runs during authentication, so it covers every authenticated surface uniformly: all API versions, job status and cancellation endpoints, and websocket status connections. There is no request-level way to bypass it.
+
+A request from an IP that is not on the allowlist is rejected with a `403`:
+
+```json
+{
+  "success": false,
+  "error": "Request blocked: IP address 198.51.100.24 is not on this team's allowed IP list. Team admins can manage allowed IPs at https://www.firecrawl.dev/app/settings?tab=advanced"
+}
+```
+
+## Error reference
+
+| Status | When |
+| --- | --- |
+| `403` | The request's IP address is not on the team's allowlist. |
+| `500` | The allowlist could not be verified. Requests fail closed (are rejected) rather than bypassing the restriction. Retry shortly. |
+
+## Notes
+
+- IP Restrictions add no credit charges.
+- IP Restrictions are independent of [Key Restrictions](/features/key-restrictions); a team can use both, and a single key can be limited by format, endpoint, and origin network at the same time.

--- a/features/ip-restrictions.mdx
+++ b/features/ip-restrictions.mdx
@@ -10,7 +10,7 @@ IP Restrictions let your team maintain an allowlist of IP addresses and CIDR ran
 The allowlist is team-scoped: it applies to all of the team's API keys at once.
 
 <Note>
-IP Restrictions are an enterprise feature and are gated per team. Contact your Firecrawl account team to have them enabled for your account.
+IP Restrictions are an enterprise feature and are gated per organization. Contact your Firecrawl account team to have them enabled for your account.
 </Note>
 
 <Note>

--- a/features/key-restrictions.mdx
+++ b/features/key-restrictions.mdx
@@ -91,4 +91,4 @@ The legacy `v0` API predates these controls, so a key with **any** restriction c
 
 - Restrictions are per key, so you can hand out a locked-down key to an agent while keeping an unrestricted key for interactive use.
 - Changes propagate to the API within about a minute. There is no way to disable enforcement from within a request.
-- Key Restrictions are independent of IP-based restrictions; a key can have both.
+- Key Restrictions are independent of [IP Restrictions](/features/ip-restrictions); a key can have both.

--- a/features/threat-protection.mdx
+++ b/features/threat-protection.mdx
@@ -62,6 +62,8 @@ Every endpoint that accepts URLs also accepts an optional `threatProtection` obj
 
 Overrides are merged onto the organization policy field by field. If your organization has **disabled request overrides**, any request that includes a `threatProtection` object is rejected with a `403` — this lets an administrator guarantee that the organization policy is the floor for every request.
 
+If Threat Protection is **enforced** for your team, an override may still tighten the policy but may not include `"mode": "off"` — a request that tries is rejected with a `403`.
+
 ## When a domain is blocked
 
 A blocked request fails with a `403` and a stable error code:
@@ -88,7 +90,9 @@ A domain scan costs **+2 credits per domain scanned** in Normal mode, on top of 
 
 - Decisions made entirely from your own policy (blacklist, whitelist, or blocked-TLD matches) do not call the classifier and are **not** charged a scan fee.
 - A request that is blocked is still charged for the scan that produced the verdict.
-- Crawls, searches, and maps scan each unique domain they encounter, so the scan fees scale with the number of distinct domains, not the number of pages.
+- Scans are deduplicated within a single scrape: a same-domain redirect re-check shares the original scan, while a redirect that lands on a different domain is a second scan.
+- **Crawls and batch scrapes check every page independently.** Verdicts are never reused across pages — nothing about your traffic is stored (see above) — so in Normal mode expect **+2 credits per scraped page**, even when the pages share a domain.
+- **Search and map** scan each unique domain in the result set once per request, so their scan fees scale with the number of distinct domains returned.
 
 ## Error reference
 
@@ -96,6 +100,7 @@ A domain scan costs **+2 credits per domain scanned** in Normal mode, on top of 
 | --- | --- |
 | `403` | A request targets a domain blocked by the policy (`code: unsafe_domain_blocked`). |
 | `403` | A request includes a `threatProtection` override while overrides are disabled for the organization. |
+| `403` | A `threatProtection` override sets `mode: "off"` while Threat Protection is enforced for the team. |
 | `403` | Threat Protection options are used on a team without the feature enabled. |
 
 ## Notes


### PR DESCRIPTION
Sweep of the docs against the recently shipped security/enterprise API features. Three gaps found and fixed:

## 1. IP Restrictions had no documentation
The per-team API key IP allowlist shipped with only a one-line bullet on the enterprise page. Adds `features/ip-restrictions.mdx` covering:
- IPv4 / IPv6 / CIDR entries (and IPv4-mapped-IPv6 normalization)
- enforcement at authentication across every API surface, with the exact 403 body
- fail-closed 500 behavior, empty-list-means-unrestricted rule, ~1 min propagation
- inbound vs. outbound (static egress IPs) disambiguation

Linked from `enterprise.mdx` and the Key Restrictions page; registered in nav (English blocks only — locadex handles locales).

## 2. Threat protection billing docs were wrong for crawls
The feature page claimed crawl/search/map scan fees scale with *unique domains, not pages*. Per the billing implementation and its snips (`scrape-billing.ts`, `threat-protection-billing.test.ts`: "crawl bills base + 2 per scraped document", "batch scrape bills base + 2 per document (each job scans afresh)"), crawls and batch scrapes scan every page independently — verdicts are never reused across page jobs (ZDR, no verdict cache). Only search and map dedupe by domain within a request. Rewrote the billing bullets accordingly, and documented the redirect dedup rule.

Also documents the `forced` mode rule (overrides may not set `mode: "off"`) with its error-reference row.

## 3. Per-request `threatProtection` override missing from OpenAPI
The feature page describes the per-request override object, but no request schema defined it. Adds a `ThreatProtectionOverride` component to both specs and references it exactly where the API accepts it:
- **v2**: shared `ScrapeOptions` (covers scrape, batch scrape, crawl/search `scrapeOptions`) + top-level on `/map`, `/extract`, `/agent`, `/search`
- **v1**: `BaseScrapeOptions` + top-level on `/map`, `/extract`, `/search`

v1 spec edited via Prettier-clean surgery (60 pure insertions, no reflow).

## Explicitly not covered
- Search highlights: already in flight in #1112.
- Admin cache-clear endpoints (`ip-restriction-cache-clear`, `key-restriction-cache-clear`): internal, BULL_AUTH_KEY-gated — intentionally undocumented.
- Key Restrictions page: verified against the merged implementation, already accurate.
- Per-key concurrency limits (api_keys.concurrency): just merged, no public config surface yet — skipped for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)