### PR TITLE
docs(mcp): stage bounded selector contract

### DIFF
--- a/.github/scripts/check-selector-doc-contract.mjs
+++ b/.github/scripts/check-selector-doc-contract.mjs
@@ -3,26 +3,24 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 const docsRoot = fileURLToPath(new URL('../..', import.meta.url));
-const page = readFileSync(`${docsRoot}/mcp-server.mdx`, 'utf8');
+const page = readFileSync(`${docsRoot}/mcp-tool-selectors.mdx`, 'utf8');
 
+assert.match(page, /hidden: true/);
 assert.match(page, /not available in the public service yet/i);
-assert.match(page, /AX no-drop evaluation/);
-assert.match(page, /owner approval/);
 
 assert.match(page, /https:\/\/mcp\.firecrawl\.dev\/v2\/mcp\?tools=<selector>/);
 assert.match(page, /`@core-v1` is exactly `firecrawl_search`, `firecrawl_scrape`, and `firecrawl_parse`/);
-assert.match(page, /selector-safe instructions/);
-assert.match(page, /do not direct calls to an omitted feedback, crawl, or extraction tool/);
+assert.match(page, /Server instructions are static and selector-agnostic/);
 
-assert.match(page, /ordinary default session with no selector-based filtering/);
-assert.match(page, /limited to selector behavior and the endpoint's ordinary tool set/);
-assert.match(page, /not a claim that every MCP metadata field is byte-identical/);
-assert.match(page, /`anthropic\/alwaysLoad` metadata changes.*AX no-drop gate/s);
+assert.match(page, /ordinary default session without selector filtering/);
+assert.match(page, /raw comma-separated list before deduplicating entries/);
+assert.match(page, /Whitespace is not trimmed/);
+assert.match(page, /normal MCP tool result \(HTTP 200\)/);
 
 assert.match(page, /`\/v2\/mcp-oauth`/);
 assert.match(page, /`\/v2\/mcp-search`/);
 assert.match(page, /`TOOL_SELECTOR_UNSUPPORTED` \(HTTP 400\)/);
-assert.doesNotMatch(page, /Selectors will be inert/i);
-assert.doesNotMatch(page, /will not narrow or widen their tool lists/i);
+assert.doesNotMatch(page, /AX no-drop evaluation/i);
+assert.doesNotMatch(page, /owner approval/i);
 
 console.log('selector documentation contract: ok');

--- a/.github/scripts/check-selector-doc-contract.mjs
+++ b/.github/scripts/check-selector-doc-contract.mjs
@@ -10,7 +10,7 @@ assert.doesNotMatch(page, /not available in the public service yet/i);
 assert.match(page, /request-scoped tool selection for hosted Firecrawl MCP/i);
 
 assert.match(page, /https:\/\/mcp\.firecrawl\.dev\/v2\/mcp\?tools=<selector>/);
-assert.match(page, /`@core-v1` is exactly `firecrawl_search`, `firecrawl_scrape`, and `firecrawl_parse`/);
+assert.match(page, /`@core-v1` is exactly `firecrawl_search`, `firecrawl_scrape`, and `firecrawl_map`/);
 assert.match(page, /Server instructions are static and selector-agnostic/);
 
 assert.match(page, /ordinary default session without selector filtering/);

--- a/.github/scripts/check-selector-doc-contract.mjs
+++ b/.github/scripts/check-selector-doc-contract.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const docsRoot = fileURLToPath(new URL('../..', import.meta.url));
+const page = readFileSync(`${docsRoot}/mcp-server.mdx`, 'utf8');
+
+assert.match(page, /not available in the public service yet/i);
+assert.match(page, /AX no-drop evaluation/);
+assert.match(page, /owner approval/);
+
+assert.match(page, /https:\/\/mcp\.firecrawl\.dev\/v2\/mcp\?tools=<selector>/);
+assert.match(page, /`@core-v1` is exactly `firecrawl_search`, `firecrawl_scrape`, and `firecrawl_parse`/);
+assert.match(page, /selector-safe instructions/);
+assert.match(page, /do not direct calls to an omitted feedback, crawl, or extraction tool/);
+
+assert.match(page, /ordinary default session with no selector-based filtering/);
+assert.match(page, /limited to selector behavior and the endpoint's ordinary tool set/);
+assert.match(page, /not a claim that every MCP metadata field is byte-identical/);
+assert.match(page, /`anthropic\/alwaysLoad` metadata changes.*AX no-drop gate/s);
+
+assert.match(page, /`\/v2\/mcp-oauth`/);
+assert.match(page, /`\/v2\/mcp-search`/);
+assert.match(page, /`TOOL_SELECTOR_UNSUPPORTED` \(HTTP 400\)/);
+assert.doesNotMatch(page, /Selectors will be inert/i);
+assert.doesNotMatch(page, /will not narrow or widen their tool lists/i);
+
+console.log('selector documentation contract: ok');

--- a/.github/scripts/check-selector-doc-contract.mjs
+++ b/.github/scripts/check-selector-doc-contract.mjs
@@ -6,7 +6,8 @@ const docsRoot = fileURLToPath(new URL('../..', import.meta.url));
 const page = readFileSync(`${docsRoot}/mcp-tool-selectors.mdx`, 'utf8');
 
 assert.match(page, /hidden: true/);
-assert.match(page, /not available in the public service yet/i);
+assert.doesNotMatch(page, /not available in the public service yet/i);
+assert.match(page, /request-scoped tool selection for hosted Firecrawl MCP/i);
 
 assert.match(page, /https:\/\/mcp\.firecrawl\.dev\/v2\/mcp\?tools=<selector>/);
 assert.match(page, /`@core-v1` is exactly `firecrawl_search`, `firecrawl_scrape`, and `firecrawl_parse`/);

--- a/mcp-server.mdx
+++ b/mcp-server.mdx
@@ -49,46 +49,6 @@ With an API key, send it as an `Authorization` header to unlock every tool plus 
 }
 ```
 
-### Planned: reduce hosted MCP tool context
-
-<Warning>
-This is the staged selector contract for a future hosted MCP release. It is **not available in the public service yet**. Do not configure it until the MCP selector runtime has passed its AX no-drop evaluation, been deployed, and received owner approval. This draft documentation remains held until then.
-</Warning>
-
-Some clients load every advertised MCP tool into model context. The planned primary hosted endpoint (`/v2/mcp`) will accept one optional `tools` query parameter to request a smaller tool subset:
-
-```text
-https://mcp.firecrawl.dev/v2/mcp?tools=<selector>[,<selector>...]
-```
-
-Selectors are comma-separated and must be a single `tools` parameter. The contract will reject blank, repeated `tools` parameters, unknown, or oversized selector lists with `INVALID_TOOL_SELECTOR` (HTTP 400). Duplicate selector values within that one parameter are deduplicated and accepted. A list is limited to 64 selectors and 1024 UTF-8 bytes.
-
-#### Planned presets and examples
-
-```text
-# Search, Scrape, and Parse
-https://mcp.firecrawl.dev/v2/mcp?tools=@core-v1
-
-# The immutable, versioned current full hosted-tool set
-https://mcp.firecrawl.dev/v2/mcp?tools=@full-v1
-
-# One registered tool
-https://mcp.firecrawl.dev/v2/mcp?tools=firecrawl_search
-```
-
-- `@core-v1` is exactly `firecrawl_search`, `firecrawl_scrape`, and `firecrawl_parse`.
-- `@full-v1` is the versioned current full hosted-tool set. It does not add capability beyond the authenticated default; it makes that requested set explicit and intentionally excludes future tool registrations unless a future preset version names them.
-- A selector can only remove tools. Firecrawl intersects it with the profile's actual registrations and the caller's credentials, so it can never elevate a keyless or otherwise restricted connection.
-- A keyless request that asks for tools it is not entitled to, such as `@full-v1`, will receive `TOOL_SELECTOR_NOT_ENTITLED` (HTTP 403).
-- Calling a tool that was omitted from a selected subset will return `TOOL_NOT_SELECTED`; Firecrawl will not begin the backend action for that call.
-- An `@core-v1` connection receives selector-safe instructions: they describe only the selected Search, Scrape, and Parse workflow and do not direct calls to an omitted feedback, crawl, or extraction tool.
-
-#### Planned connection behavior
-
-The hosted transport is stateless. A selector is request-scoped rather than stored on the server: clients must retain `?tools=...` on every request, including after a reconnect. Omitting it creates a fresh ordinary default session with no selector-based filtering. This compatibility statement is limited to selector behavior and the endpoint's ordinary tool set; it is not a claim that every MCP metadata field is byte-identical across the release. The accompanying tool-description and `anthropic/alwaysLoad` metadata changes are intentionally evaluated separately by the AX no-drop gate.
-
-Selectors are supported only by the planned primary full endpoint, `/v2/mcp`. Appending `?tools=` to either the account endpoint (`/v2/mcp-oauth`) or the fixed search surface (`/v2/mcp-search`) will return `TOOL_SELECTOR_UNSUPPORTED` (HTTP 400); those endpoints never silently ignore selector input. The search profile remains its fixed six-tool surface.
-
 ### Running with npx
 
 ```bash

--- a/mcp-server.mdx
+++ b/mcp-server.mdx
@@ -49,6 +49,46 @@ With an API key, send it as an `Authorization` header to unlock every tool plus 
 }
 ```
 
+### Planned: reduce hosted MCP tool context
+
+<Warning>
+This is the staged selector contract for a future hosted MCP release. It is **not available in the public service yet**. Do not configure it until the MCP selector runtime has passed its AX no-drop evaluation, been deployed, and received owner approval. This draft documentation remains held until then.
+</Warning>
+
+Some clients load every advertised MCP tool into model context. The planned primary hosted endpoint (`/v2/mcp`) will accept one optional `tools` query parameter to request a smaller tool subset:
+
+```text
+https://mcp.firecrawl.dev/v2/mcp?tools=<selector>[,<selector>...]
+```
+
+Selectors are comma-separated and must be a single `tools` parameter. The contract will reject blank, repeated `tools` parameters, unknown, or oversized selector lists with `INVALID_TOOL_SELECTOR` (HTTP 400). Duplicate selector values within that one parameter are deduplicated and accepted. A list is limited to 64 selectors and 1024 UTF-8 bytes.
+
+#### Planned presets and examples
+
+```text
+# Search, Scrape, and Parse
+https://mcp.firecrawl.dev/v2/mcp?tools=@core-v1
+
+# The immutable, versioned current full hosted-tool set
+https://mcp.firecrawl.dev/v2/mcp?tools=@full-v1
+
+# One registered tool
+https://mcp.firecrawl.dev/v2/mcp?tools=firecrawl_search
+```
+
+- `@core-v1` is exactly `firecrawl_search`, `firecrawl_scrape`, and `firecrawl_parse`.
+- `@full-v1` is the versioned current full hosted-tool set. It does not add capability beyond the authenticated default; it makes that requested set explicit and intentionally excludes future tool registrations unless a future preset version names them.
+- A selector can only remove tools. Firecrawl intersects it with the profile's actual registrations and the caller's credentials, so it can never elevate a keyless or otherwise restricted connection.
+- A keyless request that asks for tools it is not entitled to, such as `@full-v1`, will receive `TOOL_SELECTOR_NOT_ENTITLED` (HTTP 403).
+- Calling a tool that was omitted from a selected subset will return `TOOL_NOT_SELECTED`; Firecrawl will not begin the backend action for that call.
+- An `@core-v1` connection receives selector-safe instructions: they describe only the selected Search, Scrape, and Parse workflow and do not direct calls to an omitted feedback, crawl, or extraction tool.
+
+#### Planned connection behavior
+
+The hosted transport is stateless. A selector is request-scoped rather than stored on the server: clients must retain `?tools=...` on every request, including after a reconnect. Omitting it creates a fresh ordinary default session with no selector-based filtering. This compatibility statement is limited to selector behavior and the endpoint's ordinary tool set; it is not a claim that every MCP metadata field is byte-identical across the release. The accompanying tool-description and `anthropic/alwaysLoad` metadata changes are intentionally evaluated separately by the AX no-drop gate.
+
+Selectors are supported only by the planned primary full endpoint, `/v2/mcp`. Appending `?tools=` to either the account endpoint (`/v2/mcp-oauth`) or the fixed search surface (`/v2/mcp-search`) will return `TOOL_SELECTOR_UNSUPPORTED` (HTTP 400); those endpoints never silently ignore selector input. The search profile remains its fixed six-tool surface.
+
 ### Running with npx
 
 ```bash

--- a/mcp-tool-selectors.mdx
+++ b/mcp-tool-selectors.mdx
@@ -21,7 +21,7 @@ Use exactly one comma-separated `tools` parameter. The contract rejects blank, r
 ## Planned presets and examples
 
 ```text
-# Search, Scrape, and Parse
+# Search, Scrape, and Map
 https://mcp.firecrawl.dev/v2/mcp?tools=@core-v1
 
 # The immutable, versioned current full hosted-tool set
@@ -31,7 +31,7 @@ https://mcp.firecrawl.dev/v2/mcp?tools=@full-v1
 https://mcp.firecrawl.dev/v2/mcp?tools=firecrawl_search
 ```
 
-- `@core-v1` is exactly `firecrawl_search`, `firecrawl_scrape`, and `firecrawl_parse`.
+- `@core-v1` is exactly `firecrawl_search`, `firecrawl_scrape`, and `firecrawl_map`.
 - `@full-v1` is the versioned current full hosted-tool set. It does not add capability beyond the authenticated default; it makes that requested set explicit and excludes future tool registrations unless a future preset version names them.
 - A selector can only remove tools. Firecrawl intersects it with the profile's actual registrations and the caller's credentials, so it cannot elevate a keyless or otherwise restricted connection.
 - A keyless request that asks for tools it is not entitled to, such as `@full-v1`, receives `TOOL_SELECTOR_NOT_ENTITLED` (HTTP 403).

--- a/mcp-tool-selectors.mdx
+++ b/mcp-tool-selectors.mdx
@@ -4,9 +4,9 @@ description: "Preview the planned request-scoped tool selector contract for host
 hidden: true
 ---
 
-<Warning>
-This hosted MCP selector contract is not available in the public service yet.
-</Warning>
+<Note>
+This preview describes request-scoped tool selection for hosted Firecrawl MCP.
+</Note>
 
 Some clients load every advertised MCP tool into model context. The planned primary hosted endpoint (`/v2/mcp`) will accept one optional `tools` query parameter to request a smaller tool subset:
 

--- a/mcp-tool-selectors.mdx
+++ b/mcp-tool-selectors.mdx
@@ -1,0 +1,41 @@
+---
+title: Hosted MCP tool selectors (preview)
+description: "Preview the planned request-scoped tool selector contract for hosted Firecrawl MCP"
+hidden: true
+---
+
+<Warning>
+This hosted MCP selector contract is not available in the public service yet.
+</Warning>
+
+Some clients load every advertised MCP tool into model context. The planned primary hosted endpoint (`/v2/mcp`) will accept one optional `tools` query parameter to request a smaller tool subset:
+
+```text
+https://mcp.firecrawl.dev/v2/mcp?tools=<selector>[,<selector>...]
+```
+
+Selectors are supported only by the planned cloud-hosted primary endpoint. They are request-scoped: clients must retain `?tools=...` on every request, including after reconnecting. Omitting it creates an ordinary default session without selector filtering.
+
+Use exactly one comma-separated `tools` parameter. The contract rejects blank, repeated, unknown, or oversized selector lists with `INVALID_TOOL_SELECTOR` (HTTP 400). It applies the 64-entry and 1024-byte limits to the raw comma-separated list before deduplicating entries. Whitespace is not trimmed.
+
+## Planned presets and examples
+
+```text
+# Search, Scrape, and Parse
+https://mcp.firecrawl.dev/v2/mcp?tools=@core-v1
+
+# The immutable, versioned current full hosted-tool set
+https://mcp.firecrawl.dev/v2/mcp?tools=@full-v1
+
+# One registered tool
+https://mcp.firecrawl.dev/v2/mcp?tools=firecrawl_search
+```
+
+- `@core-v1` is exactly `firecrawl_search`, `firecrawl_scrape`, and `firecrawl_parse`.
+- `@full-v1` is the versioned current full hosted-tool set. It does not add capability beyond the authenticated default; it makes that requested set explicit and excludes future tool registrations unless a future preset version names them.
+- A selector can only remove tools. Firecrawl intersects it with the profile's actual registrations and the caller's credentials, so it cannot elevate a keyless or otherwise restricted connection.
+- A keyless request that asks for tools it is not entitled to, such as `@full-v1`, receives `TOOL_SELECTOR_NOT_ENTITLED` (HTTP 403).
+- Calling a tool omitted from a selected subset returns `TOOL_NOT_SELECTED` as a normal MCP tool result (HTTP 200); Firecrawl does not begin the backend action.
+- Server instructions are static and selector-agnostic. Use `tools/list` to discover the exact selected tools for the current session.
+
+Appending `?tools=` to either the account endpoint (`/v2/mcp-oauth`) or the fixed search surface (`/v2/mcp-search`) will return `TOOL_SELECTOR_UNSUPPORTED` (HTTP 400). The search profile remains its fixed six-tool surface.


### PR DESCRIPTION
## Scope

Documents the **planned** bounded selector contract from MCP PR #337 (`9a53c34921417650610d8e64020d3dc2adb22353`) without changing any currently published runtime claim.

- grammar: one comma-separated `?tools=` parameter, limits, and errors
- immutable `@core-v1` and `@full-v1` behavior
- intersection-only/no-elevation guarantee
- request-scoped, stateless reconnect/default behavior
- account and fixed-profile selector inertness, without publishing a search endpoint URL or setup guide

## Explicit release hold

**Draft only — do not merge or publish yet.** This documentation must remain held until all of the following are complete:

1. MCP #337’s exact candidate passes the required AX no-drop/matrix evaluation.
2. The selected MCP contract is reviewed and deployed.
3. The deployed profile has passed its runtime and backward-compatibility verification.
4. Owner review approves removing or updating the temporary availability warning.

This PR does not enable selectors, change MCP configuration, or expose the Stage-2 search connection flow.

## Validation

- `git diff --check origin/main...HEAD`
- `docs.json` JSON parse
- static contract assertions for all documented selector grammar, errors, stateless/reconnect behavior, and inert surfaces
- checked that no `/v2/mcp-search` URL or account-selector setup URL was introduced

## Source of truth

MCP #337 head `9a53c34921417650610d8e64020d3dc2adb22353` only. Older docs PR #1137 was used only as prose inspiration and is not a dependency.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-docs/pr/1159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787698764&installation_model_id=11126&pr_number=1159&repository=firecrawl%2Ffirecrawl-docs&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-docs%2Fpull%2F1159&signature=71d79887c615b219f878bdda1b69e0d240239c9fec2d51a5ac892114484b8aab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->