### PR TITLE
docs(mcp): align local setup and current tool surface

### DIFF
--- a/developer-guides/mcp-setup-guides/factory-ai.mdx
+++ b/developer-guides/mcp-setup-guides/factory-ai.mdx
@@ -28,7 +28,7 @@ iwr https://app.factory.ai/cli/install.ps1 -useb | iex
 In the Factory droid CLI, add Firecrawl using the `/mcp add` command:
 
 ```bash
-/mcp add firecrawl "npx -y firecrawl-mcp@3.22.4" -e FIRECRAWL_API_KEY=your-api-key-here
+/mcp add firecrawl "npx -y firecrawl-mcp@3.23.0" -e FIRECRAWL_API_KEY=your-api-key-here
 ```
 
 Replace `your-api-key-here` with your actual Firecrawl API key.

--- a/mcp-server/clients.mdx
+++ b/mcp-server/clients.mdx
@@ -16,6 +16,7 @@ Install the hosted keyless server in one click (no API key required):
     alt='Add Firecrawl MCP server to Cursor'
     style={{ maxHeight: 32 }}
   />
+  <span>Install Firecrawl MCP in Cursor</span>
 </a>
 
 Or add it to `~/.cursor/mcp.json` manually:
@@ -98,7 +99,15 @@ To run the server using streamable HTTP transport locally instead of the default
 env HTTP_STREAMABLE_SERVER=true FIRECRAWL_API_KEY=fc-YOUR_API_KEY npx -y firecrawl-mcp@3.22.4
 ```
 
-Use the url: http://localhost:3000/v2/mcp locally, or the hosted https://mcp.firecrawl.dev/v2/mcp
+Use `http://localhost:3000/mcp` for the local server. The `/v2/mcp` route belongs to the hosted service at `https://mcp.firecrawl.dev/v2/mcp`.
+
+Confirm the local process is ready before connecting a client:
+
+```bash
+curl http://localhost:3000/health
+```
+
+The health check returns `ok`. See [Run Firecrawl MCP locally](/mcp-server/local#run-with-streamable-http) for prerequisites and configuration.
 
 ## Installing via Smithery (Legacy)
 
@@ -264,8 +273,10 @@ To connect the Firecrawl MCP server in n8n:
   ```
 
 6. Set **Server Transport** to **HTTP Streamable**
-7. Set **Authentication** to **Bearer** and paste your Firecrawl API key, or leave it as **None** to use the keyless free tier
-8. For **Tools to include**, you can select **All**, **Selected**, or **All Except** - this will expose the Firecrawl tools (scrape, crawl, map, search, extract, etc.)
+7. Choose authentication:
+   - Set **Authentication** to **Bearer** and paste your Firecrawl API key for the full MCP tool surface.
+   - Leave **Authentication** as **None** for the keyless free tier, which exposes only Search, Scrape, and Parse.
+8. For **Tools to include**, choose **All**, **Selected**, or **All Except** from the tools advertised for your authentication mode.
 
 For self-hosted deployments, run the MCP server with npx and enable HTTP transport mode:
 
@@ -276,4 +287,4 @@ env HTTP_STREAMABLE_SERVER=true \
     npx -y firecrawl-mcp@3.22.4
 ```
 
-This will start the server on `http://localhost:3000/v2/mcp` which you can use in your n8n workflow as Endpoint. The `HTTP_STREAMABLE_SERVER=true` environment variable is required since n8n needs HTTP transport.
+This starts the server on `http://localhost:3000/mcp`, which you can use as the n8n endpoint. The `HTTP_STREAMABLE_SERVER=true` environment variable is required because n8n needs HTTP transport.

--- a/mcp-server/clients.mdx
+++ b/mcp-server/clients.mdx
@@ -16,7 +16,7 @@ Install the hosted keyless server in one click (no API key required):
     alt='Add Firecrawl MCP server to Cursor'
     style={{ maxHeight: 32 }}
   />
-  <span>Install Firecrawl MCP in Cursor</span>
+  <span className='fc-sr-only'>Install Firecrawl MCP in Cursor</span>
 </a>
 
 Or add it to `~/.cursor/mcp.json` manually:
@@ -65,9 +65,9 @@ To configure Firecrawl MCP in Cursor **v0.45.6**
 4. Enter the following:
    - Name: "firecrawl-mcp" (or your preferred name)
    - Type: "command"
-   - Command: `env FIRECRAWL_API_KEY=your-api-key npx -y firecrawl-mcp@3.22.4`
+   - Command: `env FIRECRAWL_API_KEY=your-api-key npx -y firecrawl-mcp@3.23.0`
 
-> If you are using Windows and are running into issues, try `cmd /c "set FIRECRAWL_API_KEY=your-api-key && npx -y firecrawl-mcp@3.22.4"`
+> If you are using Windows and are running into issues, try `cmd /c "set FIRECRAWL_API_KEY=your-api-key && npx -y firecrawl-mcp@3.23.0"`
 
 Replace `your-api-key` with your Firecrawl API key. If you don't have one yet, you can create an account and get it from https://www.firecrawl.dev/app/api-keys
 
@@ -96,7 +96,7 @@ Add this to your `./codeium/windsurf/model_config.json`:
 To run the server using streamable HTTP transport locally instead of the default stdio transport:
 
 ```bash
-env HTTP_STREAMABLE_SERVER=true FIRECRAWL_API_KEY=fc-YOUR_API_KEY npx -y firecrawl-mcp@3.22.4
+env HTTP_STREAMABLE_SERVER=true FIRECRAWL_API_KEY=fc-YOUR_API_KEY npx -y firecrawl-mcp@3.23.0
 ```
 
 Use `http://localhost:3000/mcp` for the local server. The `/v2/mcp` route belongs to the hosted service at `https://mcp.firecrawl.dev/v2/mcp`.
@@ -227,7 +227,7 @@ claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/v2/mcp-oauth
 claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/v2/mcp --header "Authorization: Bearer <FIRECRAWL_API_KEY>"
 
 # Or run locally via npx
-claude mcp add firecrawl -e FIRECRAWL_API_KEY=fc-your-api-key -- npx -y firecrawl-mcp@3.22.4
+claude mcp add firecrawl -e FIRECRAWL_API_KEY=fc-your-api-key -- npx -y firecrawl-mcp@3.23.0
 ```
 
 ## Running on Google Antigravity
@@ -284,7 +284,7 @@ For self-hosted deployments, run the MCP server with npx and enable HTTP transpo
 env HTTP_STREAMABLE_SERVER=true \
     FIRECRAWL_API_KEY=fc-YOUR_API_KEY \
     FIRECRAWL_API_URL=YOUR_FIRECRAWL_INSTANCE \
-    npx -y firecrawl-mcp@3.22.4
+    npx -y firecrawl-mcp@3.23.0
 ```
 
 This starts the server on `http://localhost:3000/mcp`, which you can use as the n8n endpoint. The `HTTP_STREAMABLE_SERVER=true` environment variable is required because n8n needs HTTP transport.

--- a/mcp-server/connect.mdx
+++ b/mcp-server/connect.mdx
@@ -43,11 +43,13 @@ Keyless MCP is rate-limited per IP and exposes exactly **Search, Scrape, and Par
 
 ## Pick the right mode
 
-| Mode | Endpoint | Best for | Credentials |
-| --- | --- | --- | --- |
-| Account | `/v2/mcp-oauth` | Interactive clients that can complete browser OAuth | OAuth tokens managed by the client |
-| Unattended | `/v2/mcp` | CI, servers, and scripts | `Authorization: Bearer <FIRECRAWL_API_KEY>` |
-| Keyless | `/v2/mcp` | A limited trial | None |
+| Mode | Endpoint | Available tools | Best for | Credentials |
+| --- | --- | --- | --- | --- |
+| Account | `/v2/mcp-oauth` | Full MCP tool surface, subject to plan and feature availability | Interactive clients that can complete browser OAuth | OAuth tokens managed by the client |
+| Unattended | `/v2/mcp` | Full MCP tool surface, subject to plan and feature availability | CI, servers, and scripts | `Authorization: Bearer <FIRECRAWL_API_KEY>` |
+| Keyless | `/v2/mcp` | Search, Scrape, and Parse only | A limited trial | None |
+
+See [Tools and operations](/mcp-server/tools) for the current tool inventory and local/self-hosted availability notes.
 
 ## Client-specific help
 

--- a/mcp-server/development.mdx
+++ b/mcp-server/development.mdx
@@ -4,27 +4,42 @@ description: Build, test, and contribute to the Firecrawl MCP server.
 sidebarTitle: Development
 ---
 
-## Development
+## Prerequisites
+
+- [Git](https://git-scm.com/downloads)
+- Node.js 22 or newer
+- npm, included with Node.js
+
+Confirm the Node.js version before installing dependencies:
 
 ```bash
-# Install dependencies
+node --version
+```
+
+## Clone and test the server
+
+```bash
+git clone https://github.com/firecrawl/firecrawl-mcp-server.git
+cd firecrawl-mcp-server
 npm install
-
-# Build
 npm run build
-
-# Run tests
 npm test
 ```
 
-### Contributing
+Run the linter before submitting a change:
 
-1. Fork the repository
-2. Create your feature branch
-3. Run tests: `npm test`
-4. Submit a pull request
+```bash
+npm run lint
+```
 
-### Thanks to contributors
+## Contributing
+
+1. Fork the [Firecrawl MCP server repository](https://github.com/firecrawl/firecrawl-mcp-server).
+2. Clone your fork and create a feature branch.
+3. Run `npm run lint` and `npm test`.
+4. Submit a pull request with the behavior and verification evidence.
+
+## Thanks to contributors
 
 Thanks to [@vrknetha](https://github.com/vrknetha), [@cawstudios](https://caw.tech) for the initial implementation!
 

--- a/mcp-server/local.mdx
+++ b/mcp-server/local.mdx
@@ -4,16 +4,60 @@ description: Install and configure the local Firecrawl MCP server.
 sidebarTitle: Run locally
 ---
 
-## Run locally
+## Prerequisites
+
+- Node.js 22 or newer
+- npm and `npx`, included with Node.js
+- A Firecrawl API key for the cloud API, or a self-hosted Firecrawl API URL
+
+Confirm the installed Node.js version:
+
+```bash
+node --version
+```
+
+## Run over stdio
 
 ```bash
 env FIRECRAWL_API_KEY=fc-YOUR_API_KEY npx -y firecrawl-mcp@3.22.4
 ```
 
+This is the default transport for clients that launch the MCP server as a local process.
+
+## Run with Streamable HTTP
+
+Use HTTP transport for clients such as n8n that connect to an already-running MCP server:
+
+```bash
+env HTTP_STREAMABLE_SERVER=true \
+  FIRECRAWL_API_KEY=fc-YOUR_API_KEY \
+  npx -y firecrawl-mcp@3.22.4
+```
+
+Connect the client to:
+
+```text
+http://localhost:3000/mcp
+```
+
+Confirm the server is ready:
+
+```bash
+curl http://localhost:3000/health
+```
+
+The health check returns `ok`. The local route is `/mcp`; `/v2/mcp` is the hosted Firecrawl route.
+
 ## Install globally
 
 ```bash
-npm install -g firecrawl-mcp
+npm install -g firecrawl-mcp@3.22.4
+```
+
+Then run:
+
+```bash
+env FIRECRAWL_API_KEY=fc-YOUR_API_KEY firecrawl-mcp
 ```
 
 ## Configuration
@@ -66,9 +110,13 @@ Add this to your `claude_desktop_config.json`:
 
 The hosted MCP server is optimized for safe remote use. Some options that are available when running the MCP server locally are narrowed or unavailable remotely:
 
-- Hosted keyless mode exposes only the keyless-supported tools and is rate-limited per IP.
+- Hosted keyless mode exposes only Search, Scrape, and Parse and is rate-limited per IP.
 - Local-only file reads are available only when you run the MCP server locally.
 - Webhooks and local file paths should be configured from a local or self-hosted MCP server when the agent needs access to local resources.
+
+<Note>
+Direct local-file parsing with `firecrawl_parse` requires `FIRECRAWL_API_URL` pointing to a self-hosted Firecrawl API. A local MCP server configured only with a cloud API key cannot upload a local file through that tool.
+</Note>
 
 ### Rate Limiting
 

--- a/mcp-server/local.mdx
+++ b/mcp-server/local.mdx
@@ -19,7 +19,7 @@ node --version
 ## Run over stdio
 
 ```bash
-env FIRECRAWL_API_KEY=fc-YOUR_API_KEY npx -y firecrawl-mcp@3.22.4
+env FIRECRAWL_API_KEY=fc-YOUR_API_KEY npx -y firecrawl-mcp@3.23.0
 ```
 
 This is the default transport for clients that launch the MCP server as a local process.
@@ -31,7 +31,7 @@ Use HTTP transport for clients such as n8n that connect to an already-running MC
 ```bash
 env HTTP_STREAMABLE_SERVER=true \
   FIRECRAWL_API_KEY=fc-YOUR_API_KEY \
-  npx -y firecrawl-mcp@3.22.4
+  npx -y firecrawl-mcp@3.23.0
 ```
 
 Connect the client to:
@@ -51,7 +51,7 @@ The health check returns `ok`. The local route is `/mcp`; `/v2/mcp` is the hoste
 ## Install globally
 
 ```bash
-npm install -g firecrawl-mcp@3.22.4
+npm install -g firecrawl-mcp@3.23.0
 ```
 
 Then run:

--- a/mcp-server/tools.mdx
+++ b/mcp-server/tools.mdx
@@ -4,6 +4,20 @@ description: Available tools, operational behavior, and error handling for Firec
 sidebarTitle: Tools and operations
 ---
 
+The tools listed here describe the full Firecrawl MCP server surface. Tool availability depends on how you connect.
+
+| Connection mode | Tool availability |
+| --- | --- |
+| Hosted account OAuth | Full tool surface, subject to plan and feature availability |
+| Hosted API key | Full tool surface, subject to plan and feature availability |
+| Hosted keyless | `firecrawl_search`, `firecrawl_scrape`, and `firecrawl_parse` only |
+| Local MCP with a cloud API key | API-backed tools; direct local-file Parse requires a self-hosted API URL |
+| Local MCP with a self-hosted API | Tools supported by the services enabled in that deployment |
+
+<Note>
+Some optional tools can be disabled by environment or team policy. Start with [Connect Firecrawl MCP](/mcp-server/connect) to choose an authentication mode, and see [Rate limits](/rate-limits#keyless-no-api-key) for the current keyless allowance.
+</Note>
+
 ## Available Tools
 
 ### 1. Scrape Tool (`firecrawl_scrape`)
@@ -99,6 +113,47 @@ Search the web and optionally extract content from search results.
 - `sources`: Array of source types to search (`web`, `images`, `news`)
 - `scrapeOptions`: Options for scraping search result pages
 - `enterprise`: Array of enterprise options (`default`, `anon`, `zdr`)
+
+### 3b. Search Feedback Tool (`firecrawl_search_feedback`)
+
+Send structured feedback after using `firecrawl_search`. The first feedback submission for a search ID can refund one credit, subject to the daily team cap.
+
+```json
+{
+  "name": "firecrawl_search_feedback",
+  "arguments": {
+    "searchId": "search-id-from-firecrawl-search",
+    "rating": "good",
+    "valuableSources": [
+      {
+        "url": "https://docs.firecrawl.dev/mcp-server",
+        "reason": "Contains the current connection guidance."
+      }
+    ]
+  }
+}
+```
+
+Set `FIRECRAWL_NO_SEARCH_FEEDBACK=1` to prevent this optional tool from being registered.
+
+### 3c. Generic Feedback Tool (`firecrawl_feedback`)
+
+Send concise endpoint-level feedback for completed Scrape, Parse, Map, or Search jobs. Do not include raw scraped or parsed content.
+
+```json
+{
+  "name": "firecrawl_feedback",
+  "arguments": {
+    "endpoint": "scrape",
+    "jobId": "job-id",
+    "rating": "partial",
+    "issues": ["missing_markdown"],
+    "url": "https://example.com"
+  }
+}
+```
+
+Use `firecrawl_search_feedback` for search-result quality. Set `FIRECRAWL_NO_ENDPOINT_FEEDBACK=1` to prevent the generic feedback tool from being registered.
 
 ### 4. Parse Tool (`firecrawl_parse`)
 
@@ -365,6 +420,49 @@ Stop an interact session for a scraped page. Call this when you are done interac
 - `scrapeId`: The scrape ID for the session to stop (required)
 
 **Returns:** Confirmation that the session has been stopped.
+
+### 12. Research Tools (`firecrawl_research_*`)
+
+Use the read-only research tools for literature review, paper inspection, citation discovery, and public GitHub repository search.
+
+| Tool | Purpose |
+| --- | --- |
+| `firecrawl_research_search_papers` | Search research papers |
+| `firecrawl_research_inspect_paper` | Inspect one paper's metadata and details |
+| `firecrawl_research_related_papers` | Find papers related to an anchor paper |
+| `firecrawl_research_read_paper` | Read available paper content |
+| `firecrawl_research_search_github` | Search public GitHub repositories |
+
+These tools are not part of the hosted keyless surface.
+
+### 13. Monitor Tools (`firecrawl_monitor_*`)
+
+Create and manage recurring page monitors. Monitors run scheduled checks, compare results with retained snapshots, and can notify through webhooks or email.
+
+```json
+{
+  "name": "firecrawl_monitor_create",
+  "arguments": {
+    "page": "https://example.com/pricing",
+    "goal": "Alert when pricing, packaging, or launch messaging changes."
+  }
+}
+```
+
+| Tool | Purpose |
+| --- | --- |
+| `firecrawl_monitor_create` | Create a page or crawl monitor |
+| `firecrawl_monitor_list` | List monitors |
+| `firecrawl_monitor_get` | Get one monitor |
+| `firecrawl_monitor_update` | Update a monitor |
+| `firecrawl_monitor_run` | Trigger a check now |
+| `firecrawl_monitor_delete` | Delete a monitor |
+| `firecrawl_monitor_checks` | List checks for a monitor |
+| `firecrawl_monitor_check` | Get one page-level check and its diff |
+
+<Warning>
+`firecrawl_monitor_delete` permanently removes a monitor. An MCP client should call it only when the user explicitly intends to delete that monitor.
+</Warning>
 
 ## Logging System
 

--- a/quickstarts/claude-code.mdx
+++ b/quickstarts/claude-code.mdx
@@ -23,7 +23,7 @@ After adding the server, use `/mcp` in Claude Code to complete the Firecrawl sig
 **Option B: Local (npx)**
 
 ```bash
-claude mcp add firecrawl -e FIRECRAWL_API_KEY=your-api-key -- npx -y firecrawl-mcp@3.22.4
+claude mcp add firecrawl -e FIRECRAWL_API_KEY=your-api-key -- npx -y firecrawl-mcp@3.23.0
 ```
 
 Replace `your-api-key` with your actual Firecrawl API key.


### PR DESCRIPTION
## Summary

- correct the local Streamable HTTP route to `/mcp` and add the `/health` readiness check
- clarify account, API-key, keyless, local, and self-hosted tool availability
- document all 26 tools registered by `firecrawl-mcp@3.22.4`, including feedback, monitoring, and research tools
- distinguish n8n Bearer-authenticated tools from the three-tool hosted keyless surface
- make the development path executable from a fresh checkout with Git, Node.js 22+, npm, build, test, and lint steps
- preserve every existing public route and leave localized files unchanged

## Verification

- `git diff --check`
- `sh scripts/check-hosted-mcp-docs.sh`
- `node --check` against the extracted `firecrawl-mcp@3.22.4` bundle
- matched 26 registered package tools to 26 documented tools with zero missing
- rendered the introduction, MCP overview, and all five changed MCP routes with `mint dev`
- reran the Claude Code documentation journey: 10/10 before and 10/10 after
- observed a live `firecrawl-mcp@3.22.4` process start at `http://localhost:3000/mcp`
- SEO inventory: 1,320 → 1,320 routes, with zero added or removed

## Repository-wide baseline

- `mint broken-links` reports 214 links in 101 files; none of the five changed English MCP files appears in the failure list
- `mint a11y` reports 113 issues in 35 files plus the existing dark-color contrast failure; none of the five changed English MCP files appears in the final issue list

## Scope note

The published package README still describes a different hosted keyless tool set. Updating the MCP server repository was outside this documentation-only change and should be handled as a follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-docs/pr/1173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787971653&installation_model_id=11126&pr_number=1173&repository=firecrawl%2Ffirecrawl-docs&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-docs%2Fpull%2F1173&signature=20c781313a44a51de2ec7a501c7d439b1bff3abb53fc26ada154a7e6b85330ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->