### PR TITLE
docs(api): document search highlights

### DIFF
--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -3579,6 +3579,11 @@
                     "description": "Excludes URLs from the search results that are invalid for other Firecrawl endpoints. This helps reduce errors if you are piping data from search into other Firecrawl API endpoints.",
                     "default": false
                   },
+                  "highlights": {
+                    "type": "boolean",
+                    "description": "Generate query-relevant highlights for search results. Set to false to return provider descriptions or snippets without highlighting.",
+                    "default": true
+                  },
                   "enterprise": {
                     "type": "array",
                     "items": {


### PR DESCRIPTION
## Summary

- add the highlights boolean to the English v2 search OpenAPI schema
- document the default as true and the explicit false opt-out
- leave prose pages, translated specs, and other languages unchanged

## Validation

- jq empty api-reference/v2-openapi.json
- git diff --check