### PR TITLE
docs(search): add highlights feature guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -152,6 +152,7 @@
                         "icon": "magnifying-glass",
                         "pages": [
                           "features/search",
+                          "features/search-highlights",
                           "features/research"
                         ]
                       },

--- a/features/search-highlights.mdx
+++ b/features/search-highlights.mdx
@@ -1,0 +1,152 @@
+---
+title: "Search Highlights"
+description: "Return query-relevant passages instead of generic search snippets"
+og:title: "Search Highlights | Firecrawl"
+og:description: "Return query-relevant passages from search result pages"
+icon: "highlighter"
+---
+
+Search Highlights replace generic search-provider descriptions with passages from each result page that are relevant to your query. They are enabled by default on `/v2/search` and do not require `scrapeOptions`.
+
+Highlights preserve the search result's URL, title, position, and ranking. For web results, the highlighted text is returned in `description`; for news results, it is returned in `snippet`.
+
+<Note>
+  If Firecrawl cannot generate a highlight for a result, the original provider description or snippet is preserved. One unavailable page will not prevent the other search results from being returned.
+</Note>
+
+## Request highlights
+
+Set `highlights` to `true` explicitly, or omit it to use the default behavior.
+
+<CodeGroup>
+
+```python Python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(api_key="fc-YOUR-API-KEY")
+
+results = firecrawl.search(
+    query="What makes Firecrawl useful for AI agents?",
+    limit=5,
+    highlights=True,
+)
+
+for result in results.web or []:
+    print(result.description)
+```
+
+```js Node
+import { Firecrawl } from 'firecrawl';
+
+const firecrawl = new Firecrawl({ apiKey: 'fc-YOUR-API-KEY' });
+
+const results = await firecrawl.search(
+  'What makes Firecrawl useful for AI agents?',
+  {
+    limit: 5,
+    highlights: true,
+  }
+);
+
+for (const result of results.web ?? []) {
+  console.log(result.description);
+}
+```
+
+```bash cURL
+curl -X POST https://api.firecrawl.dev/v2/search \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "What makes Firecrawl useful for AI agents?",
+    "limit": 5,
+    "highlights": true
+  }'
+```
+
+```bash CLI
+firecrawl search "What makes Firecrawl useful for AI agents?" \
+  --limit 5 \
+  --highlights
+```
+
+</CodeGroup>
+
+### MCP
+
+The `firecrawl_search` MCP tool exposes the same `highlights` parameter. It is enabled by default, or you can set it explicitly in the tool arguments:
+
+```json MCP
+{
+  "query": "What makes Firecrawl useful for AI agents?",
+  "limit": 5,
+  "highlights": true
+}
+```
+
+## Response
+
+Highlights use the existing description fields, so the response shape stays the same as a normal search response.
+
+```json
+{
+  "success": true,
+  "data": {
+    "web": [
+      {
+        "url": "https://www.firecrawl.dev/",
+        "title": "Firecrawl - The context API",
+        "description": "Firecrawl gives AI agents clean web data through search, scraping, and structured extraction.",
+        "position": 1
+      }
+    ]
+  }
+}
+```
+
+Highlights may contain Markdown when the relevant page content includes headings, lists, tables, or code. Render or process the field as Markdown if you want to preserve that structure.
+
+## Disable highlights
+
+Set `highlights` to `false` when you need the original search-provider descriptions or snippets.
+
+<CodeGroup>
+
+```python Python
+results = firecrawl.search(
+    query="Firecrawl search API",
+    highlights=False,
+)
+```
+
+```js Node
+const results = await firecrawl.search('Firecrawl search API', {
+  highlights: false,
+});
+```
+
+```bash cURL
+curl -X POST https://api.firecrawl.dev/v2/search \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "Firecrawl search API",
+    "highlights": false
+  }'
+```
+
+```bash CLI
+firecrawl search "Firecrawl search API" --no-highlights
+```
+
+</CodeGroup>
+
+## Behavior by result type
+
+- **Web:** Replaces `description` with query-relevant page content when available.
+- **News:** Replaces `snippet` with query-relevant page content when available.
+- **Images:** Image results are returned unchanged.
+- **Search with scraping:** Highlights affect the search description or snippet. Content requested through `scrapeOptions` is returned separately and is not replaced.
+- **Zero Data Retention:** ZDR searches retain the original provider descriptions and snippets.
+
+For every Search parameter and the complete response schema, see the [Search API reference](/api-reference/endpoint/search).

--- a/features/search-highlights.mdx
+++ b/features/search-highlights.mdx
@@ -26,7 +26,7 @@ from firecrawl import Firecrawl
 firecrawl = Firecrawl(api_key="fc-YOUR-API-KEY")
 
 results = firecrawl.search(
-    query="What makes Firecrawl useful for AI agents?",
+    query="how does firecrawl handle javascript rendering",
     limit=5,
 )
 
@@ -40,7 +40,7 @@ import { Firecrawl } from 'firecrawl';
 const firecrawl = new Firecrawl({ apiKey: 'fc-YOUR-API-KEY' });
 
 const results = await firecrawl.search(
-  'What makes Firecrawl useful for AI agents?',
+  'how does firecrawl handle javascript rendering',
   {
     limit: 5,
   }
@@ -56,13 +56,13 @@ curl -X POST https://api.firecrawl.dev/v2/search \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "query": "What makes Firecrawl useful for AI agents?",
+    "query": "how does firecrawl handle javascript rendering",
     "limit": 5
   }'
 ```
 
 ```bash CLI
-firecrawl search "What makes Firecrawl useful for AI agents?" \
+firecrawl search "how does firecrawl handle javascript rendering" \
   --limit 5
 ```
 
@@ -74,7 +74,7 @@ The `firecrawl_search` MCP tool also returns highlights by default:
 
 ```json MCP
 {
-  "query": "What makes Firecrawl useful for AI agents?",
+  "query": "how does firecrawl handle javascript rendering",
   "limit": 5
 }
 ```

--- a/features/search-highlights.mdx
+++ b/features/search-highlights.mdx
@@ -1,22 +1,22 @@
 ---
 title: "Search Highlights"
-description: "Return query-relevant passages instead of generic search snippets"
+description: "Return query-relevant passages instead of plain website descriptions"
 og:title: "Search Highlights | Firecrawl"
 og:description: "Return query-relevant passages from search result pages"
 icon: "highlighter"
 ---
 
-Search Highlights replace generic search-provider descriptions with passages from each result page that are relevant to your query. They are enabled by default on `/v2/search` and do not require `scrapeOptions`.
+Search Highlights replace each result's plain website description with passages from the page that are relevant to your query. They are enabled by default on `/v2/search`; no additional parameter, output format, or `scrapeOptions` is required.
 
 Highlights preserve the search result's URL, title, position, and ranking. For web results, the highlighted text is returned in `description`; for news results, it is returned in `snippet`.
 
 <Note>
-  If Firecrawl cannot generate a highlight for a result, the original provider description or snippet is preserved. One unavailable page will not prevent the other search results from being returned.
+  If Firecrawl cannot generate a highlight for a result, the website's plain description or snippet is preserved. One unavailable page will not prevent the other search results from being returned.
 </Note>
 
-## Request highlights
+## Highlights are enabled by default
 
-Set `highlights` to `true` explicitly, or omit it to use the default behavior.
+Use Search normally and Firecrawl will return highlights when relevant page content is available.
 
 <CodeGroup>
 
@@ -28,7 +28,6 @@ firecrawl = Firecrawl(api_key="fc-YOUR-API-KEY")
 results = firecrawl.search(
     query="What makes Firecrawl useful for AI agents?",
     limit=5,
-    highlights=True,
 )
 
 for result in results.web or []:
@@ -44,7 +43,6 @@ const results = await firecrawl.search(
   'What makes Firecrawl useful for AI agents?',
   {
     limit: 5,
-    highlights: true,
   }
 );
 
@@ -59,28 +57,25 @@ curl -X POST https://api.firecrawl.dev/v2/search \
   -H "Content-Type: application/json" \
   -d '{
     "query": "What makes Firecrawl useful for AI agents?",
-    "limit": 5,
-    "highlights": true
+    "limit": 5
   }'
 ```
 
 ```bash CLI
 firecrawl search "What makes Firecrawl useful for AI agents?" \
-  --limit 5 \
-  --highlights
+  --limit 5
 ```
 
 </CodeGroup>
 
 ### MCP
 
-The `firecrawl_search` MCP tool exposes the same `highlights` parameter. It is enabled by default, or you can set it explicitly in the tool arguments:
+The `firecrawl_search` MCP tool also returns highlights by default:
 
 ```json MCP
 {
   "query": "What makes Firecrawl useful for AI agents?",
-  "limit": 5,
-  "highlights": true
+  "limit": 5
 }
 ```
 
@@ -108,7 +103,7 @@ Highlights may contain Markdown when the relevant page content includes headings
 
 ## Disable highlights
 
-Set `highlights` to `false` when you need the original search-provider descriptions or snippets.
+Set `highlights` to `false` when you want each website's plain description or snippet instead.
 
 <CodeGroup>
 
@@ -147,6 +142,6 @@ firecrawl search "Firecrawl search API" --no-highlights
 - **News:** Replaces `snippet` with query-relevant page content when available.
 - **Images:** Image results are returned unchanged.
 - **Search with scraping:** Highlights affect the search description or snippet. Content requested through `scrapeOptions` is returned separately and is not replaced.
-- **Zero Data Retention:** ZDR searches retain the original provider descriptions and snippets.
+- **Zero Data Retention:** ZDR searches retain the websites' plain descriptions and snippets.
 
 For every Search parameter and the complete response schema, see the [Search API reference](/api-reference/endpoint/search).

--- a/features/search-highlights.mdx
+++ b/features/search-highlights.mdx
@@ -89,9 +89,9 @@ Highlights use the existing description fields, so the response shape stays the 
   "data": {
     "web": [
       {
-        "url": "https://www.firecrawl.dev/",
-        "title": "Firecrawl - The context API",
-        "description": "Firecrawl gives AI agents clean web data through search, scraping, and structured extraction.",
+        "url": "https://www.firecrawl.dev/blog/javascript-web-scraping",
+        "title": "Web Scraping With JavaScript: Step-by-Step Guide",
+        "description": "# Web Scraping With JavaScript: Step-by-Step Guide\n## When should you use scraping APIs instead of DIY tools?\n### Setting up Firecrawl\n```\nnpm install firecrawl\n```\n\n```\nFIRECRAWL_API_KEY=fc-your-api-key-here\n```\n\n### Solving the JavaScript quotes problem\nYou describe what you want, and Firecrawl handles extraction and validation.",
         "position": 1
       }
     ]

--- a/features/search.mdx
+++ b/features/search.mdx
@@ -31,6 +31,8 @@ import SearchFeedbackCTA from "/snippets/research-feedback-cta.mdx";
 
 Search the web and get clean, structured content from every result in a single API call. Pass a query to `/search` and Firecrawl returns titles, descriptions, and URLs. Add `scrapeOptions` to also retrieve full-page markdown, HTML, links, or screenshots for each result.
 
+Search results include query-relevant [Highlights](/features/search-highlights) by default. Set `highlights` to `false` when you need the original search-provider descriptions or snippets.
+
 For the full parameter list, see the [Search Endpoint API Reference](https://docs.firecrawl.dev/api-reference/endpoint/search).
 
 <SearchFeedbackCTA src="docs-search" />

--- a/features/search.mdx
+++ b/features/search.mdx
@@ -31,7 +31,7 @@ import SearchFeedbackCTA from "/snippets/research-feedback-cta.mdx";
 
 Search the web and get clean, structured content from every result in a single API call. Pass a query to `/search` and Firecrawl returns titles, descriptions, and URLs. Add `scrapeOptions` to also retrieve full-page markdown, HTML, links, or screenshots for each result.
 
-Search results include query-relevant [Highlights](/features/search-highlights) by default. Set `highlights` to `false` when you need the original search-provider descriptions or snippets.
+Search results include query-relevant [Highlights](/features/search-highlights) by default. Set `highlights` to `false` when you want each website's plain description or snippet instead.
 
 For the full parameter list, see the [Search Endpoint API Reference](https://docs.firecrawl.dev/api-reference/endpoint/search).
 


### PR DESCRIPTION
## What changed

- adds an English Search Highlights feature page with API, Python, JavaScript, CLI, and MCP examples
- documents the response fields, per-result fallback behavior, opt-out behavior, supported result types, scraping interaction, and ZDR behavior
- adds Highlights directly below Search in the sidebar
- links the main Search guide to the new page

## Why

Highlights are now the default Search result experience, but the behavior and opt-out path need a dedicated guide beyond the OpenAPI field description.

## Validation

- `jq empty docs.json`
- `git diff --check`
- `mint validate` parsed the site and reported only the repository's 17 existing missing-import warnings; the new page introduced no validation warning
