### PR TITLE
docs: add agent quickstart guides for all SDK languages

### DIFF
--- a/agent-quickstart/elixir.mdx
+++ b/agent-quickstart/elixir.mdx
@@ -1,0 +1,235 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+Canonical quickstart for external agents integrating with Firecrawl via the Elixir SDK. Generated from SDK source and OpenAPI spec.
+
+## Install
+
+Add to your `mix.exs` deps:
+
+```elixir
+{:firecrawl, "~> 1.9"}
+```
+
+Then run:
+
+```bash
+mix deps.get
+```
+
+## Authenticate
+
+Set the API key globally via application config:
+
+```elixir
+# config/config.exs
+config :firecrawl, api_key: "fc-YOUR_API_KEY"
+```
+
+Or pass it per-request in the trailing options:
+
+```elixir
+Firecrawl.scrape_and_extract_from_url(
+  [url: "https://example.com"],
+  api_key: "fc-YOUR_API_KEY"
+)
+```
+
+The trailing `opts` keyword list also supports `:base_url` to override the default `https://api.firecrawl.dev/v2` for self-hosted instances.
+
+If no API key is configured, the client operates in keyless free tier mode (rate-limited per IP).
+
+## When To Use What
+
+- **`search_and_scrape`**: Start with a query and discover relevant URLs and content across the web.
+- **`scrape_and_extract_from_url`**: You already have a URL and want its page content in a structured format.
+- **`interact_with_scrape_browser_session`**: The page needs clicks, form fills, or post-scrape browser actions within an active browser session.
+
+## Search
+
+### Why use it
+
+Search the web for a query and get structured results grouped by source type. Optionally scrape each result page in the same call by passing `scrape_options`.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.search_and_scrape(params, opts \\ [])
+Firecrawl.search_and_scrape!(params, opts \\ [])
+```
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.search_and_scrape(
+  query: "firecrawl web scraping API",
+  limit: 5,
+  scrape_options: [formats: ["markdown"]]
+)
+
+for result <- response.body["data"]["web"] || [] do
+  IO.puts("#{result["title"]} #{result["url"]}")
+end
+```
+
+### Parameters
+
+Passed as a keyword list. All parameters except `query` are optional.
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `query` | `:string` (required) | The search query | Always required |
+| `sources` | `{:list, :any}` | Source types: `"web"`, `"news"`, `"images"` | Filter by source type. Default: `["web"]` |
+| `categories` | `{:list, :any}` | Category filters: `"github"`, `"research"`, `"pdf"` | Narrow results to specific content types |
+| `include_domains` | `{:list, :string}` | Restrict results to these domains | Only want specific sites |
+| `exclude_domains` | `{:list, :string}` | Exclude results from these domains | Filter out specific sites |
+| `limit` | `:integer` | Max number of results | Control result count. Default: 10 |
+| `tbs` | `:string` | Time-based search string (e.g. `"qdr:d"`) | Need recent results |
+| `location` | `:string` | Geographic location string | Geo-target results |
+| `country` | `:string` | ISO country code (e.g. `"US"`) | Country-level targeting |
+| `ignore_invalid_urls` | `:boolean` | Skip invalid URLs in results | Piping results into other endpoints |
+| `timeout` | `:integer` | Timeout in milliseconds | Override default timeout |
+| `highlights` | `:boolean` | Generate query-relevant highlights | Default: true. Set `false` for raw snippets |
+| `scrape_options` | `:keyword_list` | Scrape options for each result (same keys as scrape params) | Get full page content per result |
+| `enterprise` | `{:list, :string}` | Enterprise options: `["zdr"]`, `["anon"]` | Zero data retention or anonymized search |
+
+**Returns** `{:ok, %Req.Response{}}` or `{:error, exception}`. The bang variant `search_and_scrape!` returns `%Req.Response{}` directly or raises.
+
+Response body is a decoded JSON map. Access results via `response.body["data"]["web"]`, `response.body["data"]["news"]`, `response.body["data"]["images"]`.
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get its content as markdown, HTML, structured JSON, screenshots, or other formats.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.scrape_and_extract_from_url(params, opts \\ [])
+Firecrawl.scrape_and_extract_from_url!(params, opts \\ [])
+```
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown", "links"],
+  only_main_content: true
+)
+
+data = response.body["data"]
+IO.puts(data["markdown"])
+IO.inspect(data["links"])
+```
+
+### Parameters
+
+Passed as a keyword list. Only `url` is required.
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `url` | `:string` (required) | The URL to scrape | Always required |
+| `formats` | `{:list, :any}` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Also accepts maps for typed formats like `%{type: "json", schema: ..., prompt: ...}` | Control what content you get. Default: `["markdown"]` |
+| `headers` | `:any` | Custom HTTP headers as a map | Cookies, auth headers, custom user-agent |
+| `include_tags` | `{:list, :string}` | HTML tags to include | Only want content from specific tags |
+| `exclude_tags` | `{:list, :string}` | HTML tags to exclude | Filter out nav, footer, sidebar |
+| `only_main_content` | `:boolean` | Extract only main content | Skip headers, navs, footers. Default: `true` |
+| `timeout` | `:integer` | Timeout in milliseconds | Default: 60000. Min: 1000, Max: 300000 |
+| `wait_for` | `:integer` | Milliseconds to wait after page load | Pages needing JS rendering time |
+| `mobile` | `:boolean` | Emulate mobile device | Need mobile version |
+| `parsers` | `{:list, :any}` | Parser configs (e.g. `["pdf"]`) | Scraping PDFs. Default: `["pdf"]` |
+| `actions` | `{:list, :any}` | Browser actions before scraping | Interact with page before scraping |
+| `location` | `:keyword_list` | Location config keyword list | Location-specific content. Default: `"US"` |
+| `skip_tls_verification` | `:boolean` | Skip TLS cert verification | Invalid certificates. Default: `true` |
+| `remove_base64_images` | `:boolean` | Strip base64 images | Reduce response size. Default: `true` |
+| `block_ads` | `:boolean` | Block ads and cookie popups | Default: `true` |
+| `proxy` | `{:in, [:basic, :enhanced, :auto]}` | Proxy mode (atoms) | Anti-bot protections. Default: `:auto` |
+| `max_age` | `:integer` | Max cache age in milliseconds | Use cached if younger. Default: 172800000 (2 days) |
+| `min_age` | `:integer` | Min cache age in milliseconds | Cache-only mode. Set to 1 for any cached data |
+| `store_in_cache` | `:boolean` | Cache the result | Default: `true` |
+| `lockdown` | `:boolean` | Only serve cached results | No outbound requests |
+| `redact_pii` | `:boolean` | Redact PII | Sensitive content |
+| `profile` | `:keyword_list` | Browser profile: `[name: "...", save_changes: true]` | Persistent browser state |
+| `audit_metadata` | `:keyword_list` | `[username: "..."]` for SIEM | Enterprise logging |
+| `zero_data_retention` | `:boolean` | Enable zero data retention | Must be enabled for your team |
+
+**Returns** `{:ok, %Req.Response{}}` or `{:error, exception}`. Access scraped data via `response.body["data"]`.
+
+## Interact
+
+### Why use it
+
+Execute code in the browser session associated with a scrape job. Use for post-scrape interactions like clicking buttons, filling forms, or navigating.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.interact_with_scrape_browser_session(job_id, params, opts \\ [])
+Firecrawl.interact_with_scrape_browser_session!(job_id, params, opts \\ [])
+```
+
+### Example
+
+```elixir
+{:ok, scrape_response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown"]
+)
+
+job_id = scrape_response.body["data"]["metadata"]["scrapeId"]
+
+{:ok, result} = Firecrawl.interact_with_scrape_browser_session(job_id,
+  code: "document.querySelector('button.load-more').click();",
+  language: :node,
+  timeout: 30
+)
+
+IO.puts(result.body["stdout"])
+
+# Stop the session when done
+Firecrawl.stop_interactive_scrape_browser_session(job_id)
+```
+
+### Parameters
+
+`job_id` is the first argument (string). Remaining parameters are a keyword list.
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `code` | `:string` (required) | Code to execute in the browser | The code to run |
+| `language` | `{:in, [:python, :node, :bash]}` | Execution language (atom) | Default: `:node` |
+| `timeout` | `:integer` | Execution timeout in seconds (1-300) | Default: 30 |
+| `origin` | `:string` | Origin identifier | Request attribution |
+
+**Returns** `{:ok, %Req.Response{}}` or `{:error, exception}`. Response body contains `"success"`, `"stdout"`, `"stderr"`, `"result"`, `"exitCode"`, `"killed"`, `"error"`.
+
+Call `Firecrawl.stop_interactive_scrape_browser_session(job_id)` when done to end the browser session.
+
+## Notes
+
+- **Auto-generated from OpenAPI**: The entire Elixir SDK is generated from the OpenAPI spec. Function names are verbose operation-ID-derived names, not hand-crafted Elixir conventions.
+- **Function name mapping**:
+  - `scrape` -> `scrape_and_extract_from_url`
+  - `search` -> `search_and_scrape`
+  - `interact` -> `interact_with_scrape_browser_session`
+  - `stop interaction` -> `stop_interactive_scrape_browser_session`
+- **No struct types in responses**: The SDK returns raw `Req.Response` structs. Work directly with the decoded JSON map via `response.body`.
+- **NimbleOptions validation**: Parameters are validated locally before the HTTP call. Invalid params return `{:error, %NimbleOptions.ValidationError{}}`.
+- **Atoms for enums**: Enum values can be passed as atoms (e.g. `proxy: :enhanced`, `language: :python`). They are stringified for JSON.
+- **Keyword-list nesting**: Nested objects (like `scrape_options`, `location`, `profile`) are passed as keyword lists and auto-converted to camelCase JSON maps.
+- **Bang variants**: Every function has a `!` variant that raises on error and returns the response directly.
+- **`interact` has no `prompt` parameter**: Unlike the JS, Python, and Rust SDKs, the Elixir SDK's interact function only accepts `code`, not natural-language prompts.
+- **`search` has a separate `country` parameter**: Unlike other SDKs where country is part of a location object, the Elixir SDK exposes `country` as a standalone search parameter.
+- **No deprecated aliases**: The Elixir SDK has no deprecated function names since all names are generated from OpenAPI operation IDs.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/java.mdx
+++ b/agent-quickstart/java.mdx
@@ -1,0 +1,258 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+Canonical quickstart for external agents integrating with Firecrawl via the Java SDK. Generated from SDK source and OpenAPI spec.
+
+## Install
+
+Maven:
+
+```xml
+<dependency>
+    <groupId>com.firecrawl</groupId>
+    <artifactId>firecrawl-java</artifactId>
+    <version>1.12.1</version>
+</dependency>
+```
+
+Gradle:
+
+```groovy
+implementation 'com.firecrawl:firecrawl-java:1.12.1'
+```
+
+Requires Java 11+.
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey("fc-YOUR_API_KEY")
+    .build();
+```
+
+Builder options:
+
+```java
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey("fc-YOUR_API_KEY")
+    .apiUrl("https://api.firecrawl.dev")  // optional, for self-hosted
+    .timeoutMs(300_000)                    // HTTP timeout in ms, default: 300000
+    .maxRetries(3)                         // default: 3
+    .backoffFactor(0.5)                    // exponential backoff, default: 0.5
+    .build();
+```
+
+Or from environment:
+
+```java
+FirecrawlClient client = FirecrawlClient.fromEnv();
+// reads FIRECRAWL_API_KEY env var, then firecrawl.apiKey system property
+```
+
+A null or blank API key enables the keyless free tier (rate-limited per IP).
+
+## When To Use What
+
+- **`search`**: Start with a query and discover relevant URLs and content across the web.
+- **`scrape`**: You already have a URL and want its page content in a structured format.
+- **`interact`**: The page needs clicks, form fills, or post-scrape browser actions within an active browser session.
+
+## Search
+
+### Why use it
+
+Search the web for a query and get structured results grouped by source type. Optionally scrape each result page in the same call by passing `scrapeOptions`.
+
+### Preferred SDK method
+
+```java
+client.search(query)
+client.search(query, searchOptions)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.SearchData;
+
+SearchData results = client.search("firecrawl web scraping API",
+    SearchOptions.builder()
+        .limit(5)
+        .scrapeOptions(ScrapeOptions.builder()
+            .formats(List.of("markdown"))
+            .build())
+        .build());
+
+if (results.getWeb() != null) {
+    for (Map<String, Object> result : results.getWeb()) {
+        System.out.println(result.get("title") + " " + result.get("url"));
+    }
+}
+```
+
+### Parameters
+
+Built via `SearchOptions.builder()`. All fields are nullable (null = not sent, server default applies).
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `sources` | `List<Object>` | Source types: `"web"`, `"news"`, `"images"` | Filter results by source type. Default: `["web"]` |
+| `categories` | `List<Object>` | Category filters: `"github"`, `"research"`, `"pdf"` | Narrow results to specific content types |
+| `includeDomains` | `List<String>` | Restrict results to these domains | Only want specific sites |
+| `excludeDomains` | `List<String>` | Exclude results from these domains | Filter out specific sites |
+| `limit` | `Integer` | Max number of results | Control result count. Default: 10 |
+| `tbs` | `String` | Time-based search string (e.g. `"qdr:d"`) | Need recent results |
+| `location` | `String` | Geographic location string | Geo-target results |
+| `ignoreInvalidURLs` | `Boolean` | Skip invalid URLs in results | Piping results into other endpoints |
+| `timeout` | `Integer` | Timeout in milliseconds | Override default timeout |
+| `highlights` | `Boolean` | Generate query-relevant highlights | Default: true. Set `false` for raw snippets |
+| `scrapeOptions` | `ScrapeOptions` | Scrape options for each result | Get full page content per result |
+| `integration` | `String` | Integration identifier | Track integration source |
+
+**Returns** `SearchData` with `getWeb()`, `getNews()`, `getImages()` returning `List<Map<String, Object>>`.
+
+Async variant: `client.searchAsync(query, options)` returns `CompletableFuture<SearchData>`.
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get its content as markdown, HTML, structured JSON, screenshots, or other formats.
+
+### Preferred SDK method
+
+```java
+client.scrape(url)
+client.scrape(url, scrapeOptions)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.Document;
+
+Document doc = client.scrape("https://example.com",
+    ScrapeOptions.builder()
+        .formats(List.of("markdown", "links"))
+        .onlyMainContent(true)
+        .build());
+
+System.out.println(doc.getMarkdown());
+System.out.println(doc.getLinks());
+```
+
+### Parameters
+
+Built via `ScrapeOptions.builder()`. All fields are nullable (null = not sent, server default applies).
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `formats` | `List<Object>` | Output formats: strings (`"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`, `"highlights"`, `"question"`) or format objects (`JsonFormat`, `QuestionFormat`, `HighlightsFormat`) | Control what content you get. Default: `["markdown"]` |
+| `headers` | `Map<String, String>` | Custom HTTP headers | Cookies, auth headers, custom user-agent |
+| `includeTags` | `List<String>` | HTML tags to include | Only want content from specific tags |
+| `excludeTags` | `List<String>` | HTML tags to exclude | Filter out nav, footer, sidebar |
+| `onlyMainContent` | `Boolean` | Extract only main content | Skip headers, navs, footers. Default: `true` |
+| `timeout` | `Integer` | Timeout in milliseconds | Default: 60000. Min: 1000, Max: 300000 |
+| `waitFor` | `Integer` | Milliseconds to wait after page load | Pages needing JS rendering time |
+| `mobile` | `Boolean` | Emulate mobile device | Need mobile version |
+| `parsers` | `List<Object>` | Parser configs (e.g. `"pdf"`) | Scraping PDFs. Default: `["pdf"]` |
+| `actions` | `List<Map<String, Object>>` | Browser actions (click, write, press, scroll, wait, etc.) | Interact with page before scraping |
+| `location` | `LocationConfig` | `LocationConfig` with `country`, `languages` | Location-specific content. Default: `"US"` |
+| `skipTlsVerification` | `Boolean` | Skip TLS cert verification | Invalid certificates. Default: `true` |
+| `removeBase64Images` | `Boolean` | Strip base64 images | Reduce response size. Default: `true` |
+| `blockAds` | `Boolean` | Block ads and cookie popups | Default: `true` |
+| `proxy` | `String` | Proxy mode: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"` | Anti-bot protections. Default: `"auto"` |
+| `maxAge` | `Long` | Max cache age in milliseconds | Use cached if younger |
+| `storeInCache` | `Boolean` | Cache the result | Default: `true` |
+| `lockdown` | `Boolean` | Only serve cached results | No outbound requests |
+| `redactPII` | `Boolean` | Redact PII | Sensitive content |
+| `auditMetadata` | `AuditMetadata` | `AuditMetadata(username)` for SIEM | Enterprise logging |
+| `integration` | `String` | Integration identifier | Track integration source |
+
+**Returns** `Document` with `getMarkdown()`, `getHtml()`, `getRawHtml()`, `getJson()`, `getSummary()`, `getLinks()`, `getImages()`, `getScreenshot()`, `getAudio()`, `getVideo()`, `getMetadata()`, `getActions()`, `getAnswer()`, `getHighlights()`, `getWarning()`, `getChangeTracking()`, `getBranding()`, `getProduct()`, `getMenu()`.
+
+Async variant: `client.scrapeAsync(url, options)` returns `CompletableFuture<Document>`.
+
+## Interact
+
+### Why use it
+
+Execute code in the browser session associated with a scrape job. Use for post-scrape interactions like clicking buttons, filling forms, or navigating.
+
+### Preferred SDK method
+
+```java
+client.interact(jobId, code)
+client.interact(jobId, code, language, timeout)
+client.interact(jobId, code, language, timeout, origin)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.BrowserExecuteResponse;
+
+Document doc = client.scrape("https://example.com",
+    ScrapeOptions.builder().formats(List.of("markdown")).build());
+String jobId = (String) doc.getMetadata().get("scrapeId");
+
+BrowserExecuteResponse result = client.interact(
+    jobId,
+    "document.querySelector('button.load-more').click();",
+    "node",
+    30
+);
+
+System.out.println(result.getStdout());
+
+// Stop the session when done
+client.stopInteractiveBrowser(jobId);
+```
+
+### Parameters
+
+Passed as method arguments. Three overloads are available:
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `jobId` | `String` | The scrape job ID (required) | From `doc.getMetadata().get("scrapeId")` |
+| `code` | `String` | Code to execute in the browser (required) | The code to run |
+| `language` | `String` | Execution language: `"python"`, `"node"`, `"bash"` | Default: `"node"` |
+| `timeout` | `Integer` | Execution timeout in seconds (1-300) | Default: 30 |
+| `origin` | `String` | Origin identifier | Auto-set to `"java-sdk@{version}"` if null |
+
+**Returns** `BrowserExecuteResponse` with `isSuccess()`, `getStdout()`, `getResult()`, `getStderr()`, `getExitCode()`, `isKilled()`, `getError()`.
+
+Call `client.stopInteractiveBrowser(jobId)` when done to end the browser session.
+
+Async variants: `client.interactAsync(...)` returns `CompletableFuture<BrowserExecuteResponse>`.
+
+## Notes
+
+- **camelCase naming**: All parameter names use camelCase (Java convention).
+- **Builder pattern**: All options classes use `ClassName.builder()...build()`. No public constructors.
+- **`List<Object>` for formats**: Because formats can be plain strings or typed objects (`JsonFormat`, `QuestionFormat`, `HighlightsFormat`), the parameter accepts `List<Object>`.
+- **`SearchData` uses generic maps**: Search results are `List<Map<String, Object>>`. Extract values by key.
+- **`interact` has no `prompt` parameter**: Unlike the JS, Python, and Rust SDKs, the Java SDK's `interact()` only accepts `code`, not natural-language prompts.
+- **`fromEnv()` factory**: Resolves API key from `FIRECRAWL_API_KEY` env var, then `firecrawl.apiKey` system property.
+- **Deprecated aliases** (use preferred names):
+  - `scrapeExecute()` -> `interact()`
+  - `deleteScrapeBrowser()` -> `stopInteractiveBrowser()`
+  - `QueryFormat` -> `QuestionFormat` or `HighlightsFormat`
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/`
+- `firecrawl/apps/java-sdk/build.gradle.kts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/node.mdx
+++ b/agent-quickstart/node.mdx
@@ -1,0 +1,216 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+Canonical quickstart for external agents integrating with Firecrawl via the JavaScript/TypeScript SDK. Generated from SDK source and OpenAPI spec.
+
+## Install
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+Requires Node >= 22.0.0.
+
+## Authenticate
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+
+const app = new Firecrawl("fc-YOUR_API_KEY");
+```
+
+The constructor also accepts an options object:
+
+```typescript
+const app = new Firecrawl({
+  apiKey: "fc-YOUR_API_KEY",
+  apiUrl: "https://api.firecrawl.dev",
+  timeoutMs: 30000,
+  maxRetries: 3,
+  backoffFactor: 1.0,
+});
+```
+
+If no API key is provided, the SDK falls back to the `FIRECRAWL_API_KEY` environment variable, then to the keyless free tier (rate-limited per IP).
+
+## When To Use What
+
+- **`search`**: Start with a query and discover relevant URLs and content across the web.
+- **`scrape`**: You already have a URL and want its page content in a structured format.
+- **`interact`**: The page needs clicks, form fills, or post-scrape browser actions within an active browser session.
+
+## Search
+
+### Why use it
+
+Search the web for a query and get structured results grouped by source type. Optionally scrape each result page in the same call by passing `scrapeOptions`.
+
+### Preferred SDK method
+
+```typescript
+app.search(query: string, options?)
+```
+
+### Example
+
+```typescript
+const results = await app.search("firecrawl web scraping API", {
+  limit: 5,
+  scrapeOptions: { formats: ["markdown"] },
+});
+
+for (const result of results.web ?? []) {
+  console.log(result.title, result.url);
+}
+```
+
+### Parameters
+
+| Parameter | Description | When to use |
+|---|---|---|
+| `sources` | Source types: `"web"`, `"news"`, `"images"` (strings or `{ type }` objects) | Filter results to specific source types. Default: `["web"]` |
+| `categories` | Category filters: `"github"`, `"research"`, `"pdf"` | Narrow results to specific content types |
+| `includeDomains` | Restrict results to these domains | Only want results from specific sites. Cannot combine with `excludeDomains` |
+| `excludeDomains` | Exclude results from these domains | Filter out specific sites. Cannot combine with `includeDomains` |
+| `limit` | Max number of results | Control result count. Default: 10 |
+| `tbs` | Time-based search string (e.g. `"qdr:d"` for past day, `"qdr:w"` for past week) | Need recent results or a specific date range |
+| `location` | Geographic location string | Geo-target results |
+| `ignoreInvalidURLs` | Skip invalid URLs in results | Piping results into other Firecrawl endpoints |
+| `timeout` | Timeout in milliseconds | Override the default timeout |
+| `highlights` | Generate query-relevant highlights | Enabled by default. Set `false` for raw provider snippets |
+| `scrapeOptions` | `ScrapeOptions` applied to each result | Get full page content for each search result |
+| `enterprise` | Enterprise options: `"zdr"`, `"anon"` | Zero data retention or anonymized search |
+| `threatProtection` | Per-request threat protection config | Enterprise threat protection override |
+| `integration` | Integration identifier string | Track which integration triggered the request |
+| `origin` | Origin identifier string | Request attribution |
+
+**Returns** `SearchData` with `.web`, `.news`, `.images` arrays. Accessing `.data` throws an error directing you to the source-specific arrays.
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get its content as markdown, HTML, structured JSON, screenshots, or other formats.
+
+### Preferred SDK method
+
+```typescript
+app.scrape(url: string, options?)
+```
+
+### Example
+
+```typescript
+const doc = await app.scrape("https://example.com", {
+  formats: ["markdown", "links"],
+  onlyMainContent: true,
+});
+
+console.log(doc.markdown);
+console.log(doc.links);
+```
+
+### Parameters
+
+| Parameter | Description | When to use |
+|---|---|---|
+| `formats` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Objects: `{ type: "json", schema?, prompt? }`, `{ type: "screenshot", fullPage?, quality?, viewport? }`, `{ type: "question", question }`, `{ type: "highlights", query }`, `{ type: "changeTracking", modes, schema?, prompt?, tag? }`, `{ type: "attributes", selectors }` | Control what content you get back. Default: `["markdown"]` |
+| `headers` | Custom HTTP headers (`Record<string, string>`) | Need cookies, auth headers, or custom user-agent |
+| `includeTags` | HTML tags to include (whitelist) | Only want content from specific tags |
+| `excludeTags` | HTML tags to exclude (blacklist) | Filter out nav, footer, sidebar, etc. |
+| `onlyMainContent` | Extract only main content area | Skip headers, navs, footers. Default: `true` |
+| `timeout` | Timeout in milliseconds | Override default. Default: 60000. Min: 1000, Max: 300000 |
+| `waitFor` | Milliseconds to wait after page load | Pages that need time for JS rendering |
+| `mobile` | Emulate mobile device | Need the mobile version of a page |
+| `parsers` | Parser configs, e.g. `["pdf"]` or `[{ type: "pdf", mode: "auto", maxPages: 10 }]` | Scraping PDFs or documents. Default: `["pdf"]` |
+| `actions` | Browser actions before scraping: `wait`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `screenshot`, `pdf` | Interact with the page before scraping |
+| `location` | `{ country?, languages? }` geolocation config | Location-specific content. Default country: `"US"` |
+| `skipTlsVerification` | Skip TLS certificate verification | Sites with invalid certificates. Default: `true` |
+| `removeBase64Images` | Strip base64 images from output | Reduce response size. Default: `true` |
+| `blockAds` | Block advertisements and cookie popups | Default: `true` |
+| `proxy` | Proxy mode: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"` | Dealing with anti-bot protections. Default: `"auto"` |
+| `fastMode` | Enable fast mode | Speed over completeness |
+| `maxAge` | Max cache age in milliseconds | Use cached version if younger. Default: 172800000 (2 days) |
+| `minAge` | Min cache age in milliseconds | Cache-only mode. Set to 1 for any cached data |
+| `storeInCache` | Store result in cache | Default: `true` |
+| `lockdown` | Only serve cached results, never make outbound requests | Strict cache-only operation |
+| `redactPII` | Redact PII. Pass `true` or `{ mode?, entities?, replaceStyle? }` | Handling sensitive content |
+| `profile` | `{ name, saveChanges? }` browser profile | Persistent browser state across sessions |
+| `auditMetadata` | `{ username }` for SIEM audit trails | Enterprise audit logging |
+| `integration` | Integration identifier | Track which integration triggered the request |
+| `origin` | Origin identifier | Request attribution |
+| `threatProtection` | Per-request threat protection config | Enterprise threat protection override |
+
+**Returns** `Document` with optional fields: `markdown`, `html`, `rawHtml`, `json`, `summary`, `links`, `images`, `screenshot`, `audio`, `video`, `metadata`, `actions`, `answer`, `highlights`, `warning`, `changeTracking`, `branding`, `product`, `menu`.
+
+## Interact
+
+### Why use it
+
+Execute code or natural-language prompts in the browser session associated with a scrape job. Use for post-scrape interactions like clicking buttons, filling forms, or navigating.
+
+### Preferred SDK method
+
+```typescript
+app.interact(jobId: string, args: { code?, prompt?, language?, timeout?, origin? })
+```
+
+### Example
+
+```typescript
+const doc = await app.scrape("https://example.com", {
+  formats: ["markdown"],
+});
+const jobId = doc.metadata?.scrapeId;
+
+const result = await app.interact(jobId, {
+  code: "document.querySelector('button.load-more').click();",
+  language: "node",
+  timeout: 30,
+});
+
+console.log(result.stdout);
+
+// Stop the session when done
+await app.stopInteraction(jobId);
+```
+
+### Parameters
+
+Passed as properties of the second argument object:
+
+| Parameter | Description | When to use |
+|---|---|---|
+| `code` | Code to execute in the browser session | Specific code to run. At least one of `code` or `prompt` required |
+| `prompt` | Natural-language instruction for the browser agent | Let the AI agent perform actions. At least one of `code` or `prompt` required |
+| `language` | Execution language: `"python"`, `"node"`, `"bash"` | Default: `"node"` |
+| `timeout` | Execution timeout in seconds (1-300) | Default: 30 |
+| `origin` | Origin identifier | Request attribution |
+
+**Returns** `ScrapeExecuteResponse` with `success`, `stdout`, `stderr`, `result`, `exitCode`, `killed`, `error`, `output` (AI agent response when using `prompt`), `liveViewUrl`, `interactiveLiveViewUrl`.
+
+Call `app.stopInteraction(jobId)` when done to end the browser session.
+
+## Notes
+
+- **camelCase only**: All parameter names use camelCase. No snake_case aliases exist.
+- **Zod schema support**: `JsonFormat.schema` and `ChangeTrackingFormat.schema` accept either a plain JSON Schema object or a Zod schema (`ZodTypeAny`). Zod schemas are auto-converted before sending, and the `scrape()` return type narrows the `json` field via `z.infer<>`.
+- **SearchData shape**: Results are grouped by source (`.web`, `.news`, `.images`). There is no `.data` property.
+- **Timeout buffer**: The SDK adds 5000ms to user-specified timeouts for HTTP-level timeouts. For interact, the buffer is `timeout * 1000 + 5000`.
+- **Deprecated aliases** (use preferred names):
+  - `scrapeUrl()` -> `scrape()`
+  - `scrapeExecute()` -> `interact()`
+  - `stopInteractiveBrowser()` / `deleteScrapeBrowser()` -> `stopInteraction()`
+  - `QueryFormat` -> `QuestionFormat` or `HighlightsFormat`
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/methods/scrape.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/methods/search.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/python.mdx
+++ b/agent-quickstart/python.mdx
@@ -1,0 +1,222 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+Canonical quickstart for external agents integrating with Firecrawl via the Python SDK. Generated from SDK source and OpenAPI spec.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+from firecrawl import Firecrawl
+
+app = Firecrawl(api_key="fc-YOUR_API_KEY")
+```
+
+Constructor options:
+
+```python
+app = Firecrawl(
+    api_key="fc-YOUR_API_KEY",
+    api_url="https://api.firecrawl.dev",  # optional, for self-hosted
+    timeout=30.0,                          # default request timeout in seconds
+    max_retries=3,                         # default: 3
+    backoff_factor=0.5,                    # exponential backoff factor
+)
+```
+
+If no API key is provided, the SDK falls back to the `FIRECRAWL_API_KEY` environment variable, then to the keyless free tier (rate-limited per IP).
+
+An async variant is available as `AsyncFirecrawl`.
+
+## When To Use What
+
+- **`search`**: Start with a query and discover relevant URLs and content across the web.
+- **`scrape`**: You already have a URL and want its page content in a structured format.
+- **`interact`**: The page needs clicks, form fills, or post-scrape browser actions within an active browser session.
+
+## Search
+
+### Why use it
+
+Search the web for a query and get structured results grouped by source type. Optionally scrape each result page in the same call by passing `scrape_options`.
+
+### Preferred SDK method
+
+```python
+app.search(query, **options)
+```
+
+### Example
+
+```python
+from firecrawl import Firecrawl, ScrapeOptions
+
+app = Firecrawl("fc-YOUR_API_KEY")
+
+results = app.search(
+    "firecrawl web scraping API",
+    limit=5,
+    scrape_options=ScrapeOptions(formats=["markdown"]),
+)
+
+for result in results.web or []:
+    print(result.title, result.url)
+```
+
+### Parameters
+
+All parameters are keyword-only.
+
+| Parameter | Description | When to use |
+|---|---|---|
+| `sources` | Source types: `"web"`, `"news"`, `"images"` (strings or `Source` objects) | Filter results to specific source types. Default: `["web"]` |
+| `categories` | Category filters: `"github"`, `"research"`, `"pdf"` | Narrow results to specific content types |
+| `include_domains` | Restrict results to these domains | Only want results from specific sites. Cannot combine with `exclude_domains` |
+| `exclude_domains` | Exclude results from these domains | Filter out specific sites. Cannot combine with `include_domains` |
+| `limit` | Max number of results | Control result count. Default: 10 |
+| `tbs` | Time-based search string (e.g. `"qdr:d"` for past day) | Need recent results or a specific date range |
+| `location` | Geographic location string (plain `str`, not a `Location` object) | Geo-target results |
+| `ignore_invalid_urls` | Skip invalid URLs in results | Piping results into other Firecrawl endpoints |
+| `timeout` | Timeout in milliseconds | Override the default timeout |
+| `highlights` | Generate query-relevant highlights | Enabled by default. Set `False` for raw provider snippets |
+| `scrape_options` | `ScrapeOptions` instance applied to each result | Get full page content for each search result |
+| `enterprise` | Enterprise options: `["zdr"]`, `["anon"]` | Zero data retention or anonymized search |
+| `threat_protection` | `ThreatProtectionOptions` instance | Enterprise threat protection override |
+| `integration` | Integration identifier string | Track which integration triggered the request |
+
+**Returns** `SearchData` with `.web`, `.news`, `.images` lists. Accessing `.data` raises `AttributeError` directing you to the source-specific attributes.
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get its content as markdown, HTML, structured JSON, screenshots, or other formats.
+
+### Preferred SDK method
+
+```python
+app.scrape(url, **options)
+```
+
+### Example
+
+```python
+doc = app.scrape(
+    "https://example.com",
+    formats=["markdown", "links"],
+    only_main_content=True,
+)
+
+print(doc.markdown)
+print(doc.links)
+```
+
+### Parameters
+
+All parameters except `url` are keyword-only.
+
+| Parameter | Description | When to use |
+|---|---|---|
+| `formats` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"raw_html"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"change_tracking"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Also accepts format objects like `JsonFormat`, `ScreenshotFormat`, `QuestionFormat`, `HighlightsFormat`, `ChangeTrackingFormat`, `AttributesFormat` | Control what content you get back. Default: `["markdown"]` |
+| `headers` | Custom HTTP headers (`dict`) | Need cookies, auth headers, or custom user-agent |
+| `include_tags` | HTML tags to include (whitelist) | Only want content from specific tags |
+| `exclude_tags` | HTML tags to exclude (blacklist) | Filter out nav, footer, sidebar, etc. |
+| `only_main_content` | Extract only main content area | Skip headers, navs, footers. Default: `True` |
+| `timeout` | Timeout in milliseconds | Override default. Default: 60000. Min: 1000, Max: 300000 |
+| `wait_for` | Milliseconds to wait after page load | Pages that need time for JS rendering |
+| `mobile` | Emulate mobile device | Need the mobile version of a page |
+| `parsers` | Parser list, e.g. `["pdf"]` or `[PDFParser(mode="auto", max_pages=10)]` | Scraping PDFs or documents. Default: `["pdf"]` |
+| `actions` | Browser action list (`WaitAction`, `ClickAction`, `WriteAction`, `PressAction`, `ScrollAction`, `ScrapeAction`, `ExecuteJavascriptAction`, `ScreenshotAction`, `PDFAction`) | Interact with the page before scraping |
+| `location` | `Location(country=..., languages=...)` object | Location-specific content. Default country: `"US"` |
+| `skip_tls_verification` | Skip TLS certificate verification | Sites with invalid certificates. Default: `True` |
+| `remove_base64_images` | Strip base64 images from output | Reduce response size. Default: `True` |
+| `block_ads` | Block advertisements and cookie popups | Default: `True` |
+| `proxy` | Proxy mode: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"` | Dealing with anti-bot protections. Default: `"auto"` |
+| `fast_mode` | Enable fast mode | Speed over completeness |
+| `max_age` | Max cache age in milliseconds | Use cached version if younger. Default: 172800000 (2 days) |
+| `store_in_cache` | Store result in cache | Default: `True` |
+| `lockdown` | Only serve cached results, never make outbound requests | Strict cache-only operation |
+| `redact_pii` | Redact PII. Pass `True` or `RedactPIIOptions(mode=..., entities=..., replace_style=...)` | Handling sensitive content |
+| `profile` | `{"name": "...", "saveChanges": True}` browser profile dict | Persistent browser state across sessions |
+| `audit_metadata` | `AuditMetadata(username=...)` for SIEM audit trails | Enterprise audit logging |
+| `threat_protection` | `ThreatProtectionOptions` instance | Enterprise threat protection override |
+| `integration` | Integration identifier | Track which integration triggered the request |
+
+**Returns** `Document` with optional attributes: `markdown`, `html`, `raw_html`, `json`, `summary`, `links`, `images`, `screenshot`, `audio`, `video`, `metadata`, `actions`, `answer`, `highlights`, `warning`, `change_tracking`, `branding`, `product`, `menu`.
+
+## Interact
+
+### Why use it
+
+Execute code or natural-language prompts in the browser session associated with a scrape job. Use for post-scrape interactions like clicking buttons, filling forms, or navigating.
+
+### Preferred SDK method
+
+```python
+app.interact(job_id, code=None, *, prompt=None, language="node", timeout=None, origin=None)
+```
+
+### Example
+
+```python
+doc = app.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.get("scrapeId")
+
+result = app.interact(
+    job_id,
+    code="document.querySelector('button.load-more').click();",
+    language="node",
+    timeout=30,
+)
+
+print(result.stdout)
+
+# Stop the session when done
+app.stop_interaction(job_id)
+```
+
+### Parameters
+
+`job_id` is the first positional argument. `code` is the second positional argument or can be passed as keyword.
+
+| Parameter | Description | When to use |
+|---|---|---|
+| `code` | Code to execute in the browser session | Specific code to run. At least one of `code` or `prompt` required |
+| `prompt` | Natural-language instruction for the browser agent | Let the AI agent perform actions. At least one of `code` or `prompt` required |
+| `language` | Execution language: `"python"`, `"node"`, `"bash"` | Default: `"node"` |
+| `timeout` | Execution timeout in seconds (1-300) | Default: 30 |
+| `origin` | Origin identifier | Request attribution |
+
+**Returns** `BrowserExecuteResponse` with `success`, `stdout`, `stderr`, `result`, `exit_code`, `killed`, `error`, `output` (AI agent response when using `prompt`), `cdp_url`, `live_view_url`, `interactive_live_view_url`.
+
+Call `app.stop_interaction(job_id)` when done to end the browser session.
+
+## Notes
+
+- **snake_case parameter naming**: All parameter names use Python-idiomatic snake_case (e.g. `include_tags`, `only_main_content`, `skip_tls_verification`). The SDK handles camelCase conversion internally.
+- **Format strings accept both cases**: Both `"raw_html"` and `"rawHtml"` are valid format strings.
+- **`search()` location is a plain string**: Unlike `scrape()` which takes a `Location` object, `search()` takes a plain `str` for the `location` parameter.
+- **SearchData shape**: Results are grouped by source (`.web`, `.news`, `.images`). Accessing `.data` raises `AttributeError`.
+- **Async variant**: `AsyncFirecrawl` provides the same API with `async`/`await` support.
+- **Deprecated aliases** (use preferred names):
+  - `FirecrawlApp` -> `Firecrawl`
+  - `AsyncFirecrawlApp` -> `AsyncFirecrawl`
+  - `scrape_url()` -> `scrape()`
+  - `scrape_execute()` -> `interact()`
+  - `delete_scrape_browser()` / `stop_interactive_browser()` -> `stop_interaction()`
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/rust.mdx
+++ b/agent-quickstart/rust.mdx
@@ -1,0 +1,248 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+Canonical quickstart for external agents integrating with Firecrawl via the Rust SDK. Generated from SDK source and OpenAPI spec.
+
+## Install
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+firecrawl = "2"
+tokio = { version = "1", features = ["full"] }
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+```
+
+For self-hosted instances:
+
+```rust
+let client = Client::new_selfhosted("https://your-instance.example.com", Some("fc-YOUR_API_KEY"))?;
+```
+
+If no API key is provided (or `None` is passed to `new_selfhosted`), the client operates in keyless free tier mode (rate-limited per IP).
+
+## When To Use What
+
+- **`search`**: Start with a query and discover relevant URLs and content across the web.
+- **`scrape`**: You already have a URL and want its page content in a structured format.
+- **`interact`**: The page needs clicks, form fills, or post-scrape browser actions within an active browser session.
+
+## Search
+
+### Why use it
+
+Search the web for a query and get structured results grouped by source type. Optionally scrape each result page in the same call by passing `scrape_options`.
+
+### Preferred SDK method
+
+```rust
+client.search(query, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions, ScrapeOptions};
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+
+let response = client.search("firecrawl web scraping API", SearchOptions {
+    limit: Some(5),
+    scrape_options: Some(ScrapeOptions {
+        formats: Some(vec![Format::Markdown]),
+        ..Default::default()
+    }),
+    ..Default::default()
+}).await?;
+
+if let Some(web_results) = response.data.web {
+    for result in web_results {
+        // result is SearchResultOrDocument: either WebResult or Document
+        println!("{:?}", result);
+    }
+}
+```
+
+### Parameters
+
+All fields on `SearchOptions` are `Option<T>`, defaulting to `None` (omitted from request).
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `limit` | `Option<u32>` | Max results to return | Control result count. Default: 5, Max: 20 |
+| `sources` | `Option<Vec<SearchSource>>` | Sources: `Web`, `News`, `Images` | Filter results by source type |
+| `categories` | `Option<Vec<SearchCategory>>` | Categories: `Github`, `Research`, `Pdf` | Narrow results to specific content types |
+| `include_domains` | `Option<Vec<String>>` | Restrict results to these domains | Only want specific sites |
+| `exclude_domains` | `Option<Vec<String>>` | Exclude results from these domains | Filter out specific sites |
+| `tbs` | `Option<String>` | Time-based search string (e.g. `"qdr:d"`) | Need recent results |
+| `location` | `Option<String>` | Geographic location string | Geo-target results |
+| `ignore_invalid_urls` | `Option<bool>` | Skip invalid URLs in results | Piping results into other endpoints |
+| `timeout` | `Option<u32>` | Timeout in milliseconds | Override default timeout |
+| `highlights` | `Option<bool>` | Generate query-relevant highlights | Default: true. Set `false` for raw snippets |
+| `scrape_options` | `Option<ScrapeOptions>` | Scrape options for each result | Get full page content per result |
+| `integration` | `Option<String>` | Integration identifier | Track integration source |
+| `origin` | `Option<String>` | Origin identifier | Auto-set to `"rust-sdk@{version}"` if `None` |
+
+**Returns** `SearchResponse` with `data: SearchData` containing `web: Option<Vec<SearchResultOrDocument>>`, `news: Option<Vec<SearchResultNews>>`, `images: Option<Vec<SearchResultImage>>`.
+
+A convenience method `client.search_and_scrape(query, limit).await` returns only `Vec<Document>` from scraped web results.
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get its content as markdown, HTML, structured JSON, screenshots, or other formats.
+
+### Preferred SDK method
+
+```rust
+client.scrape(url, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format};
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+
+let doc = client.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown, Format::Links]),
+    only_main_content: Some(true),
+    ..Default::default()
+}).await?;
+
+if let Some(markdown) = &doc.markdown {
+    println!("{}", markdown);
+}
+```
+
+### Parameters
+
+All fields on `ScrapeOptions` are `Option<T>`, defaulting to `None`. Pass `None` instead of `ScrapeOptions` for all defaults.
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `formats` | `Option<Vec<Format>>` | Output formats: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `Json`, `ChangeTracking`, `Attributes`, `Branding`, `Product`, `Menu`, `Audio`, `Video`, `Question(String)`, `Highlights(String)` | Control what content you get. Default: `["markdown"]` |
+| `headers` | `Option<HashMap<String, String>>` | Custom HTTP headers | Cookies, auth headers, custom user-agent |
+| `include_tags` | `Option<Vec<String>>` | HTML tags to include | Only want content from specific tags |
+| `exclude_tags` | `Option<Vec<String>>` | HTML tags to exclude | Filter out nav, footer, sidebar |
+| `only_main_content` | `Option<bool>` | Extract only main content | Skip headers, navs, footers. Default: `true` |
+| `timeout` | `Option<u32>` | Timeout in milliseconds | Default: 60000. Min: 1000, Max: 300000 |
+| `wait_for` | `Option<u32>` | Milliseconds to wait after page load | Pages needing JS rendering time |
+| `mobile` | `Option<bool>` | Emulate mobile device | Need mobile version |
+| `parsers` | `Option<Vec<ParserConfig>>` | Parser configs (e.g. PDF) | Scraping PDFs. Default: `["pdf"]` |
+| `actions` | `Option<Vec<Action>>` | Browser actions: `Wait`, `Click`, `Write`, `Press`, `Scroll`, `Scrape`, `ExecuteJavascript`, `Screenshot`, `Pdf` | Interact with page before scraping |
+| `location` | `Option<LocationConfig>` | `LocationConfig { country, languages }` | Location-specific content. Default: `"US"` |
+| `skip_tls_verification` | `Option<bool>` | Skip TLS cert verification | Invalid certificates. Default: `true` |
+| `remove_base64_images` | `Option<bool>` | Strip base64 images | Reduce response size. Default: `true` |
+| `fast_mode` | `Option<bool>` | Enable fast mode | Speed over completeness |
+| `block_ads` | `Option<bool>` | Block ads and cookie popups | Default: `true` |
+| `proxy` | `Option<ProxyType>` | Proxy: `Basic`, `Stealth`, `Enhanced`, `Auto` | Anti-bot protections. Default: `Auto` |
+| `max_age` | `Option<u32>` | Max cache age in seconds | Use cached if younger |
+| `min_age` | `Option<u32>` | Min cache age in seconds | Cache-only mode |
+| `store_in_cache` | `Option<bool>` | Cache the result | Default: `true` |
+| `lockdown` | `Option<bool>` | Only serve cached results | No outbound requests |
+| `redact_pii` | `Option<bool>` | Redact PII (serialized as `"redactPII"`) | Sensitive content |
+| `audit_metadata` | `Option<AuditMetadata>` | SIEM audit metadata | Enterprise logging |
+| `profile` | `Option<ProfileConfig>` | `ProfileConfig { name, save_changes }` | Persistent browser state |
+| `integration` | `Option<String>` | Integration identifier | Track integration source |
+| `origin` | `Option<String>` | Origin identifier | Auto-set to `"rust-sdk@{version}"` if `None` |
+| `json_options` | `Option<JsonOptions>` | JSON extraction: `{ schema, system_prompt, prompt }` | Structured data extraction |
+| `screenshot_options` | `Option<ScreenshotOptions>` | Screenshot config: `{ full_page, quality, viewport }` | Custom screenshot settings |
+| `change_tracking_options` | `Option<ChangeTrackingOptions>` | Change tracking: `{ modes, schema, prompt, tag }` | Track page changes |
+| `attribute_selectors` | `Option<Vec<AttributeSelector>>` | Attribute extraction: `{ selector, attribute }` | Extract specific HTML attributes |
+
+**Returns** `Document` with optional fields: `markdown`, `html`, `raw_html`, `json`, `summary`, `links`, `images`, `screenshot`, `audio`, `video`, `metadata`, `actions`, `answer`, `highlights`, `warning`, `change_tracking`, `branding`, `product`, `menu`.
+
+A convenience method `client.scrape_with_schema(url, schema, prompt).await` scrapes with JSON format and returns the extracted `serde_json::Value`.
+
+## Interact
+
+### Why use it
+
+Execute code or natural-language prompts in the browser session associated with a scrape job. Use for post-scrape interactions like clicking buttons, filling forms, or navigating.
+
+### Preferred SDK method
+
+```rust
+client.interact(job_id, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, ScrapeExecuteOptions, Format};
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+
+let doc = client.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown]),
+    ..Default::default()
+}).await?;
+
+let job_id = doc.metadata.as_ref()
+    .and_then(|m| m.get("scrapeId"))
+    .and_then(|v| v.as_str())
+    .expect("scrapeId in metadata");
+
+let result = client.interact(job_id, ScrapeExecuteOptions {
+    code: Some("document.querySelector('button.load-more').click();".into()),
+    language: None,  // defaults to Node
+    timeout: Some(30),
+    ..Default::default()
+}).await?;
+
+println!("{:?}", result.stdout);
+
+// Stop the session when done
+client.stop_interaction(job_id).await?;
+```
+
+### Parameters
+
+All fields on `ScrapeExecuteOptions` are `Option<T>`.
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `code` | `Option<String>` | Code to execute in the browser | Specific code to run. At least one of `code` or `prompt` required |
+| `prompt` | `Option<String>` | Natural-language instruction for browser agent | Let AI perform actions. At least one of `code` or `prompt` required |
+| `language` | `Option<ScrapeExecuteLanguage>` | Execution language: `Python`, `Node`, `Bash` | Default: `Node` |
+| `timeout` | `Option<u32>` | Execution timeout in seconds (1-300) | Default: 30 |
+| `origin` | `Option<String>` | Origin identifier | Auto-set to `"rust-sdk@{version}"` if `None` |
+
+**Returns** `ScrapeExecuteResponse` with `success`, `stdout`, `stderr`, `result`, `exit_code`, `killed`, `error`, `output` (AI response when using `prompt`), `live_view_url`, `interactive_live_view_url`.
+
+Call `client.stop_interaction(job_id).await` when done to end the browser session.
+
+## Notes
+
+- **Async-only**: All methods are `async` and require a Tokio runtime.
+- **`impl Into<Option<T>>` pattern**: `scrape()` and `search()` accept either `None` or a bare options struct (no need to wrap in `Some()`).
+- **Auto-set `origin`**: All endpoints auto-set `origin` to `"rust-sdk@{version}"` if not provided.
+- **Client-side validation**: `interact()` validates that at least one of `code`/`prompt` is non-empty locally, returning `FirecrawlError::Misuse` without a network call.
+- **Serde camelCase**: All structs serialize to camelCase JSON. Unset `Option` fields are omitted entirely.
+- **`redact_pii` rename**: Serialized as `"redactPII"` (not the standard camelCase `"redactPii"`).
+- **Deprecated aliases** (use preferred names):
+  - `scrape_execute()` -> `interact()`
+  - `stop_interactive_browser()` / `delete_scrape_browser()` -> `stop_interaction()`
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/src/v2/client.rs`
+- `firecrawl/apps/rust-sdk/src/v2/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/v2/search.rs`
+- `firecrawl/apps/rust-sdk/Cargo.toml`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary\n\n- Adds canonical one-file-per-language agent quickstart docs covering `search`, `scrape`, and `interact` endpoints\n- Covers all five SDK languages: Node.js/TypeScript, Python, Rust, Java, and Elixir\n- Each file includes install, auth, endpoint examples, and complete parameter references\n- Generated from SDK source code and OpenAPI spec as the sources of truth\n\n## Files added\n\n- `agent-quickstart/node.mdx` — JavaScript/TypeScript (camelCase, Zod schema support, `prompt` for interact)\n- `agent-quickstart/python.mdx` — Python (snake_case, async variant, `prompt` for interact)\n- `agent-quickstart/rust.mdx` — Rust (async-only, struct-based options, `prompt` for interact)\n- `agent-quickstart/java.mdx` — Java (builder pattern, overloads, code-only interact)\n- `agent-quickstart/elixir.mdx` — Elixir (auto-generated function names, keyword lists, code-only interact)\n\n## Key design decisions\n\n- SDK source is treated as primary authority, OpenAPI as secondary confirmation\n- Language-specific differences are documented explicitly (e.g., Java/Elixir interact lacks `prompt`; Elixir has verbose auto-generated function names; Python accepts both snake_case and camelCase format strings)\n- Deprecated aliases listed in Notes sections only, never as the preferred path\n- Parameters only documented when confirmed in SDK source — nothing invented\n\n## Test plan\n\n- [ ] Verify each .mdx file renders cleanly in Mintlify\n- [ ] Spot-check parameter lists against SDK source for each language\n- [ ] Confirm examples use correct method signatures\n\n---\n_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoxS5ZeK35jDjRB57NjzEP)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-docs/pr/1171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787923015&installation_model_id=11126&pr_number=1171&repository=firecrawl%2Ffirecrawl-docs&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-docs%2Fpull%2F1171&signature=35cce590bea1c8ef43ee10e61dcf30a9c1b9aff99f50781eb62b6d6a900b95df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->