### PR TITLE
docs(mcp): document hidden search-only endpoint

### DIFF
--- a/mcp-server.mdx
+++ b/mcp-server.mdx
@@ -388,6 +388,8 @@ The hosted MCP server is optimized for safe remote use. Some options that are av
 - Local-only file reads are available only when you run the MCP server locally.
 - Webhooks and local file paths should be configured from a local or self-hosted MCP server when the agent needs access to local resources.
 
+For a fixed, read-only MCP surface with search and research tools, see the [Search Only MCP Endpoint](/mcp-server/search-only).
+
 ### Rate Limiting
 
 Rate limits are enforced by Firecrawl. Use an API key for higher limits and access to the full tool set.

--- a/mcp-server/search-only.mdx
+++ b/mcp-server/search-only.mdx
@@ -1,10 +1,10 @@
 ---
-title: Search-only MCP endpoint
+title: Search Only MCP Endpoint
 description: "Use Firecrawl through a fixed, read-only MCP tool set for web and research search"
 hidden: true
 ---
 
-The [Firecrawl MCP Server](/mcp-server) at `https://mcp.firecrawl.dev/v2/mcp` is the default endpoint and provides the complete Firecrawl tool set. Use the search-only endpoint only when your integration requires a fixed, read-only search surface.
+The [Firecrawl MCP Server](/mcp-server) at `https://mcp.firecrawl.dev/v2/mcp` is the default endpoint and provides the complete Firecrawl tool set.
 
 ## Endpoint
 

--- a/mcp-server/search-only.mdx
+++ b/mcp-server/search-only.mdx
@@ -1,0 +1,47 @@
+---
+title: Search-only MCP endpoint
+description: "Use Firecrawl through a fixed, read-only MCP tool set for web and research search"
+hidden: true
+---
+
+The [Firecrawl MCP Server](/mcp-server) at `https://mcp.firecrawl.dev/v2/mcp` is the default endpoint and provides the complete Firecrawl tool set. Use the search-only endpoint only when your integration requires a fixed, read-only search surface.
+
+## Endpoint
+
+```text
+https://mcp.firecrawl.dev/v2/mcp-search
+```
+
+Every request requires authentication: connect with OAuth using the endpoint directly, or pass a Firecrawl API key in the `Authorization` header.
+
+```json
+{
+  "mcpServers": {
+    "firecrawl-search": {
+      "url": "https://mcp.firecrawl.dev/v2/mcp-search",
+      "headers": {
+        "Authorization": "Bearer fc-YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+## Available tools
+
+The search-only endpoint exposes exactly these six read-only tools:
+
+| Tool | Purpose |
+| --- | --- |
+| `firecrawl_search` | Search the web and return ranked results |
+| `firecrawl_research_search_papers` | Search indexed research papers |
+| `firecrawl_research_inspect_paper` | Get canonical metadata for a paper |
+| `firecrawl_research_related_papers` | Find related papers through citation links |
+| `firecrawl_research_read_paper` | Read full-text passages from a paper |
+| `firecrawl_research_search_github` | Search public repository history and README files |
+
+## Differences from the full MCP endpoint
+
+- The tool set is fixed and read-only.
+- Scrape, map, crawl, extract, agent, interact, parse, monitor, and feedback tools are not available.
+- `firecrawl_search` does not accept `scrapeOptions` and cannot request page-content fetching.

--- a/mcp-server/search-only.mdx
+++ b/mcp-server/search-only.mdx
@@ -34,8 +34,8 @@ The search-only endpoint exposes exactly these six read-only tools:
 | Tool | Purpose |
 | --- | --- |
 | `firecrawl_search` | Search the web and return ranked results |
-| `firecrawl_research_search_papers` | Search indexed research papers |
-| `firecrawl_research_inspect_paper` | Get canonical metadata for a paper |
+| `firecrawl_research_search_papers` | Search research papers |
+| `firecrawl_research_inspect_paper` | Get metadata for a paper |
 | `firecrawl_research_related_papers` | Find related papers through citation links |
 | `firecrawl_research_read_paper` | Read full-text passages from a paper |
 | `firecrawl_research_search_github` | Search public repository history and README files |


### PR DESCRIPTION
## Why

Firecrawl now offers a focused, read-only MCP endpoint for web search and research. This page gives users a concise reference for that smaller tool set while keeping the full Firecrawl MCP Server as the default experience.

## Summary

- Document the Search Only MCP endpoint and its six available tools.
- Show how to connect with a Firecrawl API key, with concise OAuth guidance.
- Explain that the endpoint provides search and research without page-content fetching or the broader MCP tool set.
- Add a small contextual note within the hosted MCP guidance without adding a navigation item.
- Keep the full MCP Server as the canonical page and keep the focused endpoint page out of navigation and search.

## Test Plan

- Run `npx --yes mint dev --port 3333`.
- Verify `/mcp-server/search-only` returns HTTP 200 and renders the expected title.
- Verify the rendered page has `noindex` metadata.
- Verify the route is absent from `sitemap.xml` and `llms.txt`.
- Verify the MCP Server page links to the focused endpoint from the hosted MCP guidance.
- Verify the page lists exactly six tools and includes OAuth only once.
- Run `git diff --check`.
