### PR TITLE
docs: make keyless verb lists surface-aware

### DIFF
--- a/ai-onboarding.mdx
+++ b/ai-onboarding.mdx
@@ -47,7 +47,7 @@ Firecrawl users can get an API key in two ways. Most users should sign in throug
   </Card>
 </CardGroup>
 
-**Can't sign in or get a key?** When your agent cannot obtain an API key and the human cannot sign up, you can still use the keyless free tier to search, scrape, and interact without an API key. It is rate-limited and meant as a fallback, so move to a free account or API key as soon as one is available. See [Keyless (no API key)](/rate-limits#keyless-no-api-key) for details.
+**No API key right now?** scrape, search, interact, and parse work immediately — free and rate-limited. Connect MCP to `https://mcp.firecrawl.dev/v2/mcp` (see [MCP Server](/mcp-server) and [Keyless](/rate-limits#keyless-no-api-key)). Sign up for an API key when you need higher rate limits, other endpoints (crawl, extract, map, batch scrape, etc.), or production.
 
 Once you have an API key, continue with [Skills + CLI](#skills-cli) below.
 

--- a/ai-onboarding.mdx
+++ b/ai-onboarding.mdx
@@ -47,7 +47,7 @@ Firecrawl users can get an API key in two ways. Most users should sign in throug
   </Card>
 </CardGroup>
 
-**No API key right now?** Search, scrape, interact, and parse work immediately, free and rate-limited. See [Keyless](/rate-limits#keyless-no-api-key). Sign up for an API key when you need higher rate limits, other endpoints (crawl, extract, map, batch scrape, etc.), or production.
+**No API key right now?** On the CLI, SDKs, and REST, search, scrape, interact, and parse work immediately, free and rate-limited. On hosted MCP, search, scrape, and parse work keyless; interact needs an API key. See [Keyless](/rate-limits#keyless-no-api-key). Sign up for an API key when you need higher rate limits, other endpoints (crawl, extract, map, batch scrape, etc.), or production.
 
 Once you have an API key, continue with [Skills + CLI](#skills-cli) below.
 

--- a/ai-onboarding.mdx
+++ b/ai-onboarding.mdx
@@ -47,7 +47,7 @@ Firecrawl users can get an API key in two ways. Most users should sign in throug
   </Card>
 </CardGroup>
 
-**No API key right now?** scrape, search, interact, and parse work immediately — free and rate-limited. Connect MCP to `https://mcp.firecrawl.dev/v2/mcp` (see [MCP Server](/mcp-server) and [Keyless](/rate-limits#keyless-no-api-key)). Sign up for an API key when you need higher rate limits, other endpoints (crawl, extract, map, batch scrape, etc.), or production.
+**No API key right now?** Scrape, search, interact, and parse work immediately, free and rate-limited. See [Keyless](/rate-limits#keyless-no-api-key). Sign up for an API key when you need higher rate limits, other endpoints (crawl, extract, map, batch scrape, etc.), or production.
 
 Once you have an API key, continue with [Skills + CLI](#skills-cli) below.
 

--- a/ai-onboarding.mdx
+++ b/ai-onboarding.mdx
@@ -47,7 +47,7 @@ Firecrawl users can get an API key in two ways. Most users should sign in throug
   </Card>
 </CardGroup>
 
-**No API key right now?** Scrape, search, interact, and parse work immediately, free and rate-limited. See [Keyless](/rate-limits#keyless-no-api-key). Sign up for an API key when you need higher rate limits, other endpoints (crawl, extract, map, batch scrape, etc.), or production.
+**No API key right now?** Search, scrape, interact, and parse work immediately, free and rate-limited. See [Keyless](/rate-limits#keyless-no-api-key). Sign up for an API key when you need higher rate limits, other endpoints (crawl, extract, map, batch scrape, etc.), or production.
 
 Once you have an API key, continue with [Skills + CLI](#skills-cli) below.
 

--- a/rate-limits.mdx
+++ b/rate-limits.mdx
@@ -106,7 +106,7 @@ Rate limits are measured in requests per minute and are primarily in place to pr
 
 ### Keyless (no API key)
 
-Scrape, search, interact, and parse can be used **without an API key** when the request comes from an official Firecrawl client — the [MCP server](/mcp-server), the [CLI](/sdks/cli), or an SDK. Research endpoints can also be used without an API key on Firecrawl Cloud where the research index is enabled. No other endpoints (crawl, extract, map, batch scrape, etc.) are available without a key.
+On the [CLI](/sdks/cli), SDKs, and REST, scrape, search, interact, and parse can be used **without an API key**. On hosted [MCP](/mcp-server), scrape, search, and parse work keyless; interact needs an API key. Research endpoints can also be used without an API key on Firecrawl Cloud where the research index is enabled. No other endpoints (crawl, extract, map, batch scrape, etc.) are available without a key.
 
 Keyless usage is free and capped per IP address per day by **two limits**, and exceeding either returns a `429`:
 


### PR DESCRIPTION
## Why
A single keyless verb list misleads agents across surfaces: CLI/SDK/REST keyless includes interact, but hosted MCP keyless does not. `ai-onboarding` still used fallback framing, and `rate-limits` Keyless still lumped MCP with CLI/SDK as if interact were keyless everywhere.

## Summary
- Replace the Get credentials keyless paragraph in `ai-onboarding.mdx`
- Drop “meant as a fallback” / human-unavailable framing
- Make keyless verb lists surface-aware in `ai-onboarding.mdx` and `rate-limits.mdx`:
  - CLI / SDKs / REST: search, scrape, interact, and parse
  - Hosted MCP: search, scrape, and parse (interact needs an API key)
- Keep the signup nudge for higher rate limits, other endpoints, or production

Aligns with:
- https://github.com/firecrawl/firecrawl-mcp-server/pull/307
- https://github.com/firecrawl/firecrawl-web/pull/2766

## Test Plan
- [ ] Diff is only base `ai-onboarding.mdx` and `rate-limits.mdx` (no localized files)
- [ ] `ai-onboarding` Get credentials distinguishes CLI/SDK/REST from hosted MCP
- [ ] `rate-limits` Keyless distinguishes CLI/SDK/REST from hosted MCP
- [ ] Both pages include parse on the correct surfaces and note interact needs a key on hosted MCP
- [ ] Links to `/rate-limits#keyless-no-api-key` and `/mcp-server` resolve
- [ ] Preview Get credentials and Keyless sections on the docs site