### PR TITLE
docs(openapi): document audit metadata username

### DIFF
--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -2208,6 +2208,9 @@
                       }
                     }
                   },
+                  "auditMetadata": {
+                    "$ref": "#/components/schemas/AuditMetadata"
+                  },
                   "threatProtection": {
                     "$ref": "#/components/schemas/ThreatProtectionOverride"
                   }
@@ -2512,6 +2515,9 @@
                     ],
                     "default": "spark-1-mini",
                     "description": "The model to use for the agent task. spark-1-mini (default) is 60% cheaper, spark-1-pro offers higher accuracy for complex tasks"
+                  },
+                  "auditMetadata": {
+                    "$ref": "#/components/schemas/AuditMetadata"
                   },
                   "threatProtection": {
                     "$ref": "#/components/schemas/ThreatProtectionOverride"
@@ -5529,6 +5535,21 @@
       }
     },
     "schemas": {
+      "AuditMetadata": {
+        "type": "object",
+        "description": "User attribution included with SIEM logging events when SIEM Logging is enabled for the organization.",
+        "additionalProperties": false,
+        "required": [
+          "username"
+        ],
+        "properties": {
+          "username": {
+            "type": "string",
+            "maxLength": 1024,
+            "description": "The username associated with the request."
+          }
+        }
+      },
       "SuccessResponse": {
         "type": "object",
         "properties": {
@@ -6844,6 +6865,9 @@
             "nullable": true,
             "description": "Optional integration identifier."
           },
+          "auditMetadata": {
+            "$ref": "#/components/schemas/AuditMetadata"
+          },
           "zeroDataRetention": {
             "type": "boolean",
             "default": false,
@@ -7327,6 +7351,9 @@
           },
           "threatProtection": {
             "$ref": "#/components/schemas/ThreatProtectionOverride"
+          },
+          "auditMetadata": {
+            "$ref": "#/components/schemas/AuditMetadata"
           }
         }
       },


### PR DESCRIPTION
## Summary

- add `auditMetadata` to the English v2 OpenAPI definition
- define the request shape as exactly one required `username` string
- leave translated OpenAPI definitions unchanged

## Validation

- JSON parse validation
- component reference count validation
- confirmed the diff only changes `api-reference/v2-openapi.json`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-docs/pr/1162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787762421&installation_model_id=11126&pr_number=1162&repository=firecrawl%2Ffirecrawl-docs&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-docs%2Fpull%2F1162&signature=7c853d68f9e38677d8c6c52ac1abbda73fbaf7ca1260ca4bb6b41922a34edc80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->