### PR TITLE
docs: distinguish scrape freshness from business-object liveness

### DIFF
--- a/agent-source-of-truth/curl.mdx
+++ b/agent-source-of-truth/curl.mdx
@@ -324,6 +324,17 @@ Successful responses include `success` and `data`. Common `data` fields (dependi
   - Type: boolean
   - Use when: you want zero data retention for this scrape.
 
+### Freshness vs liveness
+
+`maxAge` controls freshness: it defaults to 2 days (`172800000` ms), and `"maxAge": 0` forces a live fetch instead of a cached copy. Freshness is separate from liveness — whether the business object behind the page (a job posting, a listing) is still active.
+
+A successful scrape (HTTP 200 with content) only proves the page rendered, not that the object is still live: some ATS pages render "Job not found" or redirect a removed posting to a generic board, both with a 200. Before an irreversible action (applying, purchasing):
+
+- Set `"maxAge": 0` on the final retrieval so it is live, not cached.
+- Compare `metadata.url` (final URL after redirects) with `metadata.sourceURL` (requested); a redirect to a generic page is evidence of removal.
+- Check `metadata.statusCode` and inspect the rendered content for removal signals.
+- Treat inconclusive evidence as **unknown** and stop, rather than assuming the object is active. Firecrawl has no generic liveness field.
+
 ## Interact
 
 ### Why use it

--- a/agent-source-of-truth/elixir.mdx
+++ b/agent-source-of-truth/elixir.mdx
@@ -302,6 +302,17 @@ Use scrape when you already have a URL and want structured content in one or mor
   - Type: boolean
   - Use when: you want zero data retention for this scrape.
 
+### Freshness vs liveness
+
+`max_age` controls freshness: it defaults to 2 days (`172800000` ms), and `max_age: 0` forces a live fetch instead of a cached copy. Freshness is separate from liveness — whether the business object behind the page (a job posting, a listing) is still active.
+
+A successful scrape (HTTP 200 with content) only proves the page rendered, not that the object is still live: some ATS pages render "Job not found" or redirect a removed posting to a generic board, both with a 200. Before an irreversible action (applying, purchasing):
+
+- Set `max_age: 0` on the final retrieval so it is live, not cached.
+- Compare `metadata.url` (final URL after redirects) with `metadata.sourceURL` (requested); a redirect to a generic page is evidence of removal.
+- Check `metadata.statusCode` and inspect the rendered content for removal signals.
+- Treat inconclusive evidence as **unknown** and stop, rather than assuming the object is active. Firecrawl has no generic liveness field.
+
 ## Interact
 
 ### Why use it

--- a/agent-source-of-truth/java.mdx
+++ b/agent-source-of-truth/java.mdx
@@ -327,6 +327,17 @@ Document doc = client.scrape("https://example.com/pricing", options);
   - Type: String
   - Use when: the API expects an integration identifier on the request.
 
+### Freshness vs liveness
+
+`maxAge` controls freshness: it defaults to 2 days (`172800000` ms), and `maxAge` of `0` forces a live fetch instead of a cached copy. Freshness is separate from liveness — whether the business object behind the page (a job posting, a listing) is still active.
+
+A successful scrape (HTTP 200 with content) only proves the page rendered, not that the object is still live: some ATS pages render "Job not found" or redirect a removed posting to a generic board, both with a 200. Before an irreversible action (applying, purchasing):
+
+- Set `maxAge` to `0` on the final retrieval so it is live, not cached.
+- Compare `metadata.url` (final URL after redirects) with `metadata.sourceURL` (requested); a redirect to a generic page is evidence of removal.
+- Check `metadata.statusCode` and inspect the rendered content for removal signals.
+- Treat inconclusive evidence as **unknown** and stop, rather than assuming the object is active. Firecrawl has no generic liveness field.
+
 ## Interact
 
 ### Why use it

--- a/agent-source-of-truth/node.mdx
+++ b/agent-source-of-truth/node.mdx
@@ -316,6 +316,17 @@ const doc = await client.scrape("https://example.com/pricing", {
   - Type: object with `name` and optional `saveChanges`
   - Use when: you want a persistent browser profile shared across scrapes and interactions.
 
+### Freshness vs liveness
+
+`maxAge` controls freshness: it defaults to 2 days (`172800000` ms), and `maxAge: 0` forces a live fetch instead of a cached copy. Freshness is separate from liveness — whether the business object behind the page (a job posting, a listing) is still active.
+
+A successful scrape (HTTP 200 with content) only proves the page rendered, not that the object is still live: some ATS pages render "Job not found" or redirect a removed posting to a generic board, both with a 200. Before an irreversible action (applying, purchasing):
+
+- Set `maxAge: 0` on the final retrieval so it is live, not cached.
+- Compare `metadata.url` (final URL after redirects) with `metadata.sourceURL` (requested); a redirect to a generic page is evidence of removal.
+- Check `metadata.statusCode` and inspect the rendered content for removal signals.
+- Treat inconclusive evidence as **unknown** and stop, rather than assuming the object is active. Firecrawl has no generic liveness field.
+
 ## Interact
 
 ### Why use it

--- a/agent-source-of-truth/python.mdx
+++ b/agent-source-of-truth/python.mdx
@@ -320,6 +320,17 @@ doc = client.scrape(
   - Type: dict with `name` and optional `save_changes` or `saveChanges`
   - Use when: you want a persistent browser profile shared across scrapes and interactions.
 
+### Freshness vs liveness
+
+`max_age` controls freshness: it defaults to 2 days (`172800000` ms), and `max_age=0` forces a live fetch instead of a cached copy. Freshness is separate from liveness — whether the business object behind the page (a job posting, a listing) is still active.
+
+A successful scrape (HTTP 200 with content) only proves the page rendered, not that the object is still live: some ATS pages render "Job not found" or redirect a removed posting to a generic board, both with a 200. Before an irreversible action (applying, purchasing):
+
+- Set `max_age=0` on the final retrieval so it is live, not cached.
+- Compare `metadata.url` (final URL after redirects) with `metadata.source_url` (requested); a redirect to a generic page is evidence of removal.
+- Check `metadata.status_code` and inspect the rendered content for removal signals.
+- Treat inconclusive evidence as **unknown** and stop, rather than assuming the object is active. Firecrawl has no generic liveness field.
+
 ## Interact
 
 ### Why use it

--- a/agent-source-of-truth/rust.mdx
+++ b/agent-source-of-truth/rust.mdx
@@ -344,6 +344,17 @@ let doc = client
   - Use when: you want attribute extraction output.
   - Confirmed fields: `selector`, `attribute`
 
+### Freshness vs liveness
+
+`max_age` controls freshness: it defaults to 2 days (`172800000` ms), and `max_age: 0` forces a live fetch instead of a cached copy. Freshness is separate from liveness — whether the business object behind the page (a job posting, a listing) is still active.
+
+A successful scrape (HTTP 200 with content) only proves the page rendered, not that the object is still live: some ATS pages render "Job not found" or redirect a removed posting to a generic board, both with a 200. Before an irreversible action (applying, purchasing):
+
+- Set `max_age: 0` on the final retrieval so it is live, not cached.
+- Compare `metadata.url` (final URL after redirects) with `metadata.source_url` (requested); a redirect to a generic page is evidence of removal.
+- Check `metadata.status_code` and inspect the rendered content for removal signals.
+- Treat inconclusive evidence as **unknown** and stop, rather than assuming the object is active. Firecrawl has no generic liveness field.
+
 ## Interact
 
 ### Why use it

--- a/features/scrape.mdx
+++ b/features/scrape.mdx
@@ -549,6 +549,24 @@ curl -s -X POST "https://api.firecrawl.dev/v2/scrape" \
 ```
 </CodeGroup>
 
+### Freshness vs. liveness
+
+Caching (above) controls **freshness** — whether you get a recent copy or a live fetch. It's a separate question from **liveness** — whether the business object behind the page (a job posting, a listing, an inventory item) is still active. A scrape can only answer the first question.
+
+A successful scrape (HTTP 200 with content) proves the page rendered. It does **not** prove the underlying object is still live. Applicant tracking systems make this concrete:
+
+- Ashby can return HTTP 200 while rendering "Job not found."
+- Greenhouse can redirect a removed posting to a generic board page that also returns HTTP 200.
+
+Firecrawl deliberately has no generic business-object liveness field — liveness is a decision you make from the evidence. Before an expensive or irreversible action (applying, purchasing, sending), treat scrape output as evidence, not proof:
+
+1. Use `maxAge: 0` on the final retrieval so the fetch is live, not cached (see [Faster Scraping](/features/fast-scraping) for the freshness/latency tradeoff).
+2. Don't treat HTTP 200 or non-empty content as proof of liveness.
+3. Compare `metadata.url` (the final URL after redirects) against `metadata.sourceURL` (the URL you requested). A redirect to a generic listing or board page is evidence of removal.
+4. Check `metadata.statusCode` and inspect the rendered content for removal signals (e.g. "no longer accepting applications").
+5. Prefer a source-specific API or status field where one exists — it often exposes a status the rendered page hides.
+6. Treat inconclusive evidence as **unknown**, and stop before the irreversible step, rather than assuming the object is active.
+
 ## Batch scraping multiple URLs
 
 You can now batch scrape multiple URLs at the same time. It takes the starting URLs and optional parameters as arguments. The params argument allows you to specify additional options for the batch scrape job, such as the output formats.


### PR DESCRIPTION
## Problem

A successful, fresh scrape (HTTP 200 + content) proves a page rendered — it does not prove the object behind the page is still active. Applicant tracking systems make this trap concrete: Ashby can return a 200 while rendering "Job not found," and Greenhouse can redirect a removed posting to a generic board page that also returns 200. Agents and integrators reading our docs can mistake "the scrape worked" for "the job/listing is live" and take an irreversible action (e.g. submitting an application) against a dead object.

## What's added and where

- `features/scrape.mdx`: a new `### Freshness vs. liveness` subsection immediately after `## Caching and maxAge`. Covers the liveness rule, the ATS example, an evidence-inspection checklist (`maxAge: 0` on the final read, `metadata.url` vs `metadata.sourceURL` redirect evidence, `metadata.statusCode`, content signals, treat inconclusive as unknown), and cross-links to [Faster Scraping](/features/fast-scraping) rather than restating cache mechanics.
- `agent-source-of-truth/{node,python,rust,java,elixir,curl}.mdx`: a compact `### Freshness vs liveness` note in each Scrape section right after the Parameters list, in each file's field-naming style (`maxAge` / `max_age`). Prose-only, ~11 lines each, no code snippets, to keep the diff small. These pages are not in the nav, so no `docs.json` change.

Total: 7 files, +84 lines. Content is consistent with the companion skills reference (same rules, same framing).

## Non-goals (explicit)

- **No `cacheState` / `cachedAt` documentation.** Their public semantics are under review (firecrawl/firecrawl#4081); the new content relies only on `metadata.url`, `metadata.sourceURL`, and `metadata.statusCode`.
- **No new liveness field.** Firecrawl deliberately has no generic business-object liveness field; liveness is a decision the caller makes from the evidence.
- No changes to v1 pages (different `maxAge` defaults), `docs.json` nav, or any localized files under `es/ fr/ ja/ zh/ pt-BR/`.

## Related

- Companion skills PR: firecrawl/skills#5

---

This is a **draft for owner approval** — please review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
