### PR TITLE
Regroup Enterprise docs navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -130,7 +130,12 @@
                         "pages": [
                           "billing",
                           "rate-limits",
-                          "partner-credits",
+                          "partner-credits"
+                        ]
+                      },
+                      {
+                        "group": "Enterprise",
+                        "pages": [
                           "enterprise",
                           "features/ip-restrictions",
                           "features/key-restrictions",
@@ -687,7 +692,12 @@
                         "pages": [
                           "billing",
                           "rate-limits",
-                          "partner-credits",
+                          "partner-credits"
+                        ]
+                      },
+                      {
+                        "group": "Enterprise",
+                        "pages": [
                           "enterprise",
                           "features/ip-restrictions",
                           "features/key-restrictions",


### PR DESCRIPTION
## Summary
- Move Enterprise out from the Plans and Billing navigation group
- Add an Enterprise sibling group containing Enterprise, IP restrictions, key restrictions, and threat protection
- Apply the same navigation regrouping to both English doc versions

## Validation
- `python3 -m json.tool docs.json >/dev/null`
- `git diff --check`
- Reviewer Pi session approved
