### PR TITLE
docs: show expired-state card for FRI-GitHub feedback bounty

### DIFF
--- a/features/research.mdx
+++ b/features/research.mdx
@@ -6,6 +6,8 @@ og:description: "Use Firecrawl's research index for paper retrieval, semantic ex
 icon: "book-open"
 ---
 
+import ResearchFeedbackCTA from "/snippets/research-feedback-cta.mdx";
+
 Firecrawl Research is a purpose-built index for scientific and engineering research agents. It exposes a research-specific toolset for searching papers, inspecting paper metadata, reading relevant full-text passages, discovering related papers through structural expansion, and searching over research-related GitHub repos.
 
 - Find papers by topic, method, benchmark, author, or category
@@ -20,6 +22,8 @@ To give your agent access to the Research Index, we strongly recommend using our
 npx skills add firecrawl/skills@firecrawl-research-index
 ```
 </Note>
+
+<ResearchFeedbackCTA src="docs-research" />
 
 ## Endpoints
 

--- a/features/search.mdx
+++ b/features/search.mdx
@@ -27,10 +27,13 @@ import SearchTimeCURL from "/snippets/v2/search/time/curl.mdx";
 import SearchTimeCLI from "/snippets/v2/search/time/cli.mdx";
 import SearchResponse from "/snippets/v2/search/base/output.mdx";
 import PlaygroundCTA from "/snippets/shared/playground-cta-search.mdx";
+import SearchFeedbackCTA from "/snippets/research-feedback-cta.mdx";
 
 Search the web and get clean, structured content from every result in a single API call. Pass a query to `/search` and Firecrawl returns titles, descriptions, and URLs. Add `scrapeOptions` to also retrieve full-page markdown, HTML, links, or screenshots for each result.
 
 For the full parameter list, see the [Search Endpoint API Reference](https://docs.firecrawl.dev/api-reference/endpoint/search).
+
+<SearchFeedbackCTA src="docs-search" />
 
 <PlaygroundCTA />
 

--- a/snippets/research-feedback-cta.mdx
+++ b/snippets/research-feedback-cta.mdx
@@ -1,0 +1,11 @@
+<div className="firecrawl-cta-box" style={{ opacity: 0.6 }}>
+  <div style={{ display: "flex", alignItems: "flex-start", gap: "8px", marginBottom: "8px" }}>
+    <Icon icon="sack-dollar" color="#9ca3af" size={22} />
+    <div className="firecrawl-cta-title" style={{ margin: 0, color: "#9ca3af" }}>
+      <span>Expired: Bounty for /search/research (GitHub) feedback</span>
+    </div>
+  </div>
+  <p className="firecrawl-cta-description">
+    All interviewees eligible for the bounty reward have been contacted. Keep an eye on future bounties within our docs!
+  </p>
+</div>


### PR DESCRIPTION
## What

Shows the dimmed **Expired** card for the GitHub research bounty (Feedback Assistant study `20260629-fri-github-usage`), matching how the `/monitor` bounty was expired.

## Context

The earlier PR (#1138) removed the GitHub bounty CTA entirely. The intent was to show an expired-state card instead (like the monitoring page), not delete it. This PR corrects that:

- `features/research.mdx`: restore the CTA render + import
- `features/search.mdx`: restore the CTA render + import
- `snippets/research-feedback-cta.mdx`: recreate as the expired card (grayed out, no interview link, "all eligible interviewees have been contacted"), matching `monitor-feedback-cta.mdx`

Both the Research Index and Search pages render this one shared snippet, so both show the expired state.

## Localized copies (intentionally not touched)

Localized Research/Search pages import their own localized snippets under `snippets/<locale>/research-feedback-cta.mdx`. Per the repo's localization rule I did not hand-edit those; they sync via locadex.

## Notes

- The `/monitor` bounty is separate and already expired; unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)