### PR TITLE
docs(mcp): stage OAuth-only search setup

### DIFF
--- a/mcp-server/search-only.mdx
+++ b/mcp-server/search-only.mdx
@@ -12,20 +12,26 @@ The [Firecrawl MCP Server](/mcp-server) at `https://mcp.firecrawl.dev/v2/mcp` is
 https://mcp.firecrawl.dev/v2/mcp-search
 ```
 
-Every request requires authentication: connect with OAuth using the endpoint directly, or pass a Firecrawl API key in the `Authorization` header.
+Every request requires a Firecrawl OAuth connection. Add the endpoint directly
+to an OAuth-capable MCP client, then complete the browser sign-in and consent
+flow when the client prompts you. API keys and legacy key-in-path URLs are not
+accepted on this endpoint.
 
 ```json
 {
   "mcpServers": {
     "firecrawl-search": {
-      "url": "https://mcp.firecrawl.dev/v2/mcp-search",
-      "headers": {
-        "Authorization": "Bearer fc-YOUR_API_KEY"
-      }
+      "url": "https://mcp.firecrawl.dev/v2/mcp-search"
     }
   }
 }
 ```
+
+The endpoint advertises its protected-resource metadata and opens the
+authorization flow automatically. Keep the endpoint URL unchanged; do not add
+a raw Firecrawl API key as a header or in the path.
+
+To disconnect a client later, open **MCP** in [Firecrawl Settings](https://www.firecrawl.dev/app/settings?tab=mcp) and revoke its connection.
 
 ## Available tools
 


### PR DESCRIPTION
## Summary
- prepare the hidden search-only MCP page for the OAuth-only endpoint
- remove raw API-key and key-in-path guidance
- retain `hidden: true`; do not publish or merge until the isolated-profile private/public canary passes

## Validation
- reviewed the six-tool contract against MCP draft #332
- `git diff --check`

Depends on DB #242, Web #2944, MCP #332, and Infra #354.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-docs/pr/1157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787589352&installation_model_id=11126&pr_number=1157&repository=firecrawl%2Ffirecrawl-docs&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-docs%2Fpull%2F1157&signature=36450e3e73b203ccfb54526f6de0862c76bdb8e2b316917fc05b8b67f4743507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->