### PR TITLE
Update enterprise controls dashboard links

### DIFF
--- a/features/ip-restrictions.mdx
+++ b/features/ip-restrictions.mdx
@@ -31,7 +31,7 @@ The allowlist is enforced only when it is **non-empty**. An empty allowlist mean
 
 ## Configuring the allowlist
 
-Team admins manage the allowlist from the [Advanced settings](https://www.firecrawl.dev/app/settings?tab=advanced) in the dashboard. Add or remove entries and save — changes take effect within about a minute.
+Team admins manage the allowlist from [Enterprise Controls → IP Restriction](https://www.firecrawl.dev/app/enterprise-controls?tab=ip-restriction) in the dashboard. Add or remove entries and save — changes take effect within about a minute.
 
 ## Enforcement
 
@@ -42,7 +42,7 @@ A request from an IP that is not on the allowlist is rejected with a `403`:
 ```json
 {
   "success": false,
-  "error": "Request blocked: IP address 198.51.100.24 is not on this team's allowed IP list. Team admins can manage allowed IPs at https://www.firecrawl.dev/app/settings?tab=advanced"
+  "error": "Request blocked: IP address 198.51.100.24 is not on this team's allowed IP list. Team admins can manage allowed IPs at https://www.firecrawl.dev/app/enterprise-controls?tab=ip-restriction"
 }
 ```
 

--- a/features/key-restrictions.mdx
+++ b/features/key-restrictions.mdx
@@ -41,7 +41,7 @@ A request that asks for any format not on the list is rejected:
 ```json
 {
   "success": false,
-  "error": "Request blocked: this API key is restricted to the following formats: markdown. Requested formats not allowed: rawHtml. Team admins can manage key restrictions at https://www.firecrawl.dev/app/settings?tab=advanced"
+  "error": "Request blocked: this API key is restricted to the following formats: markdown. Requested formats not allowed: rawHtml. Team admins can manage key restrictions at https://www.firecrawl.dev/app/api-keys"
 }
 ```
 
@@ -61,7 +61,7 @@ When a key has an allowed-endpoints list, it may only call endpoints in those gr
 ```json
 {
   "success": false,
-  "error": "Request blocked: this API key is restricted to the following endpoints: scrape. Team admins can manage key restrictions at https://www.firecrawl.dev/app/settings?tab=advanced"
+  "error": "Request blocked: this API key is restricted to the following endpoints: scrape. Team admins can manage key restrictions at https://www.firecrawl.dev/app/api-keys"
 }
 ```
 

--- a/features/threat-protection.mdx
+++ b/features/threat-protection.mdx
@@ -36,9 +36,9 @@ The custom blacklist, whitelist, and blocked-TLD rules are domain-level — they
 
 ## Configuring the policy
 
-Team admins configure Threat Protection from the [organization settings](https://www.firecrawl.dev/app/settings?tab=threat-protection) in the dashboard:
+Team admins configure Threat Protection from [Enterprise Controls → Threat Protection](https://www.firecrawl.dev/app/enterprise-controls?tab=threat-protection) in the dashboard:
 
-1. Open **Settings → Threat Protection**.
+1. Open **Enterprise Controls → Threat Protection**.
 2. Choose a mode, set your risk score threshold, and add any blacklist, whitelist, or blocked-TLD entries.
 3. Choose whether to allow per-request overrides, and set the failure policy.
 4. Save. Changes take effect immediately — the next request is evaluated against the new policy.


### PR DESCRIPTION
## Summary
- Update IP Restrictions docs to point admins to Enterprise Controls → IP Restriction.
- Update Threat Protection docs to point admins to Enterprise Controls → Threat Protection.
- Update Key Restrictions examples to point admins to API Keys.

## Testing
- `git diff --check`
