### PR TITLE
docs: document hosted MCP tool selectors

### DIFF
--- a/mcp-server.mdx
+++ b/mcp-server.mdx
@@ -89,7 +89,7 @@ Examples:
 # Small keyless/core set: search, scrape, parse
 https://mcp.firecrawl.dev/v2/mcp?tools=@core-v1
 
-# Explicit full hosted set
+# Explicit full hosted set (requires an API key or account credential)
 https://mcp.firecrawl.dev/v2/mcp?tools=@full-v1
 
 # A single tool

--- a/mcp-server.mdx
+++ b/mcp-server.mdx
@@ -79,6 +79,28 @@ Send a Firecrawl API key to either hosted endpoint as a Bearer header. The keyle
 }
 ```
 
+### Optional: reduce MCP tool context
+
+Some MCP clients load every advertised tool into the model context. To keep those sessions smaller, hosted generic endpoints support an optional `?tools=` selector. If you omit it, behavior is unchanged.
+
+Examples:
+
+```bash
+# Small keyless/core set: search, scrape, parse
+https://mcp.firecrawl.dev/v2/mcp?tools=@core-v1
+
+# Explicit full hosted set
+https://mcp.firecrawl.dev/v2/mcp?tools=@full-v1
+
+# A single tool
+https://mcp.firecrawl.dev/v2/mcp?tools=firecrawl_search
+
+# Account endpoint, but only advertise the core tools
+https://mcp.firecrawl.dev/v2/mcp-oauth?tools=@core-v1
+```
+
+`?tools=` replaces the advertised list for that connection. It can only remove tools from what the endpoint and credentials already allow; it cannot unlock account-only tools in keyless mode. Marketplace-specific endpoints use fixed review surfaces and do not accept `?tools=`.
+
 Existing OAuth tokens issued for `https://mcp.firecrawl.dev/v2/mcp` remain accepted there. After rollout, new interactive connections should use the account endpoint above.
 
 Audience compatibility is intentionally one-way during rollout: existing `/v2/mcp` OAuth tokens also work on `/v2/mcp-oauth`, while new `/v2/mcp-oauth` tokens do not work on `/v2/mcp`. This preserves every existing connection without weakening the resource binding of newly issued account tokens.


### PR DESCRIPTION
## Summary

- Documents optional hosted MCP `?tools=` selectors for context-heavy clients.
- Shows `@core-v1`, credential-gated `@full-v1`, single-tool, and account-endpoint examples.
- Clarifies defaults remain unchanged, selectors can only remove tools, and marketplace endpoints stay fixed.
- Explicitly states that the full hosted preset requires an API key or account credential.

## Stack and contract

- Stacked on docs PR #1128 (`docs/hosted-mcp-resend-parity`).
- Runtime dependency: firecrawl-mcp-server PR #318.
- Selector contract: hosted MCP contract v1.2.0.
- Keep this PR draft until #318 is frozen and its AX pilot/gating follow-up is resolved.
- Publish only after the Train 1 runtime is deployed and selector runtime validation passes.

## Validation

Latest local validation on 2026-07-17:

- `python3` docs parse/content check ✅
  - parses `docs.json`
  - verifies `mcp-server.mdx` includes `?tools=@core-v1`, `?tools=@full-v1`, `firecrawl_search`, and the credential requirement for the full hosted set
- `git diff --check` ✅

## Mandatory stacked-PR release rule

This Train 3 docs draft intentionally targets the unmerged parent branch from #1128. After #1128 merges, **retarget this PR to `main`**, update/rebase the branch, rerun all required CI, and verify the PR diff contains only this child delta. Do not merge this PR while its base is a retained feature branch; doing so would update that branch rather than `main` and would bypass the intended release boundary.

Draft only. Do **not** merge or deploy from this PR directly. Himadri reviews before merge.
