### PR TITLE
docs: SIEM audit logging page + Zscaler mode in threat protection

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -150,7 +150,8 @@
                           "enterprise",
                           "features/ip-restrictions",
                           "features/key-restrictions",
-                          "features/threat-protection"
+                          "features/threat-protection",
+                          "features/siem"
                         ]
                       }
                     ]
@@ -724,7 +725,8 @@
                           "enterprise",
                           "features/ip-restrictions",
                           "features/key-restrictions",
-                          "features/threat-protection"
+                          "features/threat-protection",
+                          "features/siem"
                         ]
                       }
                     ]

--- a/features/siem.mdx
+++ b/features/siem.mdx
@@ -21,39 +21,17 @@ If you need a different destination, talk to your account team.
 
 ## What gets logged
 
-One `scrape_activity` event per scraped URL:
+One event per URL Firecrawl fetches on your behalf. The Data Collection Rule you create during setup maps events into your workspace normalized to the [ASIM web session schema](https://learn.microsoft.com/en-us/azure/sentinel/normalization-schema-web), so your existing Sentinel content — analytics rules, hunting queries, workbooks — works against the rows without Firecrawl-specific parsing.
 
-```json
-{
-  "schema_version": 1,
-  "event_type": "scrape_activity",
-  "scrape_id": "0195c7a1-...",
-  "request_id": "0195c7a1-...",
-  "endpoint": "crawl",
-  "team_id": "...",
-  "org_id": "...",
-  "api_key": { "id": "1234", "name": "production" },
-  "started_at": "2026-07-28T12:00:00.000Z",
-  "completed_at": "2026-07-28T12:00:03.412Z",
-  "url": "https://example.com/pricing",
-  "domain": "example.com",
-  "http_method": "GET",
-  "http_status": 200,
-  "result": "success",
-  "error": null,
-  "origin": "api",
-  "integration": null,
-  "zero_data_retention": false
-}
-```
+Each row captures:
 
-- **`endpoint`** identifies the workflow that caused the fetch: `scrape`, `crawl`, `batch_scrape`, `search`, `extract`, `agent`, or `parse`.
-- **`result`** is `success`, `failure`, `blocked`, or `cancelled`. Blocked means a security policy refused the fetch before or during the request.
-- **`request_id`** groups the events of one API request (for example, every page of one crawl), so you can reconstruct whole jobs.
-- **`api_key`** carries the key's ID and display name, so events are attributable to the credential that triggered them.
-- **`audit_metadata`** (optional) echoes metadata your systems attach to requests, so you can correlate events with your own ticket or session identifiers.
+- **The fetch** — the target URL and domain, HTTP status, and start/end times.
+- **The outcome** — success, failure, blocked (a security policy refused the fetch), or cancelled. `EventSeverity` distinguishes a provider-confirmed threat from a fetch blocked by one of your own policy rules.
+- **Attribution** — the API key (ID and display name) that triggered the fetch, and the workflow it came from: scrape, crawl, batch scrape, search, extract, agent, or parse.
+- **Job grouping** — a request identifier shared by every fetch of one API request, so a whole crawl reconstructs as one job in your queries.
+- **Your correlation IDs** — metadata your systems attach to requests is echoed on the row, so events line up with your own ticket or session identifiers.
 
-When [Threat Protection](/features/threat-protection) is active, events carry a `threat` object describing the decision: the rule that decided (`blacklist`, `risk-score`, `denied-category`, ...), the classifier that was consulted, the threat categories involved, and — for Zscaler-classified URLs — a `security_alert` flag. Only these normalized fields are exported; raw classifier responses never leave Firecrawl.
+When [Threat Protection](/features/threat-protection) is active, rows also carry the decision context: the rule that decided, the classifier consulted, the threat categories involved, and — for Zscaler-classified URLs — a security-alert flag. Only these normalized fields are exported; raw classifier responses never leave Firecrawl.
 
 ## Setting it up
 
@@ -62,7 +40,7 @@ You will create an Entra application, a DCE, a DCR with a custom table, and then
 In short:
 
 1. **Create an Entra application** with a client secret. Firecrawl authenticates with these credentials; grant the app only the **Monitoring Metrics Publisher** role on the DCR.
-2. **Create a DCE and a DCR** with a custom table for the events, and note the DCE ingestion URL, the DCR immutable ID, and the stream name.
+2. **Create a DCE and a DCR** with a custom table for the events — the dashboard provides the table schema and the transform that normalizes events to ASIM. Note the DCE ingestion URL, the DCR immutable ID, and the stream name.
 3. **Enter the details in the dashboard**: tenant ID, client ID, client secret, DCE URL, DCR immutable ID, and stream name.
 4. **Save.** Firecrawl verifies the destination by delivering a test event and only enables streaming once the destination accepts it. You can send another test event at any time.
 

--- a/features/siem.mdx
+++ b/features/siem.mdx
@@ -1,0 +1,90 @@
+---
+title: "SIEM Audit Logging"
+description: "Stream a structured audit event for every scrape your team runs to your own SIEM, starting with Microsoft Sentinel. Delivered server-side."
+og:title: "SIEM Audit Logging | Firecrawl"
+og:description: "Stream a structured audit event for every scrape your team runs to your own SIEM, starting with Microsoft Sentinel. Delivered server-side."
+---
+
+SIEM Audit Logging streams a structured activity event to your organization's SIEM for every scrape Firecrawl performs on your behalf — whether it came from a direct scrape call, a crawl, a batch scrape, a search, an extract, or an agent run. Your security team gets a complete, queryable audit trail of what was fetched, by which API key, and with what outcome, inside the tooling they already use.
+
+Delivery is server-side and out-of-band: events are batched and pushed from Firecrawl's infrastructure, so nothing changes about your API requests and a slow or unavailable destination never delays a scrape.
+
+<Note>
+SIEM Audit Logging is an enterprise feature and is gated per organization. Contact your Firecrawl account team to have it enabled for your account.
+</Note>
+
+## Supported destinations
+
+The first supported destination is **Microsoft Sentinel** (Azure Monitor Logs). Events are delivered through the [Logs Ingestion API](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/logs-ingestion-api-overview): a Data Collection Endpoint (DCE) plus a Data Collection Rule (DCR) that maps the events into your Log Analytics workspace, authenticated with a Microsoft Entra application using client credentials.
+
+If you need a different destination, talk to your account team.
+
+## What gets logged
+
+One `scrape_activity` event per scraped URL:
+
+```json
+{
+  "schema_version": 1,
+  "event_type": "scrape_activity",
+  "scrape_id": "0195c7a1-...",
+  "request_id": "0195c7a1-...",
+  "endpoint": "crawl",
+  "team_id": "...",
+  "org_id": "...",
+  "api_key": { "id": "1234", "name": "production" },
+  "started_at": "2026-07-28T12:00:00.000Z",
+  "completed_at": "2026-07-28T12:00:03.412Z",
+  "url": "https://example.com/pricing",
+  "domain": "example.com",
+  "http_method": "GET",
+  "http_status": 200,
+  "result": "success",
+  "error": null,
+  "origin": "api",
+  "integration": null,
+  "zero_data_retention": false
+}
+```
+
+- **`endpoint`** identifies the workflow that caused the fetch: `scrape`, `crawl`, `batch_scrape`, `search`, `extract`, `agent`, or `parse`.
+- **`result`** is `success`, `failure`, `blocked`, or `cancelled`. Blocked means a security policy refused the fetch before or during the request.
+- **`request_id`** groups the events of one API request (for example, every page of one crawl), so you can reconstruct whole jobs.
+- **`api_key`** carries the key's ID and display name, so events are attributable to the credential that triggered them.
+- **`audit_metadata`** (optional) echoes metadata your systems attach to requests, so you can correlate events with your own ticket or session identifiers.
+
+When [Threat Protection](/features/threat-protection) is active, events carry a `threat` object describing the decision: the rule that decided (`blacklist`, `risk-score`, `denied-category`, ...), the classifier that was consulted, the threat categories involved, and — for Zscaler-classified URLs — a `security_alert` flag. Only these normalized fields are exported; raw classifier responses never leave Firecrawl.
+
+## Setting it up
+
+You will create an Entra application, a DCE, a DCR with a custom table, and then connect Firecrawl to them. Team admins configure the connection from [Enterprise Controls → SIEM](https://www.firecrawl.dev/app/enterprise-controls?tab=siem-logging) in the dashboard — the page walks through each Azure step with copyable commands.
+
+In short:
+
+1. **Create an Entra application** with a client secret. Firecrawl authenticates with these credentials; grant the app only the **Monitoring Metrics Publisher** role on the DCR.
+2. **Create a DCE and a DCR** with a custom table for the events, and note the DCE ingestion URL, the DCR immutable ID, and the stream name.
+3. **Enter the details in the dashboard**: tenant ID, client ID, client secret, DCE URL, DCR immutable ID, and stream name.
+4. **Save.** Firecrawl verifies the destination by delivering a test event and only enables streaming once the destination accepts it. You can send another test event at any time.
+
+The client secret is write-only: it is encrypted at rest, never shown again, and can be replaced at any time by entering a new one. Leaving the secret field blank on later saves keeps the stored secret.
+
+## Delivery semantics
+
+- **Batched per organization** — events are grouped and delivered in batches, typically within a few seconds of the scrape finishing.
+- **Retries with backoff** — transient destination failures are retried on a delay ladder. A destination outage does not lose the audit trail immediately, and delivery resumes when the destination recovers.
+- **Never in the request path** — delivery problems never slow down or fail your API requests. If the destination stays unavailable past the retry budget, affected events are dropped rather than blocking scrapes; delivery health is visible in the dashboard.
+- **Static egress** — delivery traffic originates from a dedicated static IP, so you can allowlist Firecrawl on network controls in front of your collection endpoint. Ask your account team for the address.
+
+## Error reference
+
+| Status | When |
+| --- | --- |
+| `403` | The SIEM configuration API is used on a team without the feature enabled. |
+| `400` | The configuration is saved without a client secret when none is stored yet. |
+| `200` with `delivered: false` | A test event was attempted and the destination rejected it; the response includes the destination's error. |
+
+## Notes
+
+- SIEM Audit Logging adds no credit charges.
+- Events describe request metadata and outcomes — scraped page *content* is never sent to your SIEM.
+- Teams with [Zero Data Retention](/features/scrape#zero-data-retention-zdr) can use SIEM Audit Logging; events are flagged with `zero_data_retention: true`.

--- a/features/threat-protection.mdx
+++ b/features/threat-protection.mdx
@@ -54,7 +54,7 @@ Classification traffic to your tenant originates from a dedicated static IP for 
 
 ### Capacity and behavior
 
-ZIA's URL Lookup API allows 1 request per second and 400 requests per hour per tenant. Firecrawl batches lookups (up to 100 URLs per request) and enforces these limits tenant-wide, which gives a sustained classification ceiling of roughly 11 URLs per second. To keep demand near that budget, Zscaler mode also caps your organization's scrape concurrency. If the hourly budget is exhausted, affected requests resolve through your failure policy immediately instead of queueing indefinitely.
+ZIA's URL Lookup API allows 1 request per second and 400 requests per hour per tenant. Firecrawl batches lookups (up to 100 URLs per request) and enforces these limits tenant-wide, which gives a sustained classification ceiling of roughly 11 URLs per second. Your scrape throughput is never throttled: when demand outruns the budget, or the hourly budget is exhausted, affected requests resolve through your failure policy immediately instead of queueing indefinitely.
 
 Two endpoint-level differences from Normal mode:
 

--- a/features/threat-protection.mdx
+++ b/features/threat-protection.mdx
@@ -19,7 +19,7 @@ Threat Protection has three modes, set at the organization level:
 
 - **Off** (default) — no checks are performed.
 - **Normal** — URLs are checked against [Google Web Risk](https://cloud.google.com/web-risk), which flags pages and sites associated with malware, social engineering (phishing), and unwanted software. **+2 credits per URL scanned.**
-- **Zscaler** — URLs are checked against your organization's own [Zscaler Internet Access](https://www.zscaler.com/products-and-solutions/zscaler-internet-access) (ZIA) tenant: the Zscaler-defined URL categories you choose to block, plus your custom URL categories and custom URL lists. See [Zscaler mode](#zscaler-mode) below. **+2 credits per URL classified.**
+- **Zscaler** — URLs are checked against your organization's own [Zscaler Internet Access](https://www.zscaler.com/products-and-solutions/zscaler-internet-access) (ZIA) tenant: the Zscaler-defined URL categories you choose to block, plus your custom URL categories and custom URL lists. See [Zscaler mode](#zscaler-mode) below. **No scan fees** — classification runs against your own tenant.
 
 The checks are designed to protect your data. In Normal mode the overwhelming majority of requests resolve locally against a regularly synced threat list, so the URLs you scrape are never sent to the classifier. In Zscaler mode, URL classification happens against your own ZIA tenant — the same system that already sees your organization's web policy. In every mode, no verdict about your traffic is ever stored by Firecrawl.
 
@@ -59,7 +59,7 @@ ZIA's URL Lookup API allows 1 request per second and 400 requests per hour per t
 Two endpoint-level differences from Normal mode:
 
 - **Map results are evaluated against local rules only** (your lists plus synced custom rules) rather than classified inline — one map can return thousands of URLs, and classifying them would burn the hourly budget on links that may never be fetched. Every URL still gets the full check when a scrape of it starts.
-- **Search results are classified inline** and blocked results are removed, same as Normal mode, so search scan fees draw on the hourly lookup budget.
+- **Search results are classified inline** and blocked results are removed, same as Normal mode; each unique result draws on the hourly lookup budget.
 
 Verdicts are never cached or stored (as in every mode), so a classification change in Zscaler applies to the very next request, and custom-list changes apply on the next sync.
 
@@ -118,9 +118,9 @@ If a request is redirected to a different URL — including a same-site redirect
 
 ## Billing
 
-A scan costs **+2 credits per URL scanned**, on top of the base cost of the request — in Normal mode per Web Risk scan, in Zscaler mode per URL classified through your tenant. A few details:
+In Normal mode a scan costs **+2 credits per URL scanned**, on top of the base cost of the request. **Zscaler mode has no scan fees**: classification runs against your own ZIA tenant, with your credentials and your API quota, so the scan-fee details below apply to Normal mode only. A few details:
 
-- Decisions made entirely from your own policy (blacklist, whitelist, or blocked-TLD matches) do not call the classifier and are **not** charged a scan fee. In Zscaler mode, the same applies to decisions made from your synced custom rules.
+- Decisions made entirely from your own policy (blacklist, whitelist, or blocked-TLD matches) do not call the classifier and are **not** charged a scan fee.
 - A request that is blocked is still charged for the scan that produced the verdict.
 - Scans are deduplicated within a single scrape: a redirect re-check that resolves to the same URL shares the original scan, while a redirect that lands on a different URL is a second scan.
 - **Crawls and batch scrapes check every page independently.** Verdicts are never reused across pages — nothing about your traffic is stored (see above) — so in Normal mode expect **+2 credits per scraped page**. A link that is discovered mid-crawl and blocked bills its scan once per crawl, no matter how many pages link to it.

--- a/features/threat-protection.mdx
+++ b/features/threat-protection.mdx
@@ -15,12 +15,13 @@ Threat Protection is an enterprise feature and is gated per organization. Contac
 
 ## Modes
 
-Threat Protection has two modes, set at the organization level:
+Threat Protection has three modes, set at the organization level:
 
 - **Off** (default) — no checks are performed.
 - **Normal** — URLs are checked against [Google Web Risk](https://cloud.google.com/web-risk), which flags pages and sites associated with malware, social engineering (phishing), and unwanted software. **+2 credits per URL scanned.**
+- **Zscaler** — URLs are checked against your organization's own [Zscaler Internet Access](https://www.zscaler.com/products-and-solutions/zscaler-internet-access) (ZIA) tenant: the Zscaler-defined URL categories you choose to block, plus your custom URL categories and custom URL lists. See [Zscaler mode](#zscaler-mode) below. **+2 credits per URL classified.**
 
-The checks are designed to protect your data: for the overwhelming majority of requests the check resolves locally against a regularly synced threat list, so the URLs you scrape are never sent to the classifier, and no verdict about your traffic is ever stored by Firecrawl.
+The checks are designed to protect your data. In Normal mode the overwhelming majority of requests resolve locally against a regularly synced threat list, so the URLs you scrape are never sent to the classifier. In Zscaler mode, URL classification happens against your own ZIA tenant — the same system that already sees your organization's web policy. In every mode, no verdict about your traffic is ever stored by Firecrawl.
 
 ## Policy controls
 
@@ -29,10 +30,38 @@ Beyond the classifier, a policy can include:
 - **Custom blacklist** — exact domains or globs (e.g. `*.example.com`) that are always blocked, without a classifier call.
 - **Custom whitelist** — exact domains or globs that are always allowed. The whitelist wins over every other rule, so a domain you trust is never blocked.
 - **Blocked TLDs** — top-level domains to block outright (e.g. `zip`), matched on label boundaries.
-- **Risk score threshold** — the normalized score (0–100) at or above which a classifier verdict is treated as a block. Lower is stricter. The default is `75`.
+- **Risk score threshold** — the normalized score (0–100) at or above which a classifier verdict is treated as a block. Lower is stricter. The default is `75`. Applies to Normal mode; Zscaler mode blocks by category instead.
 - **Failure policy** — what to do when the classifier can't be reached: **block** (`closed`, the default and recommended for a security control) or **allow** (`open`).
 
 The custom blacklist, whitelist, and blocked-TLD rules are domain-level — they match on the host of the URL being checked; only the classifier operates on full URLs. Custom domains you blacklist or whitelist are matched using the same host canonicalization as the classifier, so alternate encodings of an address (for example, an integer-form IP) can't be used to slip past a list entry.
+
+## Zscaler mode
+
+Zscaler mode lets an organization that already maintains URL policy in ZIA enforce it on Firecrawl traffic, without maintaining a parallel taxonomy. Two planes work together:
+
+- **Inline classification** — URLs are classified through your tenant's URL Lookup API into Zscaler-defined categories, and URLs in a category you have denied are blocked.
+- **Synced custom rules** — your custom URL categories (URL lists and keywords) and your additions to Zscaler-defined categories are synced from the tenant on a schedule and evaluated by Firecrawl directly, because the ZIA lookup API does not return custom classifications. Entries removed in ZIA disappear on the next sync; a manual **Sync now** is available in the dashboard.
+
+The promise is **your custom lists plus your selected Zscaler categories** — not "identical to your ZIA policy." ZIA rules can also depend on users, groups, locations, time of day, and request context that Firecrawl does not replay. Keyword rules in custom categories are matched best-effort (case-insensitive match against the URL); exact URL-list entries match exactly.
+
+### Connecting your tenant
+
+Team admins connect the tenant from the dashboard (see below) with a [Zidentity OAuth client](https://help.zscaler.com/oneapi/understanding-oneapi): client ID, client secret, and your Zidentity vanity domain. Use a least-privilege API role scoped to URL Categories. The **Test connection** button verifies three things separately — the credentials, taxonomy access, and URL Lookup access — so a role that can read categories but not classify URLs is surfaced at setup rather than on your first scrape. The client secret is write-only and encrypted at rest; Zscaler's support for two active secrets lets you rotate with no downtime.
+
+After connecting, pick the categories to block from your tenant's own taxonomy — Zscaler-defined and custom categories both appear in the picker.
+
+Classification traffic to your tenant originates from a dedicated static IP for allowlisting; ask your account team for the address.
+
+### Capacity and behavior
+
+ZIA's URL Lookup API allows 1 request per second and 400 requests per hour per tenant. Firecrawl batches lookups (up to 100 URLs per request) and enforces these limits tenant-wide, which gives a sustained classification ceiling of roughly 11 URLs per second. To keep demand near that budget, Zscaler mode also caps your organization's scrape concurrency. If the hourly budget is exhausted, affected requests resolve through your failure policy immediately instead of queueing indefinitely.
+
+Two endpoint-level differences from Normal mode:
+
+- **Map results are evaluated against local rules only** (your lists plus synced custom rules) rather than classified inline — one map can return thousands of URLs, and classifying them would burn the hourly budget on links that may never be fetched. Every URL still gets the full check when a scrape of it starts.
+- **Search results are classified inline** and blocked results are removed, same as Normal mode, so search scan fees draw on the hourly lookup budget.
+
+Verdicts are never cached or stored (as in every mode), so a classification change in Zscaler applies to the very next request, and custom-list changes apply on the next sync.
 
 ## Configuring the policy
 
@@ -40,8 +69,9 @@ Team admins configure Threat Protection from [Enterprise Controls → Threat Pro
 
 1. Open **Enterprise Controls → Threat Protection**.
 2. Choose a mode, set your risk score threshold, and add any blacklist, whitelist, or blocked-TLD entries.
-3. Choose whether to allow per-request overrides, and set the failure policy.
-4. Save. Changes take effect immediately — the next request is evaluated against the new policy.
+3. For Zscaler mode: enter the tenant connection, run the connection test, pick the categories to block, and set the sync interval.
+4. Choose whether to allow per-request overrides, and set the failure policy.
+5. Save. Changes take effect immediately — the next request is evaluated against the new policy.
 
 Only team admins can view or change the policy. Everyone else sees a read-only view.
 
@@ -61,6 +91,8 @@ Every endpoint that accepts URLs also accepts an optional `threatProtection` obj
 ```
 
 Overrides are merged onto the organization policy field by field. If your organization has **disabled request overrides**, any request that includes a `threatProtection` object is rejected with a `403` — this lets an administrator guarantee that the organization policy is the floor for every request.
+
+An override may select `"mode": "zscaler"` only when the organization has a Zscaler connection configured; the connection itself and the denied-category selection are organization-level and cannot be set per request.
 
 If Threat Protection is **enforced** for your team, an override may still tighten the policy but may not include `"mode": "off"` — a request that tries is rejected with a `403`.
 
@@ -86,9 +118,9 @@ If a request is redirected to a different URL — including a same-site redirect
 
 ## Billing
 
-A scan costs **+2 credits per URL scanned** in Normal mode, on top of the base cost of the request. A few details:
+A scan costs **+2 credits per URL scanned**, on top of the base cost of the request — in Normal mode per Web Risk scan, in Zscaler mode per URL classified through your tenant. A few details:
 
-- Decisions made entirely from your own policy (blacklist, whitelist, or blocked-TLD matches) do not call the classifier and are **not** charged a scan fee.
+- Decisions made entirely from your own policy (blacklist, whitelist, or blocked-TLD matches) do not call the classifier and are **not** charged a scan fee. In Zscaler mode, the same applies to decisions made from your synced custom rules.
 - A request that is blocked is still charged for the scan that produced the verdict.
 - Scans are deduplicated within a single scrape: a redirect re-check that resolves to the same URL shares the original scan, while a redirect that lands on a different URL is a second scan.
 - **Crawls and batch scrapes check every page independently.** Verdicts are never reused across pages — nothing about your traffic is stored (see above) — so in Normal mode expect **+2 credits per scraped page**. A link that is discovered mid-crawl and blocked bills its scan once per crawl, no matter how many pages link to it.
@@ -103,6 +135,7 @@ A scan costs **+2 credits per URL scanned** in Normal mode, on top of the base c
 | `403` | A `threatProtection` override sets `mode: "off"` while Threat Protection is enforced for the team. |
 | `403` | The organization policy is updated with `mode: "off"` while Threat Protection is enforced for the team. |
 | `403` | Threat Protection options are used on a team without the feature enabled. |
+| `403` | A `threatProtection` override selects `mode: "zscaler"` while the organization has no Zscaler connection configured. |
 | `403` | A deprecated v0 endpoint is called while Threat Protection is enforced for the team (v0 does not support Threat Protection). |
 
 ## Notes
@@ -111,3 +144,4 @@ A scan costs **+2 credits per URL scanned** in Normal mode, on top of the base c
 - The whitelist always wins, so a URL on an explicitly trusted domain is never blocked by the classifier or a TLD rule.
 - The error code `unsafe_domain_blocked` is kept stable for compatibility even though checks are URL-level.
 - With the failure policy set to `closed` (the default), a classifier outage causes affected requests to be blocked rather than silently allowed.
+- With [SIEM Audit Logging](/features/siem) configured, every decision is visible in your audit trail: events carry the deciding rule, the classifier consulted, the threat categories, and — for Zscaler-classified URLs — a `security_alert` flag when the URL carried a security-alert classification.


### PR DESCRIPTION
# docs: SIEM audit logging page + Zscaler mode in threat protection

Documentation for two enterprise features (API: firecrawl/firecrawl#4161 for the Zscaler mode; the SIEM feature is already live).

## New page: `features/siem.mdx`

SIEM Audit Logging, modeled on the IP Restrictions page: what gets logged (the `scrape_activity` event with a full example and field notes, including the threat enrichment), the Microsoft Sentinel destination (Entra app + DCE/DCR via the Logs Ingestion API), the dashboard setup flow with the write-only secret and save-then-verify test event, delivery semantics (batched, retried, never in the request path, static egress for allowlisting), an error reference, and notes (no credit charges, no page content exported, ZDR-compatible).

Added to both English "Enterprise" navigation groups in `docs.json`, after Threat Protection.

## Extended page: `features/threat-protection.mdx`

Adds the **Zscaler** mode alongside Off/Normal:

- Modes list gains Zscaler (+2 credits per URL classified) and the data-protection paragraph now covers all modes.
- New **Zscaler mode** section: the two planes (inline classification via the tenant's URL Lookup API, synced custom rules because the lookup API does not return custom classifications), the "your custom lists plus your selected categories, not identical to your ZIA policy" framing, tenant connection with the three-stage test and write-only rotating secret, category picker, capacity behavior (1/s and 400/h tenant limits, ~11 URLs/s sustained ceiling, concurrency cap, fail-fast into the failure policy), map local-rules-only carve-out, and no verdict caching.
- Configuration steps, per-request override rules (mode selectable, connection org-only), billing (synced-rule decisions free), error reference, and a SIEM cross-link updated accordingly.

English files only; localized trees untouched (i18n is generated by CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-docs/pr/1169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787854050&installation_model_id=11126&pr_number=1169&repository=firecrawl%2Ffirecrawl-docs&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-docs%2Fpull%2F1169&signature=231676fd2453d65d7c0ed554c3519a06a381c22d4107c73e0bbe5c3e84ecb447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->