### PR TITLE
docs: refresh agent source-of-truth quickstarts from latest SDK source

### DIFF
--- a/agent-source-of-truth/curl.mdx
+++ b/agent-source-of-truth/curl.mdx
@@ -1,492 +1,295 @@
 ---
 title: "Curl Source of Truth"
-description: "Canonical Firecrawl curl source of truth for agents using key endpoints like search, scrape, and interact."
+description: "Canonical Firecrawl curl source of truth for agents using search, scrape, and interact."
 ---
 
-Canonical Firecrawl curl source of truth for agents. Aligned with `api-reference/v2-openapi.json` (server base URL `https://api.firecrawl.dev/v2`).
+# Firecrawl Curl Agent Quickstart
+
+This file is the canonical quickstart for external agents using the Firecrawl REST API directly. It is generated from the Firecrawl OpenAPI spec (`v2-openapi.json`).
+
+## Base URL
+
+```
+https://api.firecrawl.dev/v2
+```
 
 ## Authenticate
 
+Pass your API key in the `Authorization` header:
+
 ```bash
-export FIRECRAWL_API_KEY="fc-your-api-key"
+curl -X POST https://api.firecrawl.dev/v2/scrape \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}'
 ```
+
+The API key can be omitted for the keyless free tier (rate-limited per IP) on scrape, search, and interact.
 
 ## When To Use What
 
-- `search`: use when you start with a query and need discovery.
-- `scrape`: use when you already have a URL and want page content.
-- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
-- `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
-- `support/docs-search`: use when you need to look up Firecrawl documentation.
+- **`POST /search`** — Use when you start with a query and need to discover relevant URLs. Returns search results and optionally scrapes each result page.
+- **`POST /scrape`** — Use when you already have a URL and want page content (markdown, HTML, screenshots, structured JSON, etc.).
+- **`POST /scrape/{jobId}/interact`** — Use when the page needs post-scrape browser actions: executing code in the live browser session.
 
 ## Search
 
 ### Why use it
 
-Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. You can constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+Search the web for a query and get back results with metadata. Optionally scrape each result page by passing `scrapeOptions`.
 
 ### Endpoint
 
-`POST /search`
-
-### Simple Example
-
-```bash
-curl -X POST "https://api.firecrawl.dev/v2/search" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "site:docs.firecrawl.dev webhook retries"
-  }'
+```
+POST /v2/search
 ```
 
-### Complex Example
+### Example
 
 ```bash
-curl -X POST "https://api.firecrawl.dev/v2/search" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+curl -X POST https://api.firecrawl.dev/v2/search \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "query": "site:docs.firecrawl.dev crawl webhooks",
-    "sources": [{"type": "web"}, {"type": "news"}],
-    "categories": [{"type": "research"}],
-    "limit": 10,
-    "tbs": "qdr:m",
-    "location": "San Francisco,California,United States",
-    "country": "US",
-    "ignoreInvalidURLs": true,
-    "timeout": 60000,
-    "enterprise": ["anon"],
+    "query": "firecrawl web scraping API",
+    "limit": 5,
     "scrapeOptions": {
-      "formats": [
-        "markdown",
-        "links",
-        {"type": "json", "prompt": "Extract title and key endpoints."}
-      ],
-      "onlyMainContent": true,
-      "includeTags": ["main", "article"],
-      "excludeTags": ["nav", "footer"],
-      "waitFor": 1000
+      "formats": ["markdown"]
     }
   }'
 ```
 
-### Response
-
-Successful responses include `success`, `data`, optional `warning`, `id`, and `creditsUsed`.
-
-- `data.web`, `data.images`, `data.news`: result arrays; which keys appear depends on `sources` (by default only `data.web` is populated).
-- Web and news items include fields such as `title`, `url`, and (when `scrapeOptions` / formats request it) `markdown`, `html`, `rawHtml`, `links`, `screenshot`, `audio`, `video`, and `metadata`.
-- Image items include fields such as `imageUrl`, `url`, and dimensions when available.
-- `warning`: optional human-readable notice.
-- `id`: search job id string.
-- `creditsUsed`: integer credits charged for the call.
-
 ### Parameters
 
-- `query`
-  - Type: string (required, max length 500)
-  - Use when: you need a search query.
-  - Notes: use `site:example.com` to limit results to a domain.
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `query` | `string` | **Yes** | — | The search query. Max length: 500. |
+| `sources` | `array` | No | `["web"]` | Sources to search. Each item: `{"type": "web"}`, `{"type": "news"}`, or `{"type": "images"}`. |
+| `categories` | `array` | No | `[]` | Category filters. Each item: `{"type": "github"}`, `{"type": "research"}`, or `{"type": "pdf"}`. |
+| `includeDomains` | `string[]` | No | — | Restrict to these domains (hostnames only). Cannot use with `excludeDomains`. |
+| `excludeDomains` | `string[]` | No | — | Exclude these domains. Cannot use with `includeDomains`. |
+| `limit` | `integer` | No | `10` | Max results per source type. Min: 1, Max: 100. |
+| `tbs` | `string` | No | — | Time-based search filter. `"qdr:h"` (hour), `"qdr:d"` (day), `"qdr:w"` (week), `"qdr:m"` (month), `"qdr:y"` (year). Custom: `"cdr:1,cd_min:MM/DD/YYYY,cd_max:MM/DD/YYYY"`. Sort by date: `"sbd:1"`. Combinable: `"sbd:1,qdr:w"`. |
+| `location` | `string` | No | — | Location for geo-targeted results (e.g. `"San Francisco,California,United States"`). |
+| `country` | `string` | No | `"US"` | ISO country code. |
+| `timeout` | `integer` | No | `60000` | Timeout in milliseconds. |
+| `ignoreInvalidURLs` | `boolean` | No | `false` | Skip invalid URLs. |
+| `highlights` | `boolean` | No | `true` | Generate query-relevant highlights. |
+| `enterprise` | `string[]` | No | — | Enterprise options: `["anon"]` for anonymized ZDR, `["zdr"]` for full ZDR. |
+| `scrapeOptions` | `object` | No | `{}` | Options for scraping each result page (same schema as scrape body). |
+| `threatProtection` | `object` | No | — | Per-request threat protection override (enterprise). |
 
-- `sources`
-  - Type: array of typed source objects
-  - Use when: you want to control which sources are searched.
-  - Confirmed object shapes:
-    - `{ "type": "web" }` with optional per-source `tbs` and `location`
-    - `{ "type": "news" }`
-    - `{ "type": "images" }`
+### Response
 
-- `categories`
-  - Type: array of typed category objects
-  - Use when: you want to filter results by category.
-  - Confirmed object shapes:
-    - `{ "type": "github" }`
-    - `{ "type": "research" }`
-    - `{ "type": "pdf" }`
-
-- `limit`
-  - Type: integer (minimum 1, maximum 100, default 5)
-  - Use when: you want to cap results.
-
-- `tbs`
-  - Type: string
-  - Use when: you need a time-based filter (for example `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
-
-- `location`
-  - Type: string
-  - Use when: you want localized results.
-
-- `country`
-  - Type: string (default `"US"`)
-  - Use when: you want ISO 3166-1 alpha-2 targeting (for example `"US"`).
-
-- `ignoreInvalidURLs`
-  - Type: boolean (default false)
-  - Use when: you want to drop URLs that cannot be scraped by other endpoints.
-
-- `timeout`
-  - Type: integer (milliseconds, default 60000)
-  - Use when: you need a request timeout in milliseconds.
-
-- `enterprise`
-  - Type: array of strings (`"anon"` or `"zdr"` per item)
-  - Use when: you need enterprise search controls.
-  - Values:
-    - `"zdr"`: end-to-end zero data retention
-    - `"anon"`: anonymized zero data retention
-
-- `scrapeOptions`
-  - Type: object
-  - Use when: you want to scrape each search result (see Scrape parameters for fields).
+```json
+{
+  "success": true,
+  "data": {
+    "web": [{"url": "...", "title": "...", "description": "...", "markdown": "..."}],
+    "news": [{"title": "...", "snippet": "...", "url": "...", "date": "..."}],
+    "images": [{"title": "...", "imageUrl": "...", "url": "..."}]
+  },
+  "warning": null,
+  "id": "search-job-id",
+  "creditsUsed": 1
+}
+```
 
 ## Scrape
 
 ### Why use it
 
-Use scrape when you already have a URL and want structured content in one or more formats.
+Scrape a single URL and get back its content in one or more formats. Supports markdown, HTML, screenshots, structured JSON extraction, and more.
 
 ### Endpoint
 
-`POST /scrape`
+```
+POST /v2/scrape
+```
 
-### Simple Example
+### Example
 
 ```bash
-curl -X POST "https://api.firecrawl.dev/v2/scrape" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+curl -X POST https://api.firecrawl.dev/v2/scrape \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "url": "https://docs.firecrawl.dev",
-    "formats": ["markdown"]
+    "url": "https://example.com",
+    "formats": ["markdown", "links"]
   }'
 ```
 
-### Complex Example
+Structured JSON extraction:
 
 ```bash
-curl -X POST "https://api.firecrawl.dev/v2/scrape" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+curl -X POST https://api.firecrawl.dev/v2/scrape \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "url": "https://example.com/pricing",
-    "formats": [
-      "markdown",
-      "links",
-      {"type": "json", "prompt": "Extract plan names and prices."},
-      {"type": "screenshot", "fullPage": true, "quality": 80, "viewport": {"width": 1280, "height": 720}},
-      {"type": "changeTracking", "modes": ["git-diff"], "tag": "pricing"}
-    ],
-    "headers": {"User-Agent": "FirecrawlDocsBot/1.0"},
-    "onlyMainContent": true,
-    "waitFor": 1000,
-    "parsers": [{"type": "pdf", "mode": "auto", "maxPages": 5}],
-    "actions": [
-      {"type": "click", "selector": "#accept"},
-      {"type": "wait", "milliseconds": 750},
-      {"type": "scrape"}
-    ],
-    "location": {"country": "US", "languages": ["en-US"]},
-    "removeBase64Images": true,
-    "blockAds": true,
-    "proxy": "auto",
-    "maxAge": 86400000,
-    "minAge": 1,
-    "storeInCache": true,
-    "profile": {"name": "docs-session", "saveChanges": true},
-    "zeroDataRetention": false
+    "url": "https://example.com/product",
+    "formats": [{"type": "json", "schema": {"type": "object", "properties": {"title": {"type": "string"}, "price": {"type": "number"}}}}]
   }'
 ```
-
-### Response
-
-Successful responses include `success` and `data`. Common `data` fields (depending on `formats` and options):
-
-- `markdown`, `summary`, `html`, `rawHtml`, `screenshot`, `audio`, `video`, `links`
-- `actions`: when the request included scrape-time `actions`, contains ordered results such as `screenshots`, `scrapes`, `javascriptReturns`, and `pdfs`
-- `metadata`: page metadata (`title`, `sourceURL`, `url`, `statusCode`, `error`, and other extracted fields)
-- `warning`: optional extraction or formatting notice
-- `changeTracking`: present when the `changeTracking` format is requested
 
 ### Parameters
 
-- `url`
-  - Type: string
-  - Use when: you want to scrape a specific page.
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `url` | `string` (URI) | **Yes** | — | The URL to scrape. |
+| `formats` | `array` | No | `["markdown"]` | Output formats. See **Format types** below. |
+| `onlyMainContent` | `boolean` | No | `true` | Only return main content. |
+| `onlyCleanContent` | `boolean` | No | `false` | Beta. LLM-based removal of residual boilerplate. |
+| `includeTags` | `string[]` | No | — | HTML tags to include. |
+| `excludeTags` | `string[]` | No | — | HTML tags to exclude. |
+| `headers` | `object` | No | — | Custom HTTP headers. |
+| `timeout` | `integer` | No | `60000` | Timeout in ms. Min: 1000, Max: 300000. |
+| `waitFor` | `integer` | No | `0` | Wait time in ms before scraping. |
+| `mobile` | `boolean` | No | `false` | Emulate mobile device. |
+| `skipTlsVerification` | `boolean` | No | `true` | Skip TLS verification. |
+| `parsers` | `array` | No | `["pdf"]` | Parser config. Each item: `"pdf"` or `{"type": "pdf", "mode": "fast"\|"auto"\|"ocr", "maxPages": N}`. |
+| `actions` | `array` | No | — | Browser actions. See **Action types** below. |
+| `location` | `object` | No | — | `{"country": "US", "languages": ["en-US"]}`. |
+| `removeBase64Images` | `boolean` | No | `true` | Remove base64 images from markdown. |
+| `blockAds` | `boolean` | No | `true` | Block ads and cookie popups. |
+| `proxy` | `string` | No | `"auto"` | `"basic"`, `"enhanced"`, `"auto"`. |
+| `maxAge` | `integer` | No | `172800000` | Max cache age in ms (default 2 days). |
+| `minAge` | `integer` | No | — | Min cache age. Only checks cache, never fresh scrape. Set to `1` for any cached data. |
+| `storeInCache` | `boolean` | No | `true` | Store result in cache. |
+| `lockdown` | `boolean` | No | `false` | Serve only cached results. 404 on miss. |
+| `redactPII` | `boolean \| object` | No | `false` | Redact PII. Object: `{"mode": "accurate", "entities": ["PERSON","EMAIL"], "replaceStyle": "tag"}`. |
+| `zeroDataRetention` | `boolean` | No | `false` | Enable zero data retention. |
+| `profile` | `object` | No | — | `{"name": "my-profile", "saveChanges": true}`. |
+| `threatProtection` | `object` | No | — | Per-request threat protection override (enterprise). |
+| `auditMetadata` | `object` | No | — | `{"username": "agent-name"}`. |
 
-- `formats`
-  - Type: array of format strings or format objects
-  - Use when: you want multiple output formats.
-  - Confirmed format strings:
-    - `"markdown"`: markdown content
-    - `"html"`: cleaned HTML
-    - `"rawHtml"`: raw HTML
-    - `"links"`: page links
-    - `"images"`: image URLs
-    - `"screenshot"`: screenshot output
-    - `"summary"`: summary output
-    - `"changeTracking"`: change tracking output
-    - `"json"`: JSON extraction
-    - `"branding"`: branding profile output
-    - `"audio"`: audio extraction
-    - `"video"`: video extraction
-  - Format object fields:
-    - `type`: one of the format strings above
-    - `prompt`, `schema`: JSON extraction options for `type: "json"`
-    - `modes`, `schema`, `prompt`, `tag`: change tracking options for `type: "changeTracking"`
-    - `fullPage`, `quality`, `viewport`: screenshot options for `type: "screenshot"`
+### Format types
 
-- `headers`
-  - Type: object
-  - Use when: you need custom request headers.
+Each item in `formats` is either a string or an object with a `type` field:
 
-- `includeTags`
-  - Type: array of strings
-  - Use when: you want to include only specific HTML tags.
+| Type | Extra fields | Description |
+|---|---|---|
+| `"markdown"` | — | Markdown output |
+| `"html"` | — | Cleaned HTML |
+| `"rawHtml"` | — | Exact unmodified HTML |
+| `"links"` | — | List of links |
+| `"images"` | — | Images |
+| `"summary"` | — | Page summary |
+| `"screenshot"` | `fullPage`, `quality`, `viewport` | Screenshot (expires 24h) |
+| `"json"` | `schema` (JSON Schema), `prompt` | LLM extraction to JSON |
+| `"changeTracking"` | `modes` (`["git-diff","json"]`), `schema`, `prompt`, `tag` | Change tracking |
+| `"branding"` | — | Brand info |
+| `"product"` | — | Product info |
+| `"menu"` | — | Menu extraction |
+| `"audio"` | — | Audio from video URLs (signed URL, 1h) |
+| `"video"` | — | Video extraction (signed URL, 1h) |
+| `"question"` | `question` (required) | Ask a question about the page |
+| `"highlights"` | `query` (required) | Find relevant source text |
 
-- `excludeTags`
-  - Type: array of strings
-  - Use when: you want to exclude specific HTML tags.
+### Action types
 
-- `onlyMainContent`
-  - Type: boolean
-  - Use when: you want to strip nav, footer, and other boilerplate.
+| Type | Required fields | Optional fields | Description |
+|---|---|---|---|
+| `"wait"` | `milliseconds` or `selector` | — | Wait by duration or for element |
+| `"screenshot"` | — | `fullPage`, `quality`, `viewport` | Take screenshot |
+| `"click"` | `selector` | `all` | Click element(s) |
+| `"write"` | `text` | — | Type text into focused element |
+| `"press"` | `key` | — | Press a key |
+| `"scroll"` | — | `direction` (`"up"`/`"down"`), `selector` | Scroll |
+| `"scrape"` | — | — | Scrape current page |
+| `"executeJavascript"` | `script` | — | Execute JS |
+| `"pdf"` | — | `format`, `landscape`, `scale` | Generate PDF |
 
-- `timeout`
-  - Type: number
-  - Use when: you need a timeout in milliseconds.
+### Response
 
-- `waitFor`
-  - Type: number
-  - Use when: you need to wait for the page to render (milliseconds).
-
-- `mobile`
-  - Type: boolean
-  - Use when: you want a mobile viewport.
-
-- `parsers`
-  - Type: array of objects
-  - Use when: you need file parsing controls.
-  - Confirmed shape: `{ "type": "pdf", "mode": "fast" | "auto" | "ocr", "maxPages": number }` (`type` required; other fields optional with defaults per spec)
-
-- `actions`
-  - Type: array of action objects
-  - Use when: you need lightweight pre-scrape actions.
-  - Confirmed action types:
-    - `wait`: `milliseconds` or `selector` required
-    - `screenshot`: `fullPage`, `quality`, `viewport` optional
-    - `click`: `selector` required, `all` optional
-    - `write`: `text` required (click to focus the input first)
-    - `press`: `key` required
-    - `scroll`: `type` required; `direction` (`up` or `down`, default `down`); optional `selector`
-    - `scrape`: no additional fields
-    - `executeJavascript`: `script` required
-    - `pdf`: `format` (A0, A1, A2, A3, A4, A5, A6, Letter, Legal, Tabloid, Ledger), `landscape`, `scale` optional
-
-- `location`
-  - Type: object with `country` and `languages`
-  - Use when: you need geo or language-aware scraping.
-
-- `skipTlsVerification`
-  - Type: boolean
-  - Use when: you need to skip TLS verification.
-
-- `removeBase64Images`
-  - Type: boolean
-  - Use when: you want to drop base64 images from markdown output.
-
-- `blockAds`
-  - Type: boolean
-  - Use when: you want ad and cookie popup blocking.
-
-- `proxy`
-  - Type: string
-  - Use when: you need proxy control.
-  - Confirmed values: `"basic"`, `"enhanced"`, `"auto"`
-
-- `maxAge`
-  - Type: number
-  - Use when: you want cached data up to a maximum age (milliseconds).
-
-- `minAge`
-  - Type: number
-  - Use when: you want cached data only if it is at least this old (milliseconds).
-
-- `storeInCache`
-  - Type: boolean
-  - Use when: you want Firecrawl to cache the result.
-
-- `profile`
-  - Type: object with `name` and optional `saveChanges`
-  - Use when: you want a persistent browser profile shared across scrapes and interactions.
-
-- `zeroDataRetention`
-  - Type: boolean
-  - Use when: you want zero data retention for this scrape.
+```json
+{
+  "success": true,
+  "data": {
+    "markdown": "...",
+    "html": null,
+    "rawHtml": null,
+    "screenshot": null,
+    "links": ["..."],
+    "metadata": {
+      "title": "...",
+      "description": "...",
+      "sourceURL": "https://example.com",
+      "url": "https://example.com",
+      "statusCode": 200
+    },
+    "warning": null
+  }
+}
+```
 
 ## Interact
 
 ### Why use it
 
-Use interact when a page requires browser actions or code execution after a scrape starts.
+Execute code in the live browser session that was created by a prior scrape call. Use this for multi-step workflows: running scripts, navigating, or extracting additional data from the page.
 
 ### Endpoint
 
-`POST /scrape/{jobId}/interact`
-
-### Simple Example
-
-```bash
-curl -X POST "https://api.firecrawl.dev/v2/scrape/<jobId>/interact" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "code": "console.log(await page.title());"
-  }'
+```
+POST /v2/scrape/{jobId}/interact
 ```
 
-### Complex Example
+### Example
 
 ```bash
-curl -X POST "https://api.firecrawl.dev/v2/scrape/<jobId>/interact" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+curl -X POST https://api.firecrawl.dev/v2/scrape/JOB_ID/interact \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "code": "const title = await page.title();\nconst h1 = await page.locator(\"h1\").first().textContent().catch(() => null);\nconsole.log(JSON.stringify({ title, h1 }));",
+    "code": "document.title",
     "language": "node",
-    "timeout": 120
+    "timeout": 30
   }'
 ```
 
 ### Parameters
 
-- `jobId` (path)
-  - Type: string (UUID)
-  - Use when: you have the scrape job id for the live browser session.
-
-- `code` (JSON body)
-  - Type: string (required in OpenAPI; min length 1, max length 100000)
-  - Use when: you want to run code in the scrape-bound browser sandbox.
-
-- `language` (JSON body)
-  - Type: string
-  - Use when: you need a specific runtime.
-  - Confirmed values: `"python"`, `"node"`, `"bash"` (default `"node"`)
-
-- `timeout` (JSON body)
-  - Type: integer (seconds; minimum 1, maximum 300, default 30)
-  - Use when: you need an execution timeout.
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `jobId` | `string` (UUID) | **Yes** | — | Path parameter. The scrape job ID. |
+| `code` | `string` | **Yes** | — | Code to execute. Min: 1, Max: 100000 chars. |
+| `language` | `string` | No | `"node"` | `"python"`, `"node"`, or `"bash"`. |
+| `timeout` | `integer` | No | `30` | Timeout in seconds. Min: 1, Max: 300. |
+| `origin` | `string` | No | — | Origin label for telemetry. |
 
 ### Response
 
-Successful responses include `success` plus execution fields such as `stdout`, `result` (alias of stdout), `stderr`, `exitCode`, `killed`, and `error` (nullable).
-
-### DELETE /scrape/{jobId}/interact
-
-### Example
-
-```bash
-curl -X DELETE "https://api.firecrawl.dev/v2/scrape/<jobId>/interact" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY"
+```json
+{
+  "success": true,
+  "cdpUrl": null,
+  "liveViewUrl": "https://...",
+  "interactiveLiveViewUrl": "https://...",
+  "output": null,
+  "stdout": "Example Domain",
+  "result": "Example Domain",
+  "stderr": null,
+  "exitCode": 0,
+  "killed": false,
+  "error": null
+}
 ```
 
-No JSON body. A successful response includes `success`.
-
-## Ask (Agentic Debugging)
-
-### Why use it
-
-Use ask when a Firecrawl API call fails or returns unexpected results. The AI support agent diagnoses the issue, proposes fix parameters, and optionally validates the fix against the live API. Typical latency: 15-30 seconds.
-
-### Endpoint
-
-`POST /support/ask`
-
-### Simple Example
+### Stop interaction
 
 ```bash
-curl -X POST "https://api.firecrawl.dev/v2/support/ask" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "question": "my scrape returned empty markdown for https://example.com"
-  }'
+curl -X DELETE https://api.firecrawl.dev/v2/scrape/JOB_ID/interact \
+  -H "Authorization: Bearer fc-YOUR_API_KEY"
 ```
 
-### Complex Example
-
-```bash
-curl -X POST "https://api.firecrawl.dev/v2/support/ask" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "question": "crawl returned 3 pages but I expected 50",
-    "rationale": "user is on their third failed crawl attempt today",
-    "context": {"userPlan": "standard", "retryCount": 3}
-  }'
-```
-
-### Response
-
-Successful responses include `requestId`, `answer`, `confidence`, `fixParameters`, `validation`, `usage`, and `durationMs`.
-
-- `answer`: 2-4 sentence prose covering the diagnosis and fix.
-- `confidence`: `high`, `medium`, or `low`.
-- `fixParameters`: machine-actionable API parameters to apply the fix (null if no fix applies).
-- `validation.tested`: whether the agent tested the fix against the live API.
-- `validation.result`: `success`, `failure`, or `skipped`.
-- `feedback`: present when the agent gets stuck; null on success.
-
-### Parameters
-
-- `question`
-  - Type: string (required, 1-8000 chars)
-  - Use when: you need to describe the issue.
-
-- `rationale`
-  - Type: string (1-2000 chars)
-  - Use when: you are an AI agent calling on behalf of a user. Describe what the user is trying to accomplish.
-
-- `context`
-  - Type: object (free-form)
-  - Use when: you want to pass metadata from your agent into the debugging prompt.
-
-## Docs Search
-
-### Why use it
-
-Use docs-search to look up Firecrawl documentation.
-
-### Endpoint
-
-`POST /support/docs-search`
-
-### Example
-
-```bash
-curl -X POST "https://api.firecrawl.dev/v2/support/docs-search" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "question": "how do I verify webhook signatures?"
-  }'
-```
-
-### Parameters
-
-- `question`
-  - Type: string (required, 1-8000 chars)
-  - Use when: you need a docs-grounded answer.
+Response: `{"success": true, "sessionDurationMs": 12345, "creditsBilled": 1}`.
 
 ## Notes
 
-- Search result rows are nested under `data.web`, `data.images`, or `data.news`, not as a flat `data` array.
-- Use `POST /scrape/{jobId}/interact` for multi-step browser workflows; scrape `actions` are best for small pre-scrape steps.
-- The published OpenAPI schema requires `code` for interact. Some SDKs and clients also accept a `prompt` field for natural-language instructions; that alias is not in `v2-openapi.json`.
+- **`code` is required** — The OpenAPI spec requires `code` for the interact endpoint. Some SDKs (Node.js, Python, Rust) additionally support a `prompt` parameter for natural-language interaction, but the REST API requires `code`.
+- **`scrapeOptions` in search** — The full set of scrape options can be passed inside search to scrape each result page.
+- **Error responses** — All errors return `{"success": false, "error": "..."}` with appropriate HTTP status codes (400, 402, 404, 408, 409, 410, 429, 500).
 
 ## Source Of Truth
 
 - `firecrawl-docs/api-reference/v2-openapi.json`
-- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
-- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
-- `firecrawl/apps/rust-sdk/src/v2/scrape.rs`

--- a/agent-source-of-truth/elixir.mdx
+++ b/agent-source-of-truth/elixir.mdx
@@ -1,375 +1,223 @@
 ---
 title: "Elixir Source of Truth"
-description: "Canonical Firecrawl Elixir source of truth for agents using key endpoints like search, scrape, and interact."
+description: "Canonical Firecrawl Elixir source of truth for agents using search, scrape, and interact."
 ---
 
-Canonical Firecrawl Elixir source of truth for agents. Generated from SDK source and the v2 OpenAPI spec.
+# Firecrawl Elixir Agent Quickstart
+
+This file is the canonical quickstart for external agents using the Firecrawl Elixir SDK. It is generated from SDK source (`:firecrawl` v1.9.1) and the Firecrawl OpenAPI spec.
 
 ## Install
 
-Add to `mix.exs`:
+Add to your `mix.exs` dependencies:
 
 ```elixir
-{:firecrawl, "~> 1.0.0"}
+{:firecrawl, "~> 1.9"}
 ```
+
+Then run:
+
+```bash
+mix deps.get
+```
+
+Requires Elixir ~> 1.15.
 
 ## Authenticate
 
-```elixir
-# config/runtime.exs or config.exs
-config :firecrawl, api_key: System.get_env("FIRECRAWL_API_KEY")
+Set your API key in application config:
 
-# or pass api_key per call
-{:ok, res} = Firecrawl.search_and_scrape([query: "site:docs.firecrawl.dev webhook retries"], api_key: "fc-your-api-key")
+```elixir
+config :firecrawl, api_key: "fc-YOUR_API_KEY"
 ```
+
+Or pass per-request:
+
+```elixir
+Firecrawl.scrape_and_extract_from_url([url: "https://example.com"], api_key: "fc-YOUR_API_KEY")
+```
+
+All functions accept a trailing `opts` keyword list that can include:
+- `:api_key` — Override the API key for this request
+- `:base_url` — Override the base URL (default: `https://api.firecrawl.dev/v2`), useful for self-hosted instances
+
+A nil/empty API key is accepted for the keyless free tier (rate-limited per IP) on scrape, search, and interact.
 
 ## When To Use What
 
-- `search`: use when you start with a query and need discovery.
-- `scrape`: use when you already have a URL and want page content.
-- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+- **`search_and_scrape`** — Use when you start with a query and need to discover relevant URLs. Returns search results and optionally scrapes each result page.
+- **`scrape_and_extract_from_url`** — Use when you already have a URL and want page content (markdown, HTML, screenshots, structured JSON, etc.).
+- **`interact_with_scrape_browser_session`** — Use when the page needs post-scrape browser actions: executing code in the live browser session.
 
 ## Search
 
 ### Why use it
 
-Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. You can constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+Search the web for a query and get back results with metadata. Optionally scrape each result page by passing `scrape_options`.
 
 ### Preferred SDK method
 
-`Firecrawl.search_and_scrape(params \\ [], opts \\ [])`
-
-### Simple Example
-
 ```elixir
-{:ok, res} = Firecrawl.search_and_scrape(query: "site:docs.firecrawl.dev webhook retries")
+Firecrawl.search_and_scrape(params, opts \\ [])
+Firecrawl.search_and_scrape!(params, opts \\ [])
 ```
 
-### Complex Example
+### Example
 
 ```elixir
-{:ok, res} = Firecrawl.search_and_scrape(
-  query: "site:docs.firecrawl.dev crawl webhooks",
-  sources: [:web, :news],
-  categories: [:research],
-  limit: 10,
-  tbs: "qdr:m",
-  location: "San Francisco,California,United States",
-  country: "US",
-  ignore_invalid_urls: true,
-  timeout: 60000,
-  scrape_options: [
-    formats: [
-      "markdown",
-      "links",
-      %{type: "json", prompt: "Extract title and key endpoints."}
-    ],
-    only_main_content: true,
-    include_tags: ["main", "article"],
-    exclude_tags: ["nav", "footer"],
-    wait_for: 1000
-  ]
+{:ok, response} = Firecrawl.search_and_scrape(
+  query: "firecrawl web scraping API",
+  limit: 5,
+  scrape_options: [formats: ["markdown"]]
 )
+
+for result <- response.body["data"]["web"] do
+  IO.puts("#{result["url"]} - #{result["title"]}")
+end
+```
+
+Bang variant raises on error:
+
+```elixir
+response = Firecrawl.search_and_scrape!(query: "firecrawl API", limit: 3)
 ```
 
 ### Parameters
 
-- `query`
-  - Type: string
-  - Use when: you need a search query.
-  - Notes: use `site:example.com` to limit results to a domain.
+All parameters are passed as a keyword list. Only `query` is required.
 
-- `sources`
-  - Type: list of atoms, strings, or maps
-  - Use when: you want to control which sources are searched.
-  - Confirmed values:
-    - `"web"` or `:web`
-    - `"news"` or `:news`
-    - `"images"` or `:images`
-    - `%{type: "web" | "news" | "images"}`
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `:string` | **Required.** The search query. |
+| `sources` | `{:list, :any}` | Sources to search (e.g. `["web"]`, `["news"]`, `["images"]`). Defaults to `["web"]`. |
+| `categories` | `{:list, :any}` | Category filters (e.g. `["github"]`, `["research"]`, `["pdf"]`). |
+| `include_domains` | `{:list, :string}` | Restrict to these domains. |
+| `exclude_domains` | `{:list, :string}` | Exclude these domains. |
+| `limit` | `:integer` | Max results to return. |
+| `tbs` | `:string` | Time-based search filter (e.g. `"qdr:d"`, `"qdr:w"`, `"cdr:1,cd_min:01/01/2024,cd_max:12/31/2024"`). |
+| `location` | `:string` | Location for geo-targeted results (e.g. `"San Francisco,California,United States"`). |
+| `country` | `:string` | ISO country code (e.g. `"US"`). For best results, set both `country` and `location`. |
+| `ignore_invalid_urls` | `:boolean` | Skip invalid URLs. |
+| `timeout` | `:integer` | Timeout in milliseconds. |
+| `highlights` | `:boolean` | Generate query-relevant highlights. Defaults to true. |
+| `scrape_options` | `:keyword_list` | Options for scraping each result page. |
+| `enterprise` | `{:list, :string}` | Enterprise options: `["zdr"]` for Zero Data Retention, `["anon"]` for anonymized search. |
 
-- `categories`
-  - Type: list of atoms, strings, or maps
-  - Use when: you want to filter results by category.
-  - Confirmed values:
-    - `"github"` or `:github`
-    - `"research"` or `:research`
-    - `"pdf"` or `:pdf`
-    - `%{type: "github" | "research" | "pdf"}`
-
-- `limit`
-  - Type: integer
-  - Use when: you want to cap results.
-
-- `tbs`
-  - Type: string
-  - Use when: you need a time-based filter (for example `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
-
-- `location`
-  - Type: string
-  - Use when: you want localized results.
-
-- `country`
-  - Type: string
-  - Use when: you want ISO 3166-1 alpha-2 targeting (for example `"US"`).
-
-- `ignore_invalid_urls`
-  - Type: boolean
-  - Use when: you want to drop URLs that cannot be scraped by other endpoints.
-
-- `timeout`
-  - Type: integer
-  - Use when: you need a request timeout in milliseconds.
-
-- `enterprise`
-  - Type: list of strings
-  - Use when: you need enterprise search controls.
-  - Confirmed values:
-    - `"zdr"`: end-to-end zero data retention
-    - `"anon"`: anonymized zero data retention
-
-- `scrape_options`
-  - Type: keyword list
-  - Use when: you want to scrape each search result (see Scrape parameters for fields).
+**Return type:** `{:ok, Req.Response.t()}` or `{:error, Exception.t() | Firecrawl.Error.t()}`. Response body contains `data` with `web`, `news`, `images` arrays.
 
 ## Scrape
 
 ### Why use it
 
-Use scrape when you already have a URL and want structured content in one or more formats.
+Scrape a single URL and get back its content in one or more formats. Supports markdown, HTML, screenshots, structured JSON extraction, and more.
 
 ### Preferred SDK method
 
-`Firecrawl.scrape_and_extract_from_url(params \\ [], opts \\ [])`
-
-### Simple Example
-
 ```elixir
-{:ok, res} = Firecrawl.scrape_and_extract_from_url(
-  url: "https://docs.firecrawl.dev",
-  formats: ["markdown"]
-)
+Firecrawl.scrape_and_extract_from_url(params, opts \\ [])
+Firecrawl.scrape_and_extract_from_url!(params, opts \\ [])
 ```
 
-### Complex Example
+### Example
 
 ```elixir
-{:ok, res} = Firecrawl.scrape_and_extract_from_url(
-  url: "https://example.com/pricing",
-  formats: [
-    "markdown",
-    "links",
-    %{type: "json", prompt: "Extract plan names and prices."},
-    %{type: "screenshot", fullPage: true, quality: 80, viewport: %{width: 1280, height: 720}},
-    %{type: "changeTracking", modes: ["git-diff"], tag: "pricing"}
-  ],
-  headers: %{"User-Agent" => "FirecrawlDocsBot/1.0"},
-  only_main_content: true,
-  wait_for: 1000,
-  parsers: [%{type: "pdf", mode: "auto", maxPages: 5}],
-  actions: [
-    %{type: "click", selector: "#accept"},
-    %{type: "wait", milliseconds: 750},
-    %{type: "scrape"}
-  ],
-  location: [country: "US", languages: ["en-US"]],
-  remove_base64_images: true,
-  block_ads: true,
-  proxy: :auto,
-  max_age: 86400000,
-  min_age: 1,
-  store_in_cache: true,
-  profile: [name: "docs-session", save_changes: true],
-  zero_data_retention: false
+{:ok, response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown", "links"]
 )
+
+IO.puts(response.body["data"]["markdown"])
+```
+
+Bang variant:
+
+```elixir
+response = Firecrawl.scrape_and_extract_from_url!(url: "https://example.com")
 ```
 
 ### Parameters
 
-- `url`
-  - Type: string
-  - Use when: you want to scrape a specific page.
+All parameters are passed as a keyword list. Only `url` is required.
 
-- `formats`
-  - Type: list of format strings or format maps
-  - Use when: you want multiple output formats.
-  - Confirmed format strings:
-    - `"markdown"`: markdown content
-    - `"html"`: cleaned HTML
-    - `"rawHtml"`: raw HTML
-    - `"links"`: page links
-    - `"images"`: image URLs
-    - `"screenshot"`: screenshot output
-    - `"summary"`: summary output
-    - `"changeTracking"`: change tracking output
-    - `"json"`: JSON extraction
-    - `"branding"`: branding profile output
-    - `"audio"`: audio extraction
-    - `"video"`: video extraction
-  - Format map fields:
-    - `type`: one of the format strings above
-    - `prompt`, `schema`: JSON extraction options for `type: "json"`
-    - `modes`, `schema`, `prompt`, `tag`: change tracking options for `type: "changeTracking"`
-    - `fullPage`, `quality`, `viewport`: screenshot options for `type: "screenshot"`
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `:string` | **Required.** The URL to scrape. |
+| `formats` | `{:list, :any}` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. |
+| `headers` | `:any` | Custom HTTP headers. |
+| `include_tags` | `{:list, :string}` | HTML tags to include. |
+| `exclude_tags` | `{:list, :string}` | HTML tags to exclude. |
+| `only_main_content` | `:boolean` | Only return main content. |
+| `timeout` | `:integer` | Timeout in ms. Min: 1000, default: 60000, max: 300000. |
+| `wait_for` | `:integer` | Wait time in ms before scraping. |
+| `mobile` | `:boolean` | Emulate a mobile device. |
+| `parsers` | `{:list, :any}` | Parser config (e.g. `["pdf"]`). |
+| `actions` | `{:list, :any}` | Browser actions before scrape. |
+| `location` | `:keyword_list` | Location settings (`country`, `languages`). |
+| `skip_tls_verification` | `:boolean` | Skip TLS verification. |
+| `remove_base64_images` | `:boolean` | Remove base64 images. |
+| `block_ads` | `:boolean` | Block ads and cookie popups. |
+| `proxy` | `{:in, [:basic, :enhanced, :auto]}` | Proxy type. `:basic` = fast, `:enhanced` = advanced anti-bot (up to 5 credits), `:auto` = auto-retry. |
+| `max_age` | `:integer` | Max cache age in milliseconds. |
+| `min_age` | `:integer` | Min cache age. Only checks cache, never triggers fresh scrape. |
+| `store_in_cache` | `:boolean` | Store result in cache. |
+| `lockdown` | `:boolean` | Serve only cached results. |
+| `redact_pii` | `:boolean` | Redact personally identifiable information. |
+| `zero_data_retention` | `:boolean` | Enable zero data retention. |
+| `profile` | `:keyword_list` | Persistent browser profile. |
+| `audit_metadata` | `:keyword_list` | User attribution for SIEM logging (`username` required). |
 
-- `headers`
-  - Type: map
-  - Use when: you need custom request headers.
-
-- `include_tags`
-  - Type: list of strings
-  - Use when: you want to include only specific HTML tags.
-
-- `exclude_tags`
-  - Type: list of strings
-  - Use when: you want to exclude specific HTML tags.
-
-- `only_main_content`
-  - Type: boolean
-  - Use when: you want to strip nav, footer, and other boilerplate.
-
-- `timeout`
-  - Type: integer
-  - Use when: you need a timeout in milliseconds.
-
-- `wait_for`
-  - Type: integer
-  - Use when: you need to wait for the page to render (milliseconds).
-
-- `mobile`
-  - Type: boolean
-  - Use when: you want a mobile viewport.
-
-- `parsers`
-  - Type: list of parser strings or maps
-  - Use when: you need file parsing controls.
-  - Confirmed values:
-    - `"pdf"`
-    - `%{type: "pdf", mode: "fast" | "auto" | "ocr", maxPages: integer}`
-
-- `actions`
-  - Type: list of action maps
-  - Use when: you need lightweight pre-scrape actions.
-  - Confirmed action types:
-    - `wait`: `milliseconds` or `selector` required
-    - `screenshot`: `fullPage`, `quality`, `viewport` optional
-    - `click`: `selector` required, `all` optional
-    - `write`: `text` required (click to focus the input first)
-    - `press`: `key` required
-    - `scroll`: `direction` (`up` or `down`) required, `selector` optional
-    - `scrape`: no additional fields
-    - `executeJavascript`: `script` required
-    - `pdf`: `format` (A0, A1, A2, A3, A4, A5, A6, Letter, Legal, Tabloid, Ledger), `landscape`, `scale` optional
-
-- `location`
-  - Type: keyword list (for example `country:` and `languages:`)
-  - Use when: you need geo or language-aware scraping.
-
-- `skip_tls_verification`
-  - Type: boolean
-  - Use when: you need to skip TLS verification.
-
-- `remove_base64_images`
-  - Type: boolean
-  - Use when: you want to drop base64 images from markdown output.
-
-- `block_ads`
-  - Type: boolean
-  - Use when: you want ad and cookie popup blocking.
-
-- `proxy`
-  - Type: atom or string
-  - Use when: you need proxy control.
-  - Confirmed values: `:basic`, `:enhanced`, `:auto`
-
-- `max_age`
-  - Type: integer
-  - Use when: you want cached data up to a maximum age (milliseconds).
-
-- `min_age`
-  - Type: integer
-  - Use when: you want cached data only if it is at least this old (milliseconds).
-
-- `store_in_cache`
-  - Type: boolean
-  - Use when: you want Firecrawl to cache the result.
-
-- `profile`
-  - Type: keyword list with `name:` and optional `save_changes:` (or `saveChanges:`)
-  - Use when: you want a persistent browser profile shared across scrapes and interactions.
-
-- `zero_data_retention`
-  - Type: boolean
-  - Use when: you want zero data retention for this scrape.
+**Return type:** `{:ok, Req.Response.t()}` or `{:error, Exception.t() | Firecrawl.Error.t()}`. Response body contains `data` with the scraped document.
 
 ## Interact
 
 ### Why use it
 
-Use interact when a page requires browser actions or code execution after a scrape starts.
+Execute code in the live browser session that was created by a prior scrape call. Use this for multi-step workflows: running scripts, navigating, or extracting additional data from the page.
 
 ### Preferred SDK method
 
-`Firecrawl.interact_with_scrape_browser_session(job_id, params \\ [], opts \\ [])`
-
-### Simple Example
-
 ```elixir
-{:ok, res} = Firecrawl.interact_with_scrape_browser_session(
-  "<scrapeJobId>",
-  code: "console.log(await page.title());",
-  language: :node,
-  timeout: 60
-)
+Firecrawl.interact_with_scrape_browser_session(job_id, params \\ [], opts \\ [])
+Firecrawl.interact_with_scrape_browser_session!(job_id, params \\ [], opts \\ [])
 ```
 
-### Complex Example
+### Example
 
 ```elixir
-{:ok, res} = Firecrawl.interact_with_scrape_browser_session(
-  "<scrapeJobId>",
-  code: "// Use Playwright page methods here",
+{:ok, scrape_response} = Firecrawl.scrape_and_extract_from_url(url: "https://example.com")
+job_id = scrape_response.body["data"]["metadata"]["jobId"]
+
+{:ok, result} = Firecrawl.interact_with_scrape_browser_session(job_id,
+  code: "document.title",
   language: :node,
-  timeout: 120
+  timeout: 30
 )
+
+IO.puts(result.body["stdout"])
 ```
 
 ### Parameters
 
-- `job_id`
-  - Type: string
-  - Use when: you have a scrape job ID.
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `String.t()` | **Required.** The scrape job ID (path parameter). |
+| `code` | `:string` | **Required.** Code to execute in the browser sandbox. |
+| `language` | `{:in, [:python, :node, :bash]}` | Language for code execution. Use `:node` for JavaScript. |
+| `timeout` | `:integer` | Execution timeout in seconds. |
+| `origin` | `:string` | Origin tag for request attribution. |
 
-- `code`
-  - Type: string
-  - Use when: you want to run code in the browser session.
+**Return type:** `{:ok, Req.Response.t()}` or `{:error, Exception.t() | Firecrawl.Error.t()}`.
 
-- `language`
-  - Type: atom or string
-  - Use when: you need a specific runtime.
-  - Confirmed values: `:python`, `:node`, `:bash` (or the string equivalents)
-
-- `timeout`
-  - Type: integer
-  - Use when: you need an execution timeout in seconds.
-
-- `origin`
-  - Type: string
-  - Use when: you want an optional origin label for execution telemetry.
-
-### Stop interactive session
-
-`Firecrawl.stop_interactive_scrape_browser_session(job_id, opts \\ [])` issues `DELETE /scrape/{jobId}/interact` and tears down the browser session for that scrape job. A bang variant `stop_interactive_scrape_browser_session!/2` is also available.
-
-```elixir
-{:ok, res} = Firecrawl.stop_interactive_scrape_browser_session("<scrapeJobId>")
-```
+Call `Firecrawl.stop_interactive_scrape_browser_session(job_id)` to end the browser session when done.
 
 ## Notes
 
-- The Elixir client is OpenAPI-shaped; function names and parameter keys are generated from the spec.
-- Each public function has a bang (`!`) variant that raises on error instead of returning `{:error, _}`.
-- This SDK exposes code-based interactions only (no `prompt` parameter on `interact_with_scrape_browser_session`).
+- **OpenAPI-generated client** — The Elixir SDK is auto-generated from the OpenAPI spec. Function names are verbose and match the OpenAPI operation IDs.
+- **Code-only interact** — The Elixir SDK's interact function takes `code` only. Natural-language `prompt` is not supported. Use the Node.js, Python, or Rust SDK if you need prompt-based interaction.
+- **Bang variants** — Every function has a `!` variant (e.g. `search_and_scrape!`) that raises on error instead of returning `{:error, ...}`.
+- **Atom values** — Use atoms for enum values: `:basic`, `:enhanced`, `:auto` for proxy; `:python`, `:node`, `:bash` for language.
+- **`country` as standalone param** — In search, `country` is a top-level parameter (not nested inside `location` like in other SDKs).
+- **No deprecated aliases** — The Elixir SDK has no deprecated method aliases.
 
 ## Source Of Truth
 

--- a/agent-source-of-truth/java.mdx
+++ b/agent-source-of-truth/java.mdx
@@ -1,27 +1,31 @@
 ---
 title: "Java Source of Truth"
-description: "Canonical Firecrawl Java source of truth for agents using key endpoints like search, scrape, and interact."
+description: "Canonical Firecrawl Java source of truth for agents using search, scrape, and interact."
 ---
 
-Canonical Firecrawl Java source of truth for agents. Generated from SDK source and the v2 OpenAPI spec.
+# Firecrawl Java Agent Quickstart
+
+This file is the canonical quickstart for external agents using the Firecrawl Java SDK. It is generated from SDK source (`firecrawl-java` v1.12.1) and the Firecrawl OpenAPI spec.
 
 ## Install
 
-Maven:
+**Maven:**
 
 ```xml
 <dependency>
   <groupId>com.firecrawl</groupId>
   <artifactId>firecrawl-java</artifactId>
-  <version>1.2.0</version>
+  <version>1.12.1</version>
 </dependency>
 ```
 
-Gradle:
+**Gradle (Kotlin DSL):**
 
-```gradle
-implementation("com.firecrawl:firecrawl-java:1.2.0")
+```kotlin
+implementation("com.firecrawl:firecrawl-java:1.12.1")
 ```
+
+Requires Java 11+.
 
 ## Authenticate
 
@@ -29,405 +33,212 @@ implementation("com.firecrawl:firecrawl-java:1.2.0")
 import com.firecrawl.client.FirecrawlClient;
 
 FirecrawlClient client = FirecrawlClient.builder()
-    .apiKey(System.getenv("FIRECRAWL_API_KEY"))
+    .apiKey("fc-YOUR_API_KEY")
     .build();
 ```
 
+Or from environment:
+
+```java
+FirecrawlClient client = FirecrawlClient.fromEnv();
+```
+
+API key resolution order: explicit `.apiKey()` → `FIRECRAWL_API_KEY` env var → `firecrawl.apiKey` system property. If all are absent, the client builds in keyless free tier mode (rate-limited per IP) for scrape, search, and interact.
+
+Builder options:
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `apiKey` | `String` | See resolution above | API key |
+| `apiUrl` | `String` | `"https://api.firecrawl.dev"` | Base API URL |
+| `timeoutMs` | `long` | `300000` (5 min) | Per-request timeout in milliseconds |
+| `maxRetries` | `int` | `3` | Max automatic retries |
+| `backoffFactor` | `double` | `0.5` | Exponential backoff factor |
+| `asyncExecutor` | `Executor` | `ForkJoinPool.commonPool()` | Executor for async methods |
+| `httpClient` | `OkHttpClient` | — | Custom OkHttp client |
+
 ## When To Use What
 
-- `search`: use when you start with a query and need discovery.
-- `scrape`: use when you already have a URL and want page content.
-- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
-- `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
-- `support/docs-search`: use when you need to look up Firecrawl documentation.
+- **`search`** — Use when you start with a query and need to discover relevant URLs. Returns search results and optionally scrapes each result page.
+- **`scrape`** — Use when you already have a URL and want page content (markdown, HTML, screenshots, structured JSON, etc.).
+- **`interact`** — Use when the page needs post-scrape browser actions: executing code in the live browser session.
 
 ## Search
 
 ### Why use it
 
-Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. You can constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+Search the web for a query and get back results with metadata. Optionally scrape each result page by passing `scrapeOptions`.
 
-### Preferred SDK methods
-
-- `client.search(query)`
-- `client.search(query, options)`
-
-### Return value
-
-`search` returns `SearchData`. Read result buckets with `getWeb()`, `getNews()`, and `getImages()` (each is `List<Map<String, Object>>` and may be null). Do not treat `SearchData` as a directly iterable list of hits.
-
-### Simple Example
+### Preferred SDK method
 
 ```java
-import com.firecrawl.models.SearchData;
-import java.util.List;
-import java.util.Map;
-
-SearchData results = client.search("site:docs.firecrawl.dev webhook retries");
-List<Map<String, Object>> web = results.getWeb();
+client.search(query)
+client.search(query, options)
 ```
 
-### Complex Example
+### Example
 
 ```java
 import com.firecrawl.models.SearchOptions;
-import com.firecrawl.models.ScrapeOptions;
-import com.firecrawl.models.JsonFormat;
-import com.firecrawl.models.LocationConfig;
+import com.firecrawl.models.SearchData;
 
-SearchOptions options = SearchOptions.builder()
-    .sources(List.of("web", "news"))
-    .categories(List.of("research"))
-    .limit(10)
-    .tbs("qdr:m")
-    .location("San Francisco,California,United States")
-    .ignoreInvalidURLs(true)
-    .timeout(60000)
-    .scrapeOptions(
-        ScrapeOptions.builder()
-            .formats(List.of(
-                "markdown",
-                "links",
-                JsonFormat.builder().prompt("Extract title and key endpoints.").build()
-            ))
-            .onlyMainContent(true)
-            .waitFor(1000)
-            .build()
-    )
-    .build();
+SearchData results = client.search("firecrawl web scraping API",
+    SearchOptions.builder()
+        .limit(5)
+        .highlights(true)
+        .build()
+);
 
-SearchData results = client.search("site:docs.firecrawl.dev crawl webhooks", options);
+for (var page : results.getWeb()) {
+    System.out.println(page.get("url") + " " + page.get("title"));
+}
 ```
+
+Async variant: `client.searchAsync(query, options)` returns `CompletableFuture<SearchData>`.
 
 ### Parameters
 
-- `query`
-  - Type: String
-  - Use when: you need a search query.
-  - Notes: use `site:example.com` to limit results to a domain.
+All fields in `SearchOptions` are nullable and built via `SearchOptions.builder()`.
 
-- `options.sources`
-  - Type: List of source strings or maps
-  - Use when: you want to control which sources are searched.
-  - Confirmed values:
-    - `"web"`: web index results
-    - `"news"`: news results
-    - `"images"`: image results
-    - `{type: "web" | "news" | "images"}`: typed source map form
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `String` | **Required.** The search query. |
+| `sources` | `List<Object>` | Sources: `"web"`, `"news"`, `"images"` as strings, or `{type: "web"}` maps. |
+| `categories` | `List<Object>` | Category filters: `"github"`, `"research"`, `"pdf"`. |
+| `includeDomains` | `List<String>` | Restrict to these domains. |
+| `excludeDomains` | `List<String>` | Exclude these domains. |
+| `limit` | `Integer` | Max results to return. |
+| `tbs` | `String` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `String` | Location for geo-targeted results. |
+| `ignoreInvalidURLs` | `Boolean` | Skip invalid URLs. |
+| `timeout` | `Integer` | Timeout in milliseconds. |
+| `highlights` | `Boolean` | Generate query-relevant highlights. Defaults to true. |
+| `scrapeOptions` | `ScrapeOptions` | Options for scraping each result page. |
+| `integration` | `String` | Integration identifier. |
 
-- `options.categories`
-  - Type: List of category strings or maps
-  - Use when: you want to filter results by category.
-  - Confirmed values:
-    - `"github"`: GitHub-focused results
-    - `"research"`: research and academic results
-    - `"pdf"`: PDF-focused results
-    - `{type: "github" | "research" | "pdf"}`: typed category map form
-
-- `options.limit`
-  - Type: Integer
-  - Use when: you want to cap results.
-
-- `options.tbs`
-  - Type: String
-  - Use when: you need a time-based filter (for example `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
-
-- `options.location`
-  - Type: String
-  - Use when: you want localized results.
-
-- `options.ignoreInvalidURLs`
-  - Type: Boolean
-  - Use when: you want to drop URLs that cannot be scraped by other endpoints.
-
-- `options.timeout`
-  - Type: Integer
-  - Use when: you need a request timeout in milliseconds.
-
-- `options.scrapeOptions`
-  - Type: `ScrapeOptions`
-  - Use when: you want to scrape each search result (see Scrape parameters for fields).
-
-- `options.integration`
-  - Type: String
-  - Use when: the API expects an integration identifier on the request.
+**Return type:** `SearchData` with `getWeb()`, `getNews()`, `getImages()` returning `List<Map<String, Object>>`.
 
 ## Scrape
 
 ### Why use it
 
-Use scrape when you already have a URL and want structured content in one or more formats.
+Scrape a single URL and get back its content in one or more formats. Supports markdown, HTML, screenshots, structured JSON extraction, and more.
 
-### Preferred SDK methods
-
-- `client.scrape(url)`
-- `client.scrape(url, options)`
-
-### Return value
-
-`scrape` returns `Document`. Typical getters include `getMarkdown()`, `getHtml()`, `getRawHtml()`, `getJson()`, `getMetadata()`, `getLinks()`, `getAudio()`, `getVideo()`, and additional fields when the corresponding formats are requested.
-
-### Simple Example
+### Preferred SDK method
 
 ```java
-Document doc = client.scrape(
-    "https://docs.firecrawl.dev",
-    ScrapeOptions.builder().formats(List.of("markdown")).build()
-);
+client.scrape(url)
+client.scrape(url, options)
 ```
 
-### Complex Example
+### Example
 
 ```java
 import com.firecrawl.models.ScrapeOptions;
-import com.firecrawl.models.JsonFormat;
+import com.firecrawl.models.Document;
 
-List<Map<String, Object>> actions = List.of(
-    Map.of("type", "click", "selector", "#accept"),
-    Map.of("type", "wait", "milliseconds", 750),
-    Map.of("type", "scrape")
+Document doc = client.scrape("https://example.com",
+    ScrapeOptions.builder()
+        .formats(List.of("markdown", "links"))
+        .build()
 );
 
-LocationConfig location = LocationConfig.builder()
-    .country("US")
-    .languages(List.of("en-US"))
-    .build();
-
-ScrapeOptions options = ScrapeOptions.builder()
-    .formats(List.of(
-        "markdown",
-        "links",
-        JsonFormat.builder().prompt("Extract plan names and prices.").build(),
-        Map.of("type", "screenshot", "fullPage", true, "quality", 80)
-    ))
-    .onlyMainContent(true)
-    .waitFor(1000)
-    .parsers(List.of(Map.of("type", "pdf", "maxPages", 5)))
-    .actions(actions)
-    .location(location)
-    .removeBase64Images(true)
-    .blockAds(true)
-    .proxy("auto")
-    .maxAge(86400000L)
-    .storeInCache(true)
-    .build();
-
-Document doc = client.scrape("https://example.com/pricing", options);
+System.out.println(doc.getMarkdown());
+System.out.println(doc.getLinks());
 ```
+
+Async variant: `client.scrapeAsync(url, options)` returns `CompletableFuture<Document>`.
 
 ### Parameters
 
-- `url`
-  - Type: String
-  - Use when: you want to scrape a specific page.
+All fields in `ScrapeOptions` are nullable and built via `ScrapeOptions.builder()`.
 
-- `options.formats`
-  - Type: List of format strings or format maps
-  - Use when: you want multiple output formats.
-  - Confirmed format strings:
-    - `"markdown"`: markdown content
-    - `"html"`: cleaned HTML
-    - `"rawHtml"`: raw HTML
-    - `"links"`: page links
-    - `"images"`: image URLs
-    - `"screenshot"`: screenshot output
-    - `"summary"`: summary output
-    - `"changeTracking"`: change tracking output
-    - `"json"`: JSON extraction
-    - `"attributes"`: attribute extraction
-    - `"branding"`: branding profile output
-    - `"audio"`: audio extraction
-    - `"video"`: video extraction
-  - Format object fields:
-    - `type`: one of the format strings above
-    - `prompt`, `schema`: JSON extraction options for `type: "json"`
-    - `modes`, `schema`, `prompt`, `tag`: change tracking options for `type: "changeTracking"`
-    - `fullPage`, `quality`, `viewport`: screenshot options for `type: "screenshot"`
-    - `selectors`: array of `{selector, attribute}` for `type: "attributes"`
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `String` | **Required.** The URL to scrape. |
+| `formats` | `List<Object>` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"json"`, `"audio"`, `"video"`. Also supports typed format objects. |
+| `headers` | `Map<String, String>` | Custom HTTP headers. |
+| `includeTags` | `List<String>` | HTML tags to include. |
+| `excludeTags` | `List<String>` | HTML tags to exclude. |
+| `onlyMainContent` | `Boolean` | Only return main content. |
+| `timeout` | `Integer` | Timeout in milliseconds. |
+| `waitFor` | `Integer` | Wait time in ms before scraping. |
+| `mobile` | `Boolean` | Emulate a mobile device. |
+| `parsers` | `List<Object>` | Parser config (e.g. `"pdf"` or `{"type": "pdf", "maxPages": 10}`). |
+| `actions` | `List<Map<String, Object>>` | Browser actions before scrape. |
+| `location` | `LocationConfig` | Location config (`country`, `languages`). |
+| `skipTlsVerification` | `Boolean` | Skip TLS verification. |
+| `removeBase64Images` | `Boolean` | Remove base64 images. |
+| `blockAds` | `Boolean` | Block ads. |
+| `proxy` | `String` | Proxy: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or a custom URL. |
+| `maxAge` | `Long` | Max cache age in milliseconds. |
+| `storeInCache` | `Boolean` | Store result in cache. |
+| `lockdown` | `Boolean` | Serve only cached results. |
+| `redactPII` | `Boolean` | Redact personally identifiable information. |
+| `auditMetadata` | `AuditMetadata` | User attribution for SIEM logging (`username`). |
+| `integration` | `String` | Integration identifier. |
 
-- `options.headers`
-  - Type: `Map<String, String>`
-  - Use when: you need custom request headers.
-
-- `options.includeTags`
-  - Type: `List<String>`
-  - Use when: you want to include only specific HTML tags.
-
-- `options.excludeTags`
-  - Type: `List<String>`
-  - Use when: you want to exclude specific HTML tags.
-
-- `options.onlyMainContent`
-  - Type: Boolean
-  - Use when: you want to strip nav, footer, and other boilerplate.
-
-- `options.timeout`
-  - Type: Integer
-  - Use when: you need a timeout in milliseconds.
-
-- `options.waitFor`
-  - Type: Integer
-  - Use when: you need to wait for the page to render (milliseconds).
-
-- `options.mobile`
-  - Type: Boolean
-  - Use when: you want a mobile viewport.
-
-- `options.parsers`
-  - Type: `List<Object>`
-  - Use when: you need file parsing controls.
-  - Confirmed values:
-    - `"pdf"`
-    - `{type: "pdf", maxPages: number}`
-
-- `options.actions`
-  - Type: `List<Map<String, Object>>`
-  - Use when: you need lightweight pre-scrape actions.
-  - Confirmed action types:
-    - `wait`: `milliseconds` or `selector` required
-    - `screenshot`: `fullPage`, `quality`, `viewport` optional
-    - `click`: `selector` required
-    - `write`: `text` required (click to focus the input first)
-    - `press`: `key` required
-    - `scroll`: `direction` (`up` or `down`) required, `selector` optional
-    - `scrape`: no additional fields
-    - `executeJavascript`: `script` required
-    - `pdf`: `format` (A0, A1, A2, A3, A4, A5, A6, Letter, Legal, Tabloid, Ledger), `landscape`, `scale` optional
-
-- `options.location`
-  - Type: `LocationConfig`
-  - Use when: you need geo or language-aware scraping.
-
-- `options.skipTlsVerification`
-  - Type: Boolean
-  - Use when: you need to skip TLS verification.
-
-- `options.removeBase64Images`
-  - Type: Boolean
-  - Use when: you want to drop base64 images from markdown output.
-
-- `options.blockAds`
-  - Type: Boolean
-  - Use when: you want ad and cookie popup blocking.
-
-- `options.proxy`
-  - Type: String
-  - Use when: you need proxy control.
-  - Confirmed values: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or a custom proxy URL string
-
-- `options.maxAge`
-  - Type: Long
-  - Use when: you want cached data up to a maximum age (milliseconds).
-
-- `options.storeInCache`
-  - Type: Boolean
-  - Use when: you want Firecrawl to cache the result.
-
-- `options.integration`
-  - Type: String
-  - Use when: the API expects an integration identifier on the request.
+**Return type:** `Document` with getters: `getMarkdown()`, `getHtml()`, `getRawHtml()`, `getJson()`, `getSummary()`, `getMetadata()`, `getLinks()`, `getImages()`, `getScreenshot()`, `getAudio()`, `getVideo()`, `getAttributes()`, `getActions()`, `getAnswer()`, `getHighlights()`, `getWarning()`, `getChangeTracking()`, `getBranding()`, `getProduct()`, `getMenu()`.
 
 ## Interact
 
 ### Why use it
 
-Use interact when a page requires browser actions or code execution after a scrape starts.
+Execute code in the live browser session that was created by a prior `scrape` call. Use this for multi-step workflows: running scripts, navigating, or extracting additional data from the page.
 
-### Preferred SDK methods
+### Preferred SDK method
 
-- `client.interact(jobId, code)` — uses default language `node` and API default execution timeout
-- `client.interact(jobId, code, language, timeout)` — `timeout` is seconds (1–300), or null to omit and use the API default (30 seconds)
-- `client.interact(jobId, code, language, timeout, origin)` — optional `origin` string is sent only when non-null (request attribution)
+```java
+client.interact(jobId, code)
+client.interact(jobId, code, language, timeout)
+client.interact(jobId, code, language, timeout, origin)
+```
 
-### Simple Example
+### Example
 
 ```java
 import com.firecrawl.models.BrowserExecuteResponse;
 
-BrowserExecuteResponse result = client.interact(
-    "<scrapeJobId>",
-    "console.log(await page.title());",
-    "node",
-    60
-);
+Document doc = client.scrape("https://example.com");
+String jobId = (String) doc.getMetadata().get("jobId");
+
+BrowserExecuteResponse result = client.interact(jobId, "document.title");
+System.out.println(result.getStdout());
+
+// With language and timeout
+BrowserExecuteResponse result2 = client.interact(jobId, "console.log('hello')", "node", 30);
+System.out.println(result2.getStdout());
 ```
 
-### Complex Example
-
-```java
-BrowserExecuteResponse result = client.interact(
-    "<scrapeJobId>",
-    "// Use Playwright page methods here",
-    "node",
-    120
-);
-```
-
-### Stop interactive browser
-
-End the scrape-bound browser session when finished.
-
-**Preferred SDK method:** `client.stopInteractiveBrowser(jobId)`
-
-```java
-import com.firecrawl.models.BrowserDeleteResponse;
-
-BrowserDeleteResponse stopped = client.stopInteractiveBrowser("<scrapeJobId>");
-```
-
-### Interact response (`BrowserExecuteResponse`)
-
-- `isSuccess()`: boolean
-- `getStdout()`, `getStderr()`, `getResult()`, `getError()`: String (may be null)
-- `getExitCode()`: Integer (may be null)
-- `getKilled()`: Boolean (may be null) — true when execution was stopped due to timeout
-
-### Stop response (`BrowserDeleteResponse`)
-
-- `isSuccess()`: boolean
-- `getSessionDurationMs()`: Long (may be null)
-- `getCreditsBilled()`: Integer (may be null)
-- `getError()`: String (may be null)
+Async variant: `client.interactAsync(jobId, code, language, timeout)` returns `CompletableFuture<BrowserExecuteResponse>`.
 
 ### Parameters
 
-- `jobId`
-  - Type: String
-  - Use when: you have a scrape job ID.
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `String` | **Required.** The scrape job ID. |
+| `code` | `String` | **Required.** Code to execute in the browser sandbox. |
+| `language` | `String` | Language: `"python"`, `"node"`, `"bash"`. Default: `"node"`. |
+| `timeout` | `Integer` | Execution timeout in seconds (1–300). Default: 30. |
+| `origin` | `String` | Origin tag for request attribution. |
 
-- `code`
-  - Type: String
-  - Use when: you want to run code in the browser session.
+**Return type:** `BrowserExecuteResponse` with getters: `isSuccess()`, `getStdout()`, `getResult()`, `getStderr()`, `getExitCode()`, `getKilled()`, `getError()`.
 
-- `language`
-  - Type: String
-  - Use when: you need a specific runtime.
-  - Confirmed values: `"python"`, `"node"`, `"bash"`
-  - Notes: defaults to `"node"` in the SDK if null.
-
-- `timeout`
-  - Type: Integer
-  - Use when: you need an execution timeout in seconds (1–300). Null omits the field and uses the API default.
-
-- `origin`
-  - Type: String
-  - Use when: you need an optional origin label on the request. Prefer omitting unless your integration requires it.
+Call `client.stopInteractiveBrowser(jobId)` to end the browser session when done.
 
 ## Notes
 
-- Deprecated aliases: `scrapeExecute` → `interact`, `deleteScrapeBrowser` → `stopInteractiveBrowser` (and the corresponding `*Async` helpers).
-- The Java SDK exposes code-based interactions only: there is no `prompt` parameter on `interact` (unlike some other language SDKs).
+- **camelCase parameters** — All option fields use camelCase (e.g. `onlyMainContent`, `includeTags`).
+- **Code-only interact** — The Java SDK's `interact` method takes `code` only. Natural-language `prompt` is not supported in this SDK. Use the Node.js, Python, or Rust SDK if you need prompt-based interaction.
+- **Builder pattern** — All options use builders: `ScrapeOptions.builder()...build()`, `SearchOptions.builder()...build()`.
+- **Async methods** — Every method has an `*Async` variant returning `CompletableFuture`.
+- **Deprecated aliases** — `scrapeExecute` → `interact`, `deleteScrapeBrowser` → `stopInteractiveBrowser`. Always use the preferred names.
 
 ## Source Of Truth
 
 - `firecrawl/apps/java-sdk/build.gradle.kts`
 - `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
-- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
 - `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java`
-- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchData.java`
-- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/JsonFormat.java`
-- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/LocationConfig.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
 - `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/Document.java`
-- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/BrowserExecuteResponse.java`
-- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/BrowserDeleteResponse.java`
 - `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-source-of-truth/node.mdx
+++ b/agent-source-of-truth/node.mdx
@@ -1,535 +1,226 @@
 ---
 title: "Node.js Source of Truth"
-description: "Canonical Firecrawl Node.js source of truth for agents using key endpoints like search, scrape, and interact."
+description: "Canonical Firecrawl Node.js source of truth for agents using search, scrape, and interact."
 ---
 
-Canonical Firecrawl Node.js source of truth for agents. Aligned with `firecrawl` **v4.18.2** (`firecrawl/apps/js-sdk/firecrawl`) and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+# Firecrawl Node.js Agent Quickstart
+
+This file is the canonical quickstart for external agents using the Firecrawl Node.js SDK. It is generated from SDK source (`@mendable/firecrawl-js` v4.31.1) and the Firecrawl OpenAPI spec.
 
 ## Install
 
 ```bash
-npm install firecrawl
+npm install @mendable/firecrawl-js
 ```
 
 ## Authenticate
 
-```ts
-import { Firecrawl } from "firecrawl";
+```javascript
+import Firecrawl from "@mendable/firecrawl-js";
 
-const client = new Firecrawl({
-  apiKey: process.env.FIRECRAWL_API_KEY,
-  // apiUrl: "https://api.firecrawl.dev" // optional; falls back to FIRECRAWL_API_URL or cloud default
-});
+const client = new Firecrawl({ apiKey: "fc-YOUR_API_KEY" });
 ```
+
+The API key can also be set via the `FIRECRAWL_API_KEY` environment variable. If omitted entirely, the SDK falls back to a keyless free tier (rate-limited per IP) for scrape, search, and interact.
+
+Constructor options:
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `apiKey` | `string \| null` | `process.env.FIRECRAWL_API_KEY` | API key |
+| `apiUrl` | `string \| null` | `"https://api.firecrawl.dev"` | Base API URL |
+| `timeoutMs` | `number` | — | Per-request timeout in milliseconds |
+| `maxRetries` | `number` | — | Max automatic retries for transient failures |
+| `backoffFactor` | `number` | — | Exponential backoff factor |
 
 ## When To Use What
 
-- `search`: use when you start with a query and need discovery.
-- `scrape`: use when you already have a URL and want page content.
-- `interact`: use when the page needs clicks, forms, or other browser actions after a scrape has created a session. For multi-step interactive flows, prefer `interact` over scrape-time `actions`.
-- `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
-- `support/docs-search`: use when you need to look up Firecrawl documentation.
+- **`search`** — Use when you start with a query and need to discover relevant URLs. Returns search results and optionally scrapes each result page.
+- **`scrape`** — Use when you already have a URL and want page content (markdown, HTML, screenshots, structured JSON, etc.).
+- **`interact`** — Use when the page needs post-scrape browser actions: clicking elements, filling forms, or executing code in the live browser session.
 
 ## Search
 
 ### Why use it
 
-Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. You can constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+Search the web for a query and get back results with metadata. Optionally scrape each result page by passing `scrapeOptions`.
 
 ### Preferred SDK method
 
-`client.search(query, options?)` → `Promise<SearchData>`
-
-### Simple Example
-
-```ts
-const results = await client.search("site:docs.firecrawl.dev webhook retries");
+```javascript
+client.search(query, options?)
 ```
 
-### Complex Example
-
-```ts
-const results = await client.search("site:docs.firecrawl.dev crawl webhooks", {
-  sources: ["web", "news"],
-  categories: ["research"],
-  limit: 10,
-  tbs: "qdr:m",
-  location: "San Francisco,California,United States",
-  ignoreInvalidURLs: true,
-  timeout: 60000,
-  scrapeOptions: {
-    formats: [
-      "markdown",
-      "links",
-      { type: "json", prompt: "Extract title and key endpoints." }
-    ],
-    onlyMainContent: true,
-    includeTags: ["main", "article"],
-    excludeTags: ["nav", "footer"],
-    waitFor: 1000
-  }
-});
-```
-
-### Return value
-
-`SearchData` is an object with optional arrays (each entry is either a lightweight result object or a full `Document` when `scrapeOptions` hydrated the hit):
-
-- `web`: web index hits
-- `news`: news hits
-- `images`: image hits
-
-**Wrong turn to avoid:** `search()` does not return `{ data: [...] }`. Do not access `result.data`. Web results are in `result.web`, news in `result.news`, images in `result.images`.
-
-### Parameters
-
-- `query`
-  - Type: string
-  - Use when: you need a search query.
-  - Notes: use `site:example.com` to limit results to a domain.
-
-- `options` (optional; second argument defaults to `{}`)
-  - Type: `Omit<SearchRequest, "query">`
-
-- `options.sources`
-  - Type: array of source names or typed source objects
-  - Use when: you want to control which sources are searched.
-  - Confirmed values:
-    - `"web"`: web index results
-    - `"news"`: news results
-    - `"images"`: image results
-    - `{ type: "web" | "news" | "images" }`: typed source object form
-
-- `options.categories`
-  - Type: array of category names or typed category objects
-  - Use when: you want to filter results by category.
-  - Confirmed values:
-    - `"github"`: GitHub-focused results
-    - `"research"`: research and academic results
-    - `"pdf"`: PDF-focused results
-    - `{ type: "github" | "research" | "pdf" }`: typed category object form
-
-- `options.limit`
-  - Type: number
-  - Use when: you want to cap results.
-
-- `options.tbs`
-  - Type: string
-  - Use when: you need a time-based filter (for example `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
-
-- `options.location`
-  - Type: string
-  - Use when: you want localized results.
-
-- `options.ignoreInvalidURLs`
-  - Type: boolean
-  - Use when: you want to drop URLs that cannot be scraped by other endpoints.
-
-- `options.timeout`
-  - Type: number
-  - Use when: you need a request timeout in milliseconds.
-
-- `options.scrapeOptions`
-  - Type: `ScrapeOptions`
-  - Use when: you want to scrape each search result (see Scrape parameters for fields). The SDK runs the same validation as for `scrape` (for example plain string `"json"` in `formats` is rejected).
-
-## Scrape
-
-### Why use it
-
-Use scrape when you already have a URL and want structured content in one or more formats.
-
-### Preferred SDK method
-
-`client.scrape(url, options?)` → `Promise<Document>`
-
-### Simple Example
-
-```ts
-const doc = await client.scrape("https://docs.firecrawl.dev", {
-  formats: ["markdown"]
-});
-```
-
-### Complex Example
-
-```ts
-const doc = await client.scrape("https://example.com/pricing", {
-  formats: [
-    "markdown",
-    "links",
-    { type: "json", prompt: "Extract plan names and prices." },
-    { type: "screenshot", fullPage: true, quality: 80, viewport: { width: 1280, height: 720 } },
-    { type: "changeTracking", modes: ["git-diff"], tag: "pricing" },
-    { type: "attributes", selectors: [{ selector: "a", attribute: "href" }] }
-  ],
-  headers: {
-    "User-Agent": "FirecrawlDocsBot/1.0"
-  },
-  onlyMainContent: true,
-  waitFor: 1000,
-  parsers: [{ type: "pdf", mode: "auto", maxPages: 5 }],
-  actions: [
-    { type: "click", selector: "#accept" },
-    { type: "wait", milliseconds: 750 },
-    { type: "scrape" }
-  ],
-  location: { country: "US", languages: ["en-US"] },
-  removeBase64Images: true,
-  fastMode: true,
-  blockAds: true,
-  proxy: "auto",
-  maxAge: 86400000,
-  minAge: 1,
-  storeInCache: true,
-  profile: { name: "docs-session", saveChanges: true }
-});
-```
-
-### Parameters
-
-- `url`
-  - Type: string
-  - Use when: you want to scrape a specific page.
-
-- `options.formats`
-  - Type: array of format strings or format objects
-  - Use when: you want multiple output formats.
-  - Plain string formats (the `FormatString` union also includes `"json"`, but the SDK rejects `"json"` as a plain string — use a `json` object below):
-    - `"markdown"`: markdown content
-    - `"html"`: cleaned HTML
-    - `"rawHtml"`: raw HTML
-    - `"links"`: page links
-    - `"images"`: image URLs
-    - `"screenshot"`: screenshot output
-    - `"summary"`: summary output
-    - `"changeTracking"`: change tracking output (for options like `modes`, use `{ type: "changeTracking", modes: [...] }` — `modes` is required on that object in typings)
-    - `"attributes"`: attribute extraction (use `{ type: "attributes", selectors: [...] }` when passing selectors)
-    - `"branding"`: branding profile output
-    - `"audio"`: audio extraction
-    - `"video"`: video extraction
-  - Object-only format types (at minimum `type` as shown):
-    - `{ type: "json", prompt?: string, schema?: JSON schema or Zod schema }`: at least one of `prompt` or `schema` is required (SDK validation).
-    - `{ type: "question", question: string }`: question-answer style extraction.
-    - `{ type: "highlights", query: string }`: relevant source-text extraction.
-    - `{ type: "screenshot", fullPage?, quality?, viewport? }`: same options as the string form but as an object.
-    - `{ type: "changeTracking", modes: ("git-diff" | "json")[], schema?, prompt?, tag? }`: `modes` is required.
-    - `{ type: "attributes", selectors: Array<{ selector, attribute }> }`
-  - Shared object fields where applicable:
-    - `schema`: JSON schema or Zod schema for `json`, or for `changeTracking` in `json` mode (Zod is converted to JSON Schema by the SDK).
-    - `modes`: for `changeTracking` only: `"git-diff"` and/or `"json"`.
-    - `tag`: optional change-tracking branch tag.
-    - `fullPage`, `quality`, `viewport`: screenshot options.
-
-- `options.headers`
-  - Type: record of string to string
-  - Use when: you need custom request headers.
-
-- `options.includeTags`
-  - Type: array of strings
-  - Use when: you want to include only specific HTML tags.
-
-- `options.excludeTags`
-  - Type: array of strings
-  - Use when: you want to exclude specific HTML tags.
-
-- `options.onlyMainContent`
-  - Type: boolean
-  - Use when: you want to strip nav, footer, and other boilerplate.
-
-- `options.timeout`
-  - Type: number
-  - Use when: you need a timeout in milliseconds.
-
-- `options.waitFor`
-  - Type: number
-  - Use when: you need to wait for the page to render (milliseconds).
-
-- `options.mobile`
-  - Type: boolean
-  - Use when: you want a mobile viewport.
-
-- `options.parsers`
-  - Type: array of parser names or parser objects
-  - Use when: you need file parsing controls (for example PDF parsing).
-  - Confirmed values:
-    - `"pdf"`: enable PDF parsing
-    - `{ type: "pdf", mode?: "fast" | "auto" | "ocr", maxPages?: number }`: PDF parser options
-
-- `options.actions`
-  - Type: array of action objects
-  - Use when: you need lightweight pre-scrape actions.
-  - Confirmed action types:
-    - `wait`: `milliseconds` or `selector` required
-    - `screenshot`: `fullPage`, `quality`, `viewport` optional
-    - `click`: `selector` required
-    - `write`: `text` required (click to focus the input first)
-    - `press`: `key` required
-    - `scroll`: `direction` (`up` or `down`) required, `selector` optional
-    - `scrape`: no additional fields
-    - `executeJavascript`: `script` required
-    - `pdf`: `format` (A0, A1, A2, A3, A4, A5, A6, Letter, Legal, Tabloid, Ledger), `landscape`, `scale` optional
-
-- `options.location`
-  - Type: object with `country` and `languages`
-  - Use when: you need geo or language-aware scraping.
-
-- `options.skipTlsVerification`
-  - Type: boolean
-  - Use when: you need to skip TLS verification.
-
-- `options.removeBase64Images`
-  - Type: boolean
-  - Use when: you want to drop base64 images from markdown output.
-
-- `options.fastMode`
-  - Type: boolean
-  - Use when: you want faster scrapes with reduced fidelity.
-
-- `options.blockAds`
-  - Type: boolean
-  - Use when: you want ad and cookie popup blocking.
-
-- `options.proxy`
-  - Type: string
-  - Use when: you need proxy control.
-  - Confirmed values:
-    - `"basic"`
-    - `"stealth"`
-    - `"enhanced"`
-    - `"auto"`
-    - custom proxy URL string
-
-- `options.maxAge`
-  - Type: number
-  - Use when: you want cached data up to a maximum age (milliseconds).
-
-- `options.minAge`
-  - Type: number
-  - Use when: you want cached data only if it is at least this old (milliseconds).
-
-- `options.storeInCache`
-  - Type: boolean
-  - Use when: you want Firecrawl to cache the result.
-
-- `options.profile`
-  - Type: object with `name` and optional `saveChanges`
-  - Use when: you want a persistent browser profile shared across scrapes and interactions.
-
-## Interact
-
-### Why use it
-
-Use `interact` for code or natural-language control of the browser session tied to a scrape job (via `metadata.scrapeId`). The SDK requires at least one of `code` or `prompt`. For flows that go beyond quick pre-scrape tweaks, prefer `interact` over scrape-time `actions`.
-
-### Preferred SDK method
-
-`client.interact(jobId, args)` → `Promise<ScrapeExecuteResponse>`
-
-### Simple Example
-
-```ts
-const doc = await client.scrape("https://example.com", { formats: ["markdown"] });
-const jobId = doc.metadata?.scrapeId;
-if (!jobId) throw new Error("Missing scrapeId from scrape response");
-
-const result = await client.interact(jobId, {
-  prompt: "Click the pricing tab and summarize the plans."
-});
-```
-
-### Complex Example
-
-```ts
-const result = await client.interact("<scrapeJobId>", {
-  code: "console.log(await page.title());",
-  language: "node",
-  timeout: 60
-});
-```
-
-### Parameters
-
-- `jobId`
-  - Type: string
-  - Use when: you have a scrape job ID from `document.metadata.scrapeId`.
-
-- `args.code`
-  - Type: string
-  - Use when: you want to run code in the browser session (for example Playwright `page` usage in the `node` runtime).
-
-- `args.prompt`
-  - Type: string
-  - Use when: you want the browser agent to follow a natural-language instruction.
-
-- At least one of `args.code` or `args.prompt` must be non-empty (SDK throws otherwise).
-
-- `args.language`
-  - Type: string
-  - Use when: you need a specific runtime.
-  - Confirmed values: `"python"`, `"node"`, `"bash"`
-  - Default when omitted: `"node"` (set by the SDK on the request body).
-
-- `args.timeout`
-  - Type: number
-  - Use when: you need an execution timeout in seconds.
-
-### Return value (`interact`)
-
-`ScrapeExecuteResponse` matches `BrowserExecuteResponse`. Confirmed fields include:
-
-- `success`: boolean
-- `output`: string (aggregated output when present)
-- `stdout`: string
-- `result`: string (alias-style field alongside stdout in typings)
-- `stderr`: string
-- `exitCode`: number
-- `killed`: boolean
-- `liveViewUrl`: string
-- `interactiveLiveViewUrl`: string
-- `error`: string
-
-### Stop session
-
-`client.stopInteraction(jobId)` → `Promise<ScrapeBrowserDeleteResponse>`
-
-- `jobId`: scrape job id (same id used for `interact`).
-- Response fields in typings include `success`, `sessionDurationMs`, `creditsBilled`, `error`.
-
-## Ask (Agentic Debugging)
-
-### Why use it
-
-Use ask when a Firecrawl API call fails or returns unexpected results. The AI support agent diagnoses the issue, proposes fix parameters, and optionally validates the fix against the live API. Typical latency: 15-30 seconds.
-
-### Preferred SDK method
-
-Not yet available in the Node.js SDK. Use `fetch` directly.
-
-### Simple Example
-
-```ts
-const response = await fetch("https://api.firecrawl.dev/v2/support/ask", {
-  method: "POST",
-  headers: {
-    Authorization: `Bearer ${process.env.FIRECRAWL_API_KEY}`,
-    "Content-Type": "application/json",
-  },
-  body: JSON.stringify({
-    question: "my scrape returned empty markdown for https://example.com",
-  }),
-});
-const result = await response.json();
-console.log(result.answer);
-console.log(result.fixParameters);
-```
-
-### Complex Example
-
-```ts
-const response = await fetch("https://api.firecrawl.dev/v2/support/ask", {
-  method: "POST",
-  headers: {
-    Authorization: `Bearer ${process.env.FIRECRAWL_API_KEY}`,
-    "Content-Type": "application/json",
-  },
-  body: JSON.stringify({
-    question: "crawl returned 3 pages but I expected 50",
-    rationale: "user is on their third failed crawl attempt today",
-    context: { userPlan: "standard", retryCount: 3 },
-  }),
-});
-const result = await response.json();
-```
-
-### Agent retry pattern
-
-```ts
-import { Firecrawl } from "firecrawl";
-
-const client = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
-
-const doc = await client.scrape("https://example.com/pricing", {
-  formats: ["markdown"],
+### Example
+
+```javascript
+const results = await client.search("firecrawl web scraping API", {
+  limit: 5,
+  scrapeOptions: { formats: ["markdown"] },
 });
 
-if (!doc.markdown || doc.markdown.length < 100) {
-  const diagResponse = await fetch(
-    "https://api.firecrawl.dev/v2/support/ask",
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${process.env.FIRECRAWL_API_KEY}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        question: `scrape returned only ${doc.markdown?.length ?? 0} chars for https://example.com/pricing`,
-      }),
-    }
-  );
-  const diagnosis = await diagResponse.json();
-
-  if (diagnosis.fixParameters) {
-    const retryDoc = await client.scrape("https://example.com/pricing", {
-      formats: ["markdown"],
-      ...diagnosis.fixParameters,
-    });
-  }
+for (const page of results.web) {
+  console.log(page.url, page.markdown?.slice(0, 200));
 }
 ```
 
 ### Parameters
 
-- `question`
-  - Type: string (required, 1-8000 chars)
-  - Use when: you need to describe the issue.
+All parameters are optional except `query`.
 
-- `rationale`
-  - Type: string (1-2000 chars)
-  - Use when: you are an AI agent calling on behalf of a user.
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `string` | **Required.** The search query. Must be non-empty. |
+| `sources` | `Array<"web" \| "news" \| "images" \| { type: ... }>` | Which search sources to query. Determines which arrays appear in the response. |
+| `categories` | `Array<"github" \| "research" \| "pdf">` | Category filters for results. |
+| `includeDomains` | `string[]` | Restrict results to these domains. Cannot use with `excludeDomains`. |
+| `excludeDomains` | `string[]` | Exclude results from these domains. Cannot use with `includeDomains`. |
+| `limit` | `number` | Max results to return. Must be positive. |
+| `tbs` | `string` | Time-based search filter (e.g. `"qdr:d"` for past day, `"qdr:w"` for past week). |
+| `location` | `string` | Location for geo-targeted results. |
+| `ignoreInvalidURLs` | `boolean` | Skip invalid URLs in results instead of failing. |
+| `timeout` | `number` | Timeout in milliseconds. Must be positive. |
+| `highlights` | `boolean` | Generate query-relevant highlights. Defaults to `true`. |
+| `scrapeOptions` | `ScrapeOptions` | Options applied when scraping each result page (same type as `scrape` options). |
+| `enterprise` | `Array<"default" \| "anon" \| "zdr">` | Enterprise options. `"zdr"` = Zero Data Retention, `"anon"` = anonymized search. |
+| `threatProtection` | `ThreatProtectionOptions` | Per-request threat protection override (enterprise). |
+| `integration` | `string` | Integration identifier. |
+| `origin` | `string` | Origin identifier. |
 
-- `context`
-  - Type: object (free-form)
-  - Use when: you want to pass metadata into the debugging prompt.
+**Return type:** `SearchData` with properties `.web`, `.news`, `.images`. Access `.data` throws an error — use the typed properties instead.
 
-## Docs Search
+## Scrape
 
 ### Why use it
 
-Use docs-search to look up Firecrawl documentation.
+Scrape a single URL and get back its content in one or more formats. Supports markdown, HTML, screenshots, structured JSON extraction, and more.
 
-### Simple Example
+### Preferred SDK method
 
-```ts
-const response = await fetch(
-  "https://api.firecrawl.dev/v2/support/docs-search",
-  {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${process.env.FIRECRAWL_API_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      question: "how do I verify webhook signatures?",
-    }),
-  }
-);
-const result = await response.json();
-console.log(result.answer);
+```javascript
+client.scrape(url, options?)
+```
+
+### Example
+
+```javascript
+const doc = await client.scrape("https://example.com", {
+  formats: ["markdown", "links"],
+});
+
+console.log(doc.markdown);
+console.log(doc.links);
+```
+
+Structured JSON extraction with a Zod schema:
+
+```javascript
+import { z } from "zod";
+
+const doc = await client.scrape("https://example.com/product", {
+  formats: [{ type: "json", schema: z.object({ title: z.string(), price: z.number() }) }],
+});
+
+console.log(doc.json); // { title: "...", price: 29.99 }
 ```
 
 ### Parameters
 
-- `question`
-  - Type: string (required, 1-8000 chars)
-  - Use when: you need a docs-grounded answer.
+All parameters are optional except `url`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `string` | **Required.** The URL to scrape. |
+| `formats` | `FormatOption[]` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Objects: `{ type: "json", schema?, prompt? }`, `{ type: "screenshot", fullPage?, quality?, viewport? }`, `{ type: "changeTracking", modes, schema?, prompt?, tag? }`, `{ type: "attributes", selectors }`, `{ type: "question", question }`, `{ type: "highlights", query }`. Note: `"json"` as a plain string is rejected — use the object form. |
+| `headers` | `Record<string, string>` | Custom HTTP headers. |
+| `includeTags` | `string[]` | HTML tags to include. |
+| `excludeTags` | `string[]` | HTML tags to exclude. |
+| `onlyMainContent` | `boolean` | Only return main content, excluding navbars/footers. |
+| `timeout` | `number` | Timeout in milliseconds. |
+| `waitFor` | `number` | Wait time in ms before scraping (in addition to smart wait). |
+| `mobile` | `boolean` | Emulate a mobile device. |
+| `parsers` | `Array<string \| { type: "pdf", mode?, maxPages? }>` | Parser config (e.g. PDF parsing). |
+| `actions` | `ActionOption[]` | Browser actions before scrape. Types: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`. |
+| `location` | `{ country?: string, languages?: string[] }` | Proxy location and language emulation. |
+| `skipTlsVerification` | `boolean` | Skip TLS certificate verification. |
+| `removeBase64Images` | `boolean` | Remove base64-encoded images from output. |
+| `fastMode` | `boolean` | Enable fast mode. |
+| `blockAds` | `boolean` | Block ads and cookie popups. |
+| `proxy` | `"basic" \| "stealth" \| "enhanced" \| "auto" \| string` | Proxy type. `"enhanced"` handles advanced anti-bot (up to 5 credits). `"auto"` retries with enhanced if basic fails. |
+| `maxAge` | `number` | Max cache age in milliseconds. |
+| `minAge` | `number` | Min cache age in milliseconds. Only checks cache, never triggers fresh scrape. |
+| `storeInCache` | `boolean` | Store result in cache. |
+| `lockdown` | `boolean` | Serve only cached results, never make outbound requests. Returns 404 on cache miss. |
+| `redactPII` | `boolean \| RedactPIIOptions` | Redact PII. Object form: `{ mode?, entities?, replaceStyle? }`. |
+| `threatProtection` | `ThreatProtectionOptions` | Per-request threat protection override (enterprise). |
+| `auditMetadata` | `{ username: string }` | User attribution for SIEM logging. |
+| `profile` | `{ name: string, saveChanges?: boolean }` | Persistent browser profile for cookies/localStorage across sessions. |
+| `integration` | `string` | Integration identifier. |
+| `origin` | `string` | Origin identifier. |
+
+**Return type:** `Document` with fields: `markdown`, `html`, `rawHtml`, `json`, `summary`, `metadata`, `links`, `images`, `screenshot`, `audio`, `video`, `attributes`, `actions`, `answer`, `highlights`, `warning`, `changeTracking`, `branding`, `product`, `menu`.
+
+## Interact
+
+### Why use it
+
+Execute code or a natural-language prompt in the live browser session that was created by a prior `scrape` call. Use this for multi-step workflows: clicking buttons, filling forms, navigating, or running scripts against the page.
+
+### Preferred SDK method
+
+```javascript
+client.interact(jobId, args)
+```
+
+### Example
+
+```javascript
+const doc = await client.scrape("https://example.com", {
+  formats: ["markdown"],
+});
+const jobId = doc.metadata.jobId;
+
+const result = await client.interact(jobId, {
+  code: "document.title",
+  language: "node",
+  timeout: 30,
+});
+
+console.log(result.stdout);
+```
+
+Using a natural-language prompt:
+
+```javascript
+const result = await client.interact(jobId, {
+  prompt: "Click the login button and fill in the email field with test@example.com",
+});
+
+console.log(result.output);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `string` | **Required.** The scrape job ID (from `doc.metadata.jobId`). |
+| `code` | `string` | Code to execute. Either `code` or `prompt` must be provided. |
+| `prompt` | `string` | Natural-language instruction for the browser agent. Either `code` or `prompt` must be provided. |
+| `language` | `"python" \| "node" \| "bash"` | Language for code execution. Defaults to `"node"`. |
+| `timeout` | `number` | Execution timeout in seconds. |
+| `origin` | `string` | Origin identifier. |
+
+**Return type:** `BrowserExecuteResponse` with fields: `success`, `cdpUrl`, `liveViewUrl`, `interactiveLiveViewUrl`, `output`, `stdout`, `result`, `stderr`, `exitCode`, `killed`, `error`.
+
+Call `client.stopInteraction(jobId)` to end the browser session when done.
 
 ## Notes
 
-- Deprecated client aliases: `scrapeExecute` → `interact`; `stopInteractiveBrowser` and `deleteScrapeBrowser` → `stopInteraction`.
-- The default `Firecrawl` export is the v2 client; v1 remains under `client.v1`.
-- Zod schemas passed to `formats` (for `json` or `changeTracking`) are converted to JSON Schema by the SDK.
-- The package declares **Node.js >= 22** in `engines`.
+- **camelCase parameters** — All option fields use camelCase (e.g. `onlyMainContent`, `includeTags`).
+- **`"json"` format** — Must be passed as an object `{ type: "json", schema?, prompt? }`, never as the plain string `"json"`. Zod schemas are automatically converted to JSON Schema by the SDK.
+- **`"question"` and `"highlights"` formats** — Also object-only: `{ type: "question", question: "..." }` and `{ type: "highlights", query: "..." }`.
+- **SearchData access** — Use `.web`, `.news`, `.images` on the search result. Accessing `.data` throws an error.
+- **Deprecated aliases** — `scrapeUrl` → `scrape`, `scrapeExecute` → `interact`, `stopInteractiveBrowser`/`deleteScrapeBrowser` → `stopInteraction`. Always use the preferred names.
 
 ## Source Of Truth
 
@@ -537,7 +228,4 @@ console.log(result.answer);
 - `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
 - `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
 - `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
-- `firecrawl/apps/js-sdk/firecrawl/src/v2/utils/validation.ts`
-- `firecrawl/apps/js-sdk/firecrawl/src/v2/methods/search.ts`
-- `firecrawl/apps/js-sdk/firecrawl/src/v2/methods/scrape.ts`
 - `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-source-of-truth/python.mdx
+++ b/agent-source-of-truth/python.mdx
@@ -1,9 +1,11 @@
 ---
 title: "Python Source of Truth"
-description: "Canonical Firecrawl Python source of truth for agents using key endpoints like search, scrape, and interact."
+description: "Canonical Firecrawl Python source of truth for agents using search, scrape, and interact."
 ---
 
-Canonical Firecrawl Python source of truth for agents. Generated from SDK source (`firecrawl-py` / `firecrawl` **4.22.1**) and the v2 OpenAPI spec. Method names, parameters, and return types match the v2 client in `firecrawl/v2/client.py` unless noted.
+# Firecrawl Python Agent Quickstart
+
+This file is the canonical quickstart for external agents using the Firecrawl Python SDK. It is generated from SDK source (`firecrawl-py`) and the Firecrawl OpenAPI spec.
 
 ## Install
 
@@ -13,512 +15,206 @@ pip install firecrawl-py
 
 ## Authenticate
 
-```py
-import os
+```python
 from firecrawl import Firecrawl
 
-client = Firecrawl(api_key=os.environ.get("FIRECRAWL_API_KEY"))
-# client = Firecrawl(api_key="fc-...", api_url="https://api.firecrawl.dev")
+client = Firecrawl(api_key="fc-YOUR_API_KEY")
 ```
+
+The API key can also be set via the `FIRECRAWL_API_KEY` environment variable. If omitted entirely, the SDK falls back to a keyless free tier (rate-limited per IP) for scrape, search, and interact.
+
+For async usage, use `AsyncFirecrawl` instead of `Firecrawl`.
+
+Constructor parameters:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `api_key` | `str` | `None` (falls back to env var) | API key |
+| `api_url` | `str` | `"https://api.firecrawl.dev"` | Base API URL |
+| `timeout` | `float` | `None` | Default request timeout in seconds |
+| `max_retries` | `int` | `3` | Max automatic retries |
+| `backoff_factor` | `float` | `0.5` | Exponential backoff factor |
 
 ## When To Use What
 
-- `search`: use when you start with a query and need discovery.
-- `scrape`: use when you already have a URL and want page content.
-- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
-- `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
-- `support/docs-search`: use when you need to look up Firecrawl documentation.
+- **`search`** — Use when you start with a query and need to discover relevant URLs. Returns search results and optionally scrapes each result page.
+- **`scrape`** — Use when you already have a URL and want page content (markdown, HTML, screenshots, structured JSON, etc.).
+- **`interact`** — Use when the page needs post-scrape browser actions: clicking elements, filling forms, or executing code in the live browser session.
 
 ## Search
 
 ### Why use it
 
-Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. You can constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+Search the web for a query and get back results with metadata. Optionally scrape each result page by passing `scrape_options`.
 
 ### Preferred SDK method
 
-`client.search(query, **options)` → `SearchData` (`firecrawl.v2.types`)
-
-### Return value
-
-Returns a `SearchData` model with optional lists:
-
-- `web` — web hits (`SearchResultWeb` or full `Document` when `scrape_options` hydrates content)
-- `news` — news hits (`SearchResultNews` or `Document`)
-- `images` — image hits (`SearchResultImages` or `Document`)
-
-Omitted buckets are `None` when the API did not return that key.
-
-**Wrong turn to avoid:** `search()` does not return `{ data: [...] }`. Do not access `result.data`. Web results are in `result.web`, news in `result.news`, images in `result.images`.
-
-### Simple Example
-
-```py
-results = client.search("site:docs.firecrawl.dev webhook retries")
-for item in results.web or []:
-    print(getattr(item, "url", None), getattr(item, "title", None))
+```python
+client.search(query, **options)
 ```
 
-### Complex Example
+### Example
 
-```py
-from firecrawl.v2.types import ScrapeOptions
-
+```python
 results = client.search(
-    "site:docs.firecrawl.dev crawl webhooks",
-    sources=["web", "news"],
-    categories=["research"],
-    limit=10,
-    tbs="qdr:m",
-    location="San Francisco,California,United States",
-    ignore_invalid_urls=True,
-    timeout=300000,
-    scrape_options=ScrapeOptions(
-        formats=[
-            "markdown",
-            "links",
-            {"type": "json", "prompt": "Extract title and key endpoints."},
-        ],
-        only_main_content=True,
-        include_tags=["main", "article"],
-        exclude_tags=["nav", "footer"],
-        wait_for=1000,
-        actions=[
-            {"type": "click", "selector": "button#accept"},
-            {"type": "wait", "milliseconds": 750},
-            {"type": "scrape"},
-        ],
-    ),
+    "firecrawl web scraping API",
+    limit=5,
+    scrape_options={"formats": ["markdown"]},
 )
+
+for page in results.web:
+    print(page.url, page.markdown[:200] if page.markdown else "")
 ```
 
 ### Parameters
 
-- `query`
-  - Type: str
-  - Use when: you need a search query.
-  - Notes: use `site:example.com` to limit results to a domain.
+All parameters are keyword-only except `query`.
 
-- `sources`
-  - Type: list of source names or `Source` objects
-  - Use when: you want to control which sources are searched.
-  - Confirmed values:
-    - `"web"`: web index results
-    - `"news"`: news results
-    - `"images"`: image results
-    - `Source(type="web" | "news" | "images")`: typed source object form
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `str` | **Required.** The search query string. |
+| `sources` | `list[str \| Source]` | Sources to search (e.g. `"web"`, `"news"`, `"images"`). |
+| `categories` | `list[str \| Category]` | Category filters (e.g. `"github"`, `"research"`, `"pdf"`). |
+| `include_domains` | `list[str]` | Restrict results to these domains. Cannot use with `exclude_domains`. |
+| `exclude_domains` | `list[str]` | Exclude results from these domains. Cannot use with `include_domains`. |
+| `limit` | `int` | Max results to return. Default: `5`. |
+| `tbs` | `str` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `str` | Location string for geo-targeted results. |
+| `ignore_invalid_urls` | `bool` | Skip invalid URLs instead of failing. |
+| `timeout` | `int` | Timeout in milliseconds. Default: `300000`. |
+| `highlights` | `bool` | Generate query-relevant highlights. Defaults to `True`. |
+| `scrape_options` | `ScrapeOptions \| dict` | Options for scraping each result page. |
+| `integration` | `str` | Integration identifier. |
+| `enterprise` | `list[str]` | Enterprise options. `["zdr"]` for Zero Data Retention, `["anon"]` for anonymized search. |
+| `threat_protection` | `ThreatProtectionOptions` | Per-request threat protection override (enterprise). |
 
-- `categories`
-  - Type: list of category names or `Category` objects
-  - Use when: you want to filter results by category.
-  - Confirmed values:
-    - `"github"`: GitHub-focused results
-    - `"research"`: research and academic results
-    - `"pdf"`: PDF-focused results
-    - `Category(type="github" | "research" | "pdf")`: typed category object form
-
-- `limit`
-  - Type: int
-  - Use when: you want to cap results.
-  - Notes: defaults to `5` in the SDK model.
-
-- `tbs`
-  - Type: str
-  - Use when: you need a time-based filter (for example `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
-
-- `location`
-  - Type: str
-  - Use when: you want localized results.
-
-- `ignore_invalid_urls`
-  - Type: bool
-  - Use when: you want to drop URLs that cannot be scraped by other endpoints.
-
-- `timeout`
-  - Type: int
-  - Use when: you need a request timeout in milliseconds.
-  - Notes: defaults to `300000` in the SDK model.
-
-- `scrape_options`
-  - Type: `ScrapeOptions`
-  - Use when: you want to scrape each search result (see Scrape parameters for fields).
+**Return type:** `SearchData` with properties `.web`, `.news`, `.images`. Accessing `.data` raises an `AttributeError` — use the typed properties instead.
 
 ## Scrape
 
 ### Why use it
 
-Use scrape when you already have a URL and want structured content in one or more formats.
+Scrape a single URL and get back its content in one or more formats. Supports markdown, HTML, screenshots, structured JSON extraction, and more.
 
 ### Preferred SDK method
 
-`client.scrape(url, **options)` → `Document` (`firecrawl.v2.types`)
-
-### Simple Example
-
-```py
-doc = client.scrape("https://docs.firecrawl.dev", formats=["markdown"])
+```python
+client.scrape(url, **options)
 ```
 
-### Complex Example
+### Example
 
-```py
+```python
+doc = client.scrape("https://example.com", formats=["markdown", "links"])
+
+print(doc.markdown)
+print(doc.links)
+```
+
+Structured JSON extraction:
+
+```python
 doc = client.scrape(
-    "https://example.com/pricing",
-    formats=[
-        "markdown",
-        "links",
-        {"type": "json", "prompt": "Extract plan names and prices."},
-        {"type": "screenshot", "full_page": True, "quality": 80, "viewport": {"width": 1280, "height": 720}},
-        {"type": "changeTracking", "modes": ["git-diff"], "tag": "pricing"},
-        {"type": "attributes", "selectors": [{"selector": "a", "attribute": "href"}]},
-    ],
-    headers={"User-Agent": "FirecrawlDocsBot/1.0"},
-    only_main_content=True,
-    wait_for=1000,
-    parsers=[{"type": "pdf", "mode": "auto", "max_pages": 5}],
-    actions=[
-        {"type": "click", "selector": "#accept"},
-        {"type": "wait", "milliseconds": 750},
-        {"type": "scrape"},
-    ],
-    location={"country": "US", "languages": ["en-US"]},
-    remove_base64_images=True,
-    fast_mode=True,
-    block_ads=True,
-    proxy="auto",
-    max_age=86400000,
-    store_in_cache=True,
-    profile={"name": "docs-session", "save_changes": True},
+    "https://example.com/product",
+    formats=[{"type": "json", "schema": {"type": "object", "properties": {"title": {"type": "string"}, "price": {"type": "number"}}}}],
 )
+
+print(doc.json)  # {"title": "...", "price": 29.99}
 ```
 
 ### Parameters
 
-- `url`
-  - Type: str
-  - Use when: you want to scrape a specific page.
+All parameters are keyword-only except `url`.
 
-- `formats`
-  - Type: list of format strings or format objects
-  - Use when: you want multiple output formats.
-  - Confirmed format strings:
-    - `"markdown"`: markdown content
-    - `"html"`: cleaned HTML
-    - `"rawHtml"` or `"raw_html"`: raw HTML
-    - `"links"`: page links
-    - `"images"`: image URLs
-    - `"screenshot"`: screenshot output
-    - `"summary"`: summary output
-    - `"changeTracking"` or `"change_tracking"`: change tracking output
-    - `"attributes"`: attribute extraction
-    - `"branding"`: branding profile output
-    - `"audio"`: audio extraction
-    - `"video"`: video extraction
-  - Object-only format types:
-    - `{"type": "json", ...}`: JSON extraction. Use an object, not the plain string `"json"`.
-    - `{"type": "question", "question": "..."}`: question-answer output.
-    - `{"type": "highlights", "query": "..."}`: relevant source-text output.
-  - Format object fields:
-    - `type`: one of the format strings above, or `"json"`, `"question"`, or `"highlights"` for object-only formats
-    - `question`: for `type: "question"`
-    - `query`: for `type: "highlights"`
-    - `prompt`: optional for `type: "json"`
-    - `schema`: JSON schema for `type: "json"` or for change tracking JSON mode
-    - `modes`: array of `"git-diff"` or `"json"` for `type: "changeTracking"`
-    - `tag`: change tracking tag for `type: "changeTracking"`
-    - `full_page`, `quality`, `viewport`: screenshot options for `type: "screenshot"`
-    - `selectors`: array of `{selector, attribute}` for `type: "attributes"`
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `str` | **Required.** The URL to scrape. |
+| `formats` | `list[str]` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"` (or `"raw_html"`), `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"` (or `"change_tracking"`), `"json"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. |
+| `headers` | `dict[str, str]` | Custom HTTP headers. |
+| `include_tags` | `list[str]` | HTML tags to include. |
+| `exclude_tags` | `list[str]` | HTML tags to exclude. |
+| `only_main_content` | `bool` | Only return main content, excluding navbars/footers. |
+| `timeout` | `int` | Timeout in milliseconds. |
+| `wait_for` | `int` | Wait time in ms before scraping (in addition to smart wait). |
+| `mobile` | `bool` | Emulate a mobile device. |
+| `parsers` | `list[str \| PDFParser]` | Parser config (e.g. `["pdf"]` or `[PDFParser(mode="fast")]`). |
+| `actions` | `list[Action]` | Browser actions before scrape. Types: `WaitAction`, `ScreenshotAction`, `ClickAction`, `WriteAction`, `PressAction`, `ScrollAction`, `ScrapeAction`, `ExecuteJavascriptAction`, `PDFAction`. |
+| `location` | `Location` | Location config with `country` and `languages`. |
+| `skip_tls_verification` | `bool` | Skip TLS certificate verification. |
+| `remove_base64_images` | `bool` | Remove base64-encoded images from output. |
+| `fast_mode` | `bool` | Enable fast mode. |
+| `block_ads` | `bool` | Block ads and cookie popups. |
+| `proxy` | `str` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. |
+| `max_age` | `int` | Max cache age in milliseconds. |
+| `store_in_cache` | `bool` | Store result in cache. |
+| `lockdown` | `bool` | Serve only cached results, never make outbound requests. Returns 404 on cache miss. |
+| `threat_protection` | `ThreatProtectionOptions` | Per-request threat protection override (enterprise). |
+| `profile` | `dict` | Persistent browser profile (e.g. `{"name": "my-profile", "saveChanges": True}`). |
+| `audit_metadata` | `AuditMetadata` | User attribution for SIEM logging (e.g. `AuditMetadata(username="agent")`). |
+| `integration` | `str` | Integration identifier. |
 
-- `headers`
-  - Type: dict of str to str
-  - Use when: you need custom request headers.
-
-- `include_tags`
-  - Type: list of str
-  - Use when: you want to include only specific HTML tags.
-
-- `exclude_tags`
-  - Type: list of str
-  - Use when: you want to exclude specific HTML tags.
-
-- `only_main_content`
-  - Type: bool
-  - Use when: you want to strip nav, footer, and other boilerplate.
-
-- `timeout`
-  - Type: int
-  - Use when: you need a timeout in milliseconds.
-
-- `wait_for`
-  - Type: int
-  - Use when: you need to wait for the page to render (milliseconds).
-
-- `mobile`
-  - Type: bool
-  - Use when: you want a mobile viewport.
-
-- `parsers`
-  - Type: list of parser names or parser objects
-  - Use when: you need file parsing controls (for example PDF parsing).
-  - Confirmed values:
-    - `"pdf"`: enable PDF parsing
-    - `{ "type": "pdf", "mode": "fast" | "auto" | "ocr", "max_pages": int }`: PDF parser options
-
-- `actions`
-  - Type: list of action objects
-  - Use when: you need lightweight pre-scrape actions.
-  - Confirmed action types:
-    - `wait`: `milliseconds` or `selector` required
-    - `screenshot`: `full_page`, `quality`, `viewport` optional
-    - `click`: `selector` required
-    - `write`: `text` required (click to focus the input first)
-    - `press`: `key` required
-    - `scroll`: `direction` (`up` or `down`) required, `selector` optional
-    - `scrape`: no additional fields
-    - `executeJavascript`: `script` required
-    - `pdf`: `format` (A0, A1, A2, A3, A4, A5, A6, Letter, Legal, Tabloid, Ledger), `landscape`, `scale` optional
-
-- `location`
-  - Type: dict with `country` and `languages`
-  - Use when: you need geo or language-aware scraping.
-
-- `skip_tls_verification`
-  - Type: bool
-  - Use when: you need to skip TLS verification.
-
-- `remove_base64_images`
-  - Type: bool
-  - Use when: you want to drop base64 images from markdown output.
-
-- `fast_mode`
-  - Type: bool
-  - Use when: you want faster scrapes with reduced fidelity.
-
-- `block_ads`
-  - Type: bool
-  - Use when: you want ad and cookie popup blocking.
-
-- `proxy`
-  - Type: str
-  - Use when: you need proxy control.
-  - Confirmed values: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`
-
-- `max_age`
-  - Type: int
-  - Use when: you want cached data up to a maximum age (milliseconds).
-
-- `min_age`
-  - Type: int
-  - Use when: you want cached data only if it is at least this old (milliseconds).
-  - Notes: only on `ScrapeOptions` passed as `scrape_options` to `client.search`. The `client.scrape` method does not accept `min_age`.
-
-- `store_in_cache`
-  - Type: bool
-  - Use when: you want Firecrawl to cache the result.
-
-- `profile`
-  - Type: dict with `name` and optional `save_changes` or `saveChanges`
-  - Use when: you want a persistent browser profile shared across scrapes and interactions.
+**Return type:** `Document` with fields: `markdown`, `html`, `raw_html`, `json`, `summary`, `metadata`, `links`, `images`, `screenshot`, `audio`, `video`, `attributes`, `actions`, `answer`, `highlights`, `warning`, `change_tracking`, `branding`, `product`, `menu`.
 
 ## Interact
 
 ### Why use it
 
-Use interact when a page requires browser actions or code execution after a scrape starts.
+Execute code or a natural-language prompt in the live browser session that was created by a prior `scrape` call. Use this for multi-step workflows: clicking buttons, filling forms, navigating, or running scripts against the page.
 
 ### Preferred SDK method
 
-`client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None)`
+```python
+client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None)
+```
 
-`prompt` is keyword-only: call `client.interact(job_id, prompt="...")` or `client.interact(job_id, code="...")`. At least one of `code` or `prompt` must be non-empty (validated in `firecrawl/v2/methods/scrape.py`).
+### Example
 
-### Simple Example
-
-```py
+```python
 doc = client.scrape("https://example.com", formats=["markdown"])
-job_id = doc.metadata.scrape_id if doc.metadata else None
-if not job_id:
-    raise RuntimeError("Missing scrape_id from scrape response")
+job_id = doc.metadata.job_id
 
-result = client.interact(job_id, prompt="Click the pricing tab and summarize the plans.")
+result = client.interact(job_id, code="document.title", language="node", timeout=30)
+print(result.stdout)
 ```
 
-### Complex Example
+Using a natural-language prompt:
 
-```py
+```python
 result = client.interact(
-    "<scrapeJobId>",
-    code="print(await page.title())",
-    language="python",
-    timeout=60,
+    job_id,
+    prompt="Click the login button and fill in the email field with test@example.com",
 )
-```
-
-### Stop session
-
-`client.stop_interaction(job_id)` ends the scrape-bound browser session. Returns `BrowserDeleteResponse` (`success`, optional `session_duration_ms`, `credits_billed`, `error`).
-
-### Parameters
-
-- `job_id`
-  - Type: str
-  - Use when: you have a scrape job ID from `document.metadata.scrape_id`.
-
-- `code`
-  - Type: str
-  - Use when: you want to run code in the browser session (optional if `prompt` is set).
-
-- `prompt`
-  - Type: str
-  - Use when: you want the browser agent to follow a natural-language instruction (optional if `code` is set).
-
-- `language`
-  - Type: str
-  - Use when: you need a specific runtime.
-  - Confirmed values: `"python"`, `"node"`, `"bash"`
-  - Notes: defaults to `"node"` in the SDK.
-
-- `timeout`
-  - Type: int
-  - Use when: you need an execution timeout in seconds.
-
-### Return value
-
-Returns `BrowserExecuteResponse`: `success`, optional `live_view_url`, `interactive_live_view_url`, `output`, `stdout`, `result`, `stderr`, `exit_code`, `killed`, `error` (API camelCase is normalized to snake_case on the model).
-
-## Ask (Agentic Debugging)
-
-### Why use it
-
-Use ask when a Firecrawl API call fails or returns unexpected results. The AI support agent diagnoses the issue, proposes fix parameters, and optionally validates the fix against the live API. Typical latency: 15-30 seconds.
-
-### Preferred SDK method
-
-Not yet available in the Python SDK. Use `requests` or `httpx` directly.
-
-### Simple Example
-
-```py
-import requests
-
-response = requests.post(
-    "https://api.firecrawl.dev/v2/support/ask",
-    headers={
-        "Authorization": f"Bearer {os.environ['FIRECRAWL_API_KEY']}",
-        "Content-Type": "application/json",
-    },
-    json={"question": "my scrape returned empty markdown for https://example.com"},
-)
-result = response.json()
-print(result["answer"])
-print(result["fixParameters"])
-```
-
-### Complex Example
-
-```py
-import requests
-
-response = requests.post(
-    "https://api.firecrawl.dev/v2/support/ask",
-    headers={
-        "Authorization": f"Bearer {os.environ['FIRECRAWL_API_KEY']}",
-        "Content-Type": "application/json",
-    },
-    json={
-        "question": "crawl returned 3 pages but I expected 50",
-        "rationale": "user is on their third failed crawl attempt today",
-        "context": {"userPlan": "standard", "retryCount": 3},
-    },
-)
-result = response.json()
-```
-
-### Agent retry pattern
-
-```py
-from firecrawl import Firecrawl
-import requests, os
-
-client = Firecrawl(api_key=os.environ["FIRECRAWL_API_KEY"])
-
-doc = client.scrape("https://example.com/pricing", formats=["markdown"])
-
-if not doc.markdown or len(doc.markdown) < 100:
-    diagnosis = requests.post(
-        "https://api.firecrawl.dev/v2/support/ask",
-        headers={
-            "Authorization": f"Bearer {os.environ['FIRECRAWL_API_KEY']}",
-            "Content-Type": "application/json",
-        },
-        json={
-            "question": f"scrape returned only {len(doc.markdown or '')} chars for https://example.com/pricing",
-        },
-    ).json()
-
-    if diagnosis.get("fixParameters"):
-        doc = client.scrape(
-            "https://example.com/pricing",
-            formats=["markdown"],
-            **diagnosis["fixParameters"],
-        )
+print(result.output)
 ```
 
 ### Parameters
 
-- `question`
-  - Type: str (required, 1-8000 chars)
-  - Use when: you need to describe the issue.
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `str` | **Required.** The scrape job ID (from `doc.metadata.job_id`). |
+| `code` | `str \| None` | Code to execute. Either `code` or `prompt` must be provided. |
+| `prompt` | `str \| None` | Natural-language instruction for the browser agent. Either `code` or `prompt` must be provided. |
+| `language` | `Literal["python", "node", "bash"]` | Language for code execution. Default: `"node"`. |
+| `timeout` | `int \| None` | Execution timeout in seconds (1–300). |
+| `origin` | `str \| None` | Origin tag for request attribution. |
 
-- `rationale`
-  - Type: str (1-2000 chars)
-  - Use when: you are an AI agent calling on behalf of a user.
+**Return type:** `BrowserExecuteResponse` with fields: `success`, `cdp_url`, `live_view_url`, `interactive_live_view_url`, `output`, `stdout`, `result`, `stderr`, `exit_code`, `killed`, `error`.
 
-- `context`
-  - Type: dict (free-form)
-  - Use when: you want to pass metadata into the debugging prompt.
-
-## Docs Search
-
-### Why use it
-
-Use docs-search to look up Firecrawl documentation.
-
-### Simple Example
-
-```py
-import requests
-
-FIRECRAWL_API_KEY = "fc-YOUR_API_KEY"
-
-response = requests.post(
-    "https://api.firecrawl.dev/v2/support/docs-search",
-    headers={"Authorization": f"Bearer {FIRECRAWL_API_KEY}"},
-    json={"question": "how do I verify webhook signatures?"},
-)
-print(response.json()["answer"])
-```
-
-### Parameters
-
-- `question`
-  - Type: str (required, 1-8000 chars)
-  - Use when: you need a docs-grounded answer.
+Call `client.stop_interaction(job_id)` to end the browser session when done.
 
 ## Notes
 
-- Deprecated aliases: `scrape_execute` → `interact`; `stop_interactive_browser` and `delete_scrape_browser` → `stop_interaction`.
-- The top-level `Firecrawl` client exposes v2 methods directly; v1 remains under `client.v1`.
-- The bundled v2 OpenAPI snippet for `POST /v2/scrape/{jobId}/interact` may only document `code`; the Python SDK and server accept either `code` or `prompt` for this endpoint.
+- **snake_case parameters** — All option fields use snake_case (e.g. `only_main_content`, `include_tags`).
+- **Format aliases** — Both camelCase and snake_case format strings are accepted: `"rawHtml"` or `"raw_html"`, `"changeTracking"` or `"change_tracking"`.
+- **`min_age` on scrape** — The `min_age` parameter is only available inside `scrape_options` when passed to `client.search()`, not directly on `client.scrape()`.
+- **SearchData access** — Use `.web`, `.news`, `.images` on the search result. Accessing `.data` raises an `AttributeError`.
+- **Async variant** — Use `AsyncFirecrawl` for async operations. All methods have the same signatures.
+- **Deprecated aliases** — `scrape_url` → `scrape`, `scrape_execute` → `interact`, `stop_interactive_browser`/`delete_scrape_browser` → `stop_interaction`, `FirecrawlApp` → `Firecrawl`. Always use the preferred names.
 
 ## Source Of Truth
 
 - `firecrawl/apps/python-sdk/pyproject.toml`
-- `firecrawl/apps/python-sdk/firecrawl/__init__.py`
 - `firecrawl/apps/python-sdk/firecrawl/client.py`
 - `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
 - `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
-- `firecrawl/apps/python-sdk/firecrawl/v2/methods/search.py`
-- `firecrawl/apps/python-sdk/firecrawl/v2/methods/scrape.py`
-- `firecrawl/apps/python-sdk/firecrawl/v2/utils/validation.py`
 - `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-source-of-truth/rust.mdx
+++ b/agent-source-of-truth/rust.mdx
@@ -1,9 +1,11 @@
 ---
 title: "Rust Source of Truth"
-description: "Canonical Firecrawl Rust source of truth for agents using key endpoints like search, scrape, and interact."
+description: "Canonical Firecrawl Rust source of truth for agents using search, scrape, and interact."
 ---
 
-Canonical Firecrawl Rust source of truth for agents. Generated from SDK source and the v2 OpenAPI spec.
+# Firecrawl Rust Agent Quickstart
+
+This file is the canonical quickstart for external agents using the Firecrawl Rust SDK. It is generated from SDK source (`firecrawl` crate v2.12.1) and the Firecrawl OpenAPI spec.
 
 ## Install
 
@@ -11,450 +13,248 @@ Canonical Firecrawl Rust source of truth for agents. Generated from SDK source a
 cargo add firecrawl
 ```
 
-Crate: **`firecrawl`** on crates.io. The current SDK version is **2.0.0** (verify the latest release on crates.io before pinning).
+Or add to `Cargo.toml`:
+
+```toml
+[dependencies]
+firecrawl = "2.12.1"
+tokio = { version = "1", features = ["full"] }
+```
 
 ## Authenticate
 
 ```rust
 use firecrawl::Client;
 
-let client = Client::new("fc-your-api-key")?;
-// Self-hosted example:
-// let client = Client::new_selfhosted("http://localhost:3002", Some("fc-your-api-key"))?;
+let client = Client::new("fc-YOUR_API_KEY")?;
 ```
+
+For self-hosted instances:
+
+```rust
+let client = Client::new_selfhosted("https://your-instance.com", Some("fc-YOUR_API_KEY"))?;
+```
+
+An empty or whitespace API key is accepted for the keyless free tier (rate-limited per IP) on scrape, search, and interact.
 
 ## When To Use What
 
-- `search`: use when you start with a query and need discovery.
-- `scrape`: use when you already have a URL and want page content.
-- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
-- `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
-- `support/docs-search`: use when you need to look up Firecrawl documentation.
+- **`search`** — Use when you start with a query and need to discover relevant URLs. Returns search results and optionally scrapes each result page.
+- **`scrape`** — Use when you already have a URL and want page content (markdown, HTML, screenshots, structured JSON, etc.).
+- **`interact`** — Use when the page needs post-scrape browser actions: clicking elements, filling forms, or executing code in the live browser session.
 
 ## Search
 
 ### Why use it
 
-Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. You can constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+Search the web for a query and get back results with metadata. Optionally scrape each result page by passing `scrape_options`.
 
 ### Preferred SDK method
 
-`client.search(query, options)` → `Result<SearchResponse, FirecrawlError>`
-
-### Simple Example
-
 ```rust
-use firecrawl::Client;
-
-let results = client
-    .search("site:docs.firecrawl.dev webhook retries", None)
-    .await?;
+client.search(query, options).await?
 ```
 
-### Complex Example
+### Example
 
 ```rust
-use firecrawl::{
-    Client, SearchOptions, SearchSource, SearchCategory, ScrapeOptions, Format, JsonOptions,
-};
+use firecrawl::{Client, SearchOptions};
 
-let options = SearchOptions {
-    sources: Some(vec![SearchSource::Web, SearchSource::News]),
-    categories: Some(vec![SearchCategory::Research]),
-    limit: Some(10),
-    tbs: Some("qdr:m".to_string()),
-    location: Some("San Francisco,California,United States".to_string()),
-    ignore_invalid_urls: Some(true),
-    timeout: Some(60000),
-    scrape_options: Some(ScrapeOptions {
-        formats: Some(vec![Format::Markdown, Format::Links, Format::Json]),
-        json_options: Some(JsonOptions {
-            prompt: Some("Extract title and key endpoints.".to_string()),
-            ..Default::default()
-        }),
-        only_main_content: Some(true),
-        ..Default::default()
-    }),
+let client = Client::new("fc-YOUR_API_KEY")?;
+
+let response = client.search("firecrawl web scraping API", SearchOptions {
+    limit: Some(5),
     ..Default::default()
-};
+}).await?;
 
-let results = client
-    .search("site:docs.firecrawl.dev crawl webhooks", options)
-    .await?;
+if let Some(web_results) = &response.data.web {
+    for result in web_results {
+        println!("{:?}", result);
+    }
+}
 ```
 
-### Return type
+Convenience method for search + scrape:
 
-`client.search(...)` returns `Result<SearchResponse, FirecrawlError>`.
-
-- `SearchResponse`
-  - `success: bool`
-  - `data: SearchData`
-  - `warning: Option<String>`
-- `SearchData`
-  - `web: Option<Vec<SearchResultOrDocument>>` — each item is either `SearchResultOrDocument::WebResult(SearchResultWeb)` (url, title, description, …) or `SearchResultOrDocument::Document(Document)` when the API returned scraped content for that row (detected when markdown, html, rawHtml, or metadata is present).
-  - `news: Option<Vec<SearchResultNews>>`
-  - `images: Option<Vec<SearchResultImage>>`
+```rust
+let docs = client.search_and_scrape("firecrawl API", 5).await?;
+for doc in docs {
+    println!("{}", doc.markdown.unwrap_or_default());
+}
+```
 
 ### Parameters
 
-- `query`
-  - Type: `impl AsRef<str>`
-  - Use when: you need a search query.
-  - Notes: use `site:example.com` to limit results to a domain.
+All fields in `SearchOptions` are `Option` and default to `None`.
 
-- `options.sources`
-  - Type: `Vec<SearchSource>`
-  - Use when: you want to control which sources are searched.
-  - Confirmed values: `Web`, `News`, `Images`
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `impl AsRef<str>` | **Required.** The search query string. |
+| `limit` | `Option<u32>` | Max results. Default: 5, Max: 20. |
+| `sources` | `Option<Vec<SearchSource>>` | Sources: `SearchSource::Web`, `News`, `Images`. |
+| `categories` | `Option<Vec<SearchCategory>>` | Category filters: `SearchCategory::Github`, `Research`, `Pdf`. |
+| `include_domains` | `Option<Vec<String>>` | Restrict to these domains. |
+| `exclude_domains` | `Option<Vec<String>>` | Exclude these domains. |
+| `tbs` | `Option<String>` | Time-based search filter (e.g. `"qdr:d"`). |
+| `location` | `Option<String>` | Geographic location for results. |
+| `ignore_invalid_urls` | `Option<bool>` | Skip invalid URLs. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. |
+| `highlights` | `Option<bool>` | Generate query-relevant highlights. Defaults to true. |
+| `scrape_options` | `Option<ScrapeOptions>` | Options for scraping each result page. |
+| `integration` | `Option<String>` | Integration identifier. |
+| `origin` | `Option<String>` | Origin tag. Auto-set to SDK version if `None`. |
 
-- `options.categories`
-  - Type: `Vec<SearchCategory>`
-  - Use when: you want to filter results by category.
-  - Confirmed values: `Github`, `Research`, `Pdf`
-
-- `options.limit`
-  - Type: u32
-  - Use when: you want to cap results.
-
-- `options.tbs`
-  - Type: String
-  - Use when: you need a time-based filter (for example `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
-
-- `options.location`
-  - Type: String
-  - Use when: you want localized results.
-
-- `options.ignore_invalid_urls`
-  - Type: bool
-  - Use when: you want to drop URLs that cannot be scraped by other endpoints.
-
-- `options.timeout`
-  - Type: u32
-  - Use when: you need a request timeout in milliseconds.
-
-- `options.scrape_options`
-  - Type: `ScrapeOptions`
-  - Use when: you want to scrape each search result (see Scrape parameters for fields).
-
-- `options.integration`
-  - Type: `Option<String>`
-  - Use when: you need an integration identifier for server-side tracking.
-  - Notes: omit in agent-oriented examples unless your product intentionally sets it.
+**Return type:** `SearchResponse` containing `SearchData` with `web: Option<Vec<SearchResultOrDocument>>`, `news: Option<Vec<SearchResultNews>>`, `images: Option<Vec<SearchResultImage>>`.
 
 ## Scrape
 
 ### Why use it
 
-Use scrape when you already have a URL and want structured content in one or more formats.
+Scrape a single URL and get back its content in one or more formats. Supports markdown, HTML, screenshots, structured JSON extraction, and more.
 
 ### Preferred SDK method
 
-`client.scrape(url, options)` → `Result<Document, FirecrawlError>` (the HTTP response `data` field is unwrapped in the SDK).
+```rust
+client.scrape(url, options).await?
+```
 
-### Simple Example
+### Example
 
 ```rust
 use firecrawl::{Client, ScrapeOptions, Format};
 
-let doc = client
-    .scrape("https://docs.firecrawl.dev", ScrapeOptions {
-        formats: Some(vec![Format::Markdown]),
-        ..Default::default()
-    })
-    .await?;
+let client = Client::new("fc-YOUR_API_KEY")?;
+
+let doc = client.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown, Format::Links]),
+    ..Default::default()
+}).await?;
+
+println!("{}", doc.markdown.unwrap_or_default());
 ```
 
-### Complex Example
+Structured JSON extraction:
 
 ```rust
-use firecrawl::{
-    Client, ScrapeOptions, Format, JsonOptions, ScreenshotOptions, ChangeTrackingOptions,
-    ChangeTrackingMode, AttributeSelector, Action, ParserConfig, ProxyType,
-};
+use serde_json::json;
 
-let doc = client
-    .scrape("https://example.com/pricing", ScrapeOptions {
-        formats: Some(vec![
-            Format::Markdown,
-            Format::Links,
-            Format::Json,
-            Format::Screenshot,
-            Format::ChangeTracking,
-            Format::Attributes,
-        ]),
-        json_options: Some(JsonOptions {
-            prompt: Some("Extract plan names and prices.".to_string()),
-            ..Default::default()
-        }),
-        screenshot_options: Some(ScreenshotOptions {
-            full_page: Some(true),
-            quality: Some(80),
-            ..Default::default()
-        }),
-        change_tracking_options: Some(ChangeTrackingOptions {
-            modes: Some(vec![ChangeTrackingMode::GitDiff]),
-            tag: Some("pricing".to_string()),
-            ..Default::default()
-        }),
-        attribute_selectors: Some(vec![AttributeSelector {
-            selector: "a".to_string(),
-            attribute: "href".to_string(),
-        }]),
-        parsers: Some(vec![ParserConfig::Pdf {
-            parser_type: "pdf".to_string(),
-            max_pages: Some(5),
-        }]),
-        actions: Some(vec![
-            Action::Click { selector: "#accept".to_string() },
-            Action::Wait { milliseconds: Some(750), selector: None },
-            Action::Scrape,
-        ]),
-        proxy: Some(ProxyType::Auto),
-        ..Default::default()
-    })
-    .await?;
+let result = client.scrape_with_schema(
+    "https://example.com/product",
+    json!({"type": "object", "properties": {"title": {"type": "string"}, "price": {"type": "number"}}}),
+    Some("Extract the product title and price"),
+).await?;
+
+println!("{}", result);
 ```
 
 ### Parameters
 
-- `url`
-  - Type: `impl AsRef<str>`
-  - Use when: you want to scrape a specific page.
+All fields in `ScrapeOptions` are `Option` and default to `None`.
 
-- `options.formats`
-  - Type: `Vec<Format>`
-  - Use when: you want multiple output formats.
-  - Confirmed values: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Audio`, `Video`
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `impl AsRef<str>` | **Required.** The URL to scrape. |
+| `formats` | `Option<Vec<Format>>` | Output formats. Variants: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Product`, `Menu`, `Audio`, `Video`, `Question(String)`, `Highlights(String)`, `Query(String)`. |
+| `headers` | `Option<HashMap<String, String>>` | Custom HTTP headers. |
+| `include_tags` | `Option<Vec<String>>` | HTML tags to include. |
+| `exclude_tags` | `Option<Vec<String>>` | HTML tags to exclude. |
+| `only_main_content` | `Option<bool>` | Only return main content. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. |
+| `wait_for` | `Option<u32>` | Wait time in ms before scraping. |
+| `mobile` | `Option<bool>` | Emulate a mobile device. |
+| `parsers` | `Option<Vec<ParserConfig>>` | Parser config (e.g. PDF parsing). |
+| `actions` | `Option<Vec<Action>>` | Browser actions. Variants: `Click`, `Wait`, `Scrape`, `Screenshot`, `Write`, `Press`, `Scroll`, `ExecuteJavascript`, `Pdf`. |
+| `location` | `Option<LocationConfig>` | Location config (`country`, `languages`). |
+| `skip_tls_verification` | `Option<bool>` | Skip TLS verification. |
+| `remove_base64_images` | `Option<bool>` | Remove base64 images. |
+| `fast_mode` | `Option<bool>` | Enable fast mode. |
+| `block_ads` | `Option<bool>` | Block ads. |
+| `proxy` | `Option<ProxyType>` | Proxy type: `Basic`, `Stealth`, `Enhanced`, `Auto`. |
+| `max_age` | `Option<u32>` | Max cache age. |
+| `min_age` | `Option<u32>` | Min cache age. Only checks cache. |
+| `store_in_cache` | `Option<bool>` | Store result in cache. |
+| `lockdown` | `Option<bool>` | Serve only cached results. |
+| `redact_pii` | `Option<bool>` | Redact personally identifiable information. |
+| `audit_metadata` | `Option<AuditMetadata>` | User attribution for SIEM logging. |
+| `profile` | `Option<ProfileConfig>` | Persistent browser profile (`name`, `save_changes`). |
+| `integration` | `Option<String>` | Integration identifier. |
+| `json_options` | `Option<JsonOptions>` | JSON extraction options (`schema`, `system_prompt`, `prompt`). |
+| `screenshot_options` | `Option<ScreenshotOptions>` | Screenshot options (`full_page`, `quality`, `viewport`). |
+| `change_tracking_options` | `Option<ChangeTrackingOptions>` | Change tracking options (`modes`, `schema`, `prompt`, `tag`). |
+| `attribute_selectors` | `Option<Vec<AttributeSelector>>` | Attribute selectors (`selector`, `attribute`). |
+| `origin` | `Option<String>` | Origin tag. Auto-set to SDK version if `None`. |
 
-- `options.headers`
-  - Type: `HashMap<String, String>`
-  - Use when: you need custom request headers.
-
-- `options.include_tags`
-  - Type: `Vec<String>`
-  - Use when: you want to include only specific HTML tags.
-
-- `options.exclude_tags`
-  - Type: `Vec<String>`
-  - Use when: you want to exclude specific HTML tags.
-
-- `options.only_main_content`
-  - Type: bool
-  - Use when: you want to strip nav, footer, and other boilerplate.
-
-- `options.timeout`
-  - Type: u32
-  - Use when: you need a timeout in milliseconds.
-
-- `options.wait_for`
-  - Type: u32
-  - Use when: you need to wait for the page to render (milliseconds).
-
-- `options.mobile`
-  - Type: bool
-  - Use when: you want a mobile viewport.
-
-- `options.parsers`
-  - Type: `Vec<ParserConfig>`
-  - Use when: you need file parsing controls.
-  - Confirmed values:
-    - `ParserConfig::Simple("pdf".to_string())`
-    - `ParserConfig::Pdf { parser_type: "pdf", max_pages: Some(n) }`
-
-- `options.actions`
-  - Type: `Vec<Action>`
-  - Use when: you need lightweight pre-scrape actions.
-  - Confirmed action types:
-    - `Wait`: `milliseconds` or `selector` required
-    - `Screenshot`: `full_page`, `quality`, `viewport` optional
-    - `Click`: `selector` required
-    - `Write`: `text` required (click to focus the input first)
-    - `Press`: `key` required
-    - `Scroll`: `direction` (`Up` or `Down`) required, `selector` optional
-    - `Scrape`: no additional fields
-    - `ExecuteJavascript`: `script` required
-    - `Pdf`: `format` (A0, A1, A2, A3, A4, A5, A6, Letter, Legal, Tabloid, Ledger), `landscape`, `scale` optional
-
-- `options.location`
-  - Type: `LocationConfig`
-  - Use when: you need geo or language-aware scraping.
-  - Confirmed fields: `country`, `languages`
-
-- `options.skip_tls_verification`
-  - Type: bool
-  - Use when: you need to skip TLS verification.
-
-- `options.remove_base64_images`
-  - Type: bool
-  - Use when: you want to drop base64 images from markdown output.
-
-- `options.fast_mode`
-  - Type: bool
-  - Use when: you want faster scrapes with reduced fidelity.
-
-- `options.block_ads`
-  - Type: bool
-  - Use when: you want ad and cookie popup blocking.
-
-- `options.proxy`
-  - Type: `ProxyType`
-  - Use when: you need proxy control.
-  - Confirmed values: `Basic`, `Stealth`, `Enhanced`, `Auto`
-
-- `options.max_age`
-  - Type: u32
-  - Use when: you want cached data up to a maximum age (milliseconds).
-
-- `options.min_age`
-  - Type: u32
-  - Use when: you want cached data only if it is at least this old (milliseconds).
-
-- `options.store_in_cache`
-  - Type: bool
-  - Use when: you want Firecrawl to cache the result.
-
-- `options.profile`
-  - Type: `ProfileConfig`
-  - Use when: you want a persistent browser profile shared across scrapes and interactions.
-  - Confirmed fields: `name`, `save_changes`
-
-- `options.integration`
-  - Type: `Option<String>`
-  - Use when: you need an integration identifier for server-side tracking.
-  - Notes: omit in agent-oriented examples unless your product intentionally sets it.
-
-- `options.json_options`
-  - Type: `JsonOptions`
-  - Use when: you want to configure JSON extraction.
-  - Confirmed fields: `schema`, `system_prompt`, `prompt`
-
-- `options.screenshot_options`
-  - Type: `ScreenshotOptions`
-  - Use when: you want to configure screenshot output.
-  - Confirmed fields: `full_page`, `quality`, `viewport`
-
-- `options.change_tracking_options`
-  - Type: `ChangeTrackingOptions`
-  - Use when: you want to configure change tracking output.
-  - Confirmed fields: `modes` (`GitDiff` or `Json`), `schema`, `prompt`, `tag`
-
-- `options.attribute_selectors`
-  - Type: `Vec<AttributeSelector>`
-  - Use when: you want attribute extraction output.
-  - Confirmed fields: `selector`, `attribute`
+**Return type:** `Document` with fields: `markdown`, `html`, `raw_html`, `json`, `summary`, `metadata`, `links`, `images`, `screenshot`, `audio`, `video`, `attributes`, `actions`, `answer`, `highlights`, `warning`, `change_tracking`, `branding`, `product`, `menu`.
 
 ## Interact
 
 ### Why use it
 
-Use interact when a page requires browser actions or code execution after a scrape starts.
+Execute code or a natural-language prompt in the live browser session that was created by a prior `scrape` call. Use this for multi-step workflows: clicking buttons, filling forms, navigating, or running scripts against the page.
 
 ### Preferred SDK method
 
-`client.interact(job_id, options)`
-
-To end the browser session, use `client.stop_interaction(job_id)` (HTTP `DELETE` on `/v2/scrape/{jobId}/interact`).
-
-### Simple Example
-
 ```rust
-use firecrawl::{Client, ScrapeExecuteOptions};
-
-let result = client
-    .interact(
-        "<scrapeJobId>",
-        ScrapeExecuteOptions {
-            prompt: Some("Click the pricing tab and summarize the plans.".to_string()),
-            ..Default::default()
-        },
-    )
-    .await?;
+client.interact(job_id, options).await?
 ```
 
-### Complex Example
+### Example
 
 ```rust
-use firecrawl::{Client, ScrapeExecuteOptions, ScrapeExecuteLanguage};
+use firecrawl::{Client, ScrapeOptions, ScrapeExecuteOptions, Format};
 
-let result = client
-    .interact(
-        "<scrapeJobId>",
-        ScrapeExecuteOptions {
-            code: Some("console.log(await page.title());".to_string()),
-            language: Some(ScrapeExecuteLanguage::Node),
-            timeout: Some(60),
-            ..Default::default()
-        },
-    )
-    .await?;
-```
+let client = Client::new("fc-YOUR_API_KEY")?;
 
-### Stop session
+let doc = client.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown]),
+    ..Default::default()
+}).await?;
 
-```rust
-let stopped = client.stop_interaction("<scrapeJobId>").await?;
-// stopped: ScrapeBrowserDeleteResponse { success, session_duration_ms, credits_billed, error, ... }
+let job_id = doc.metadata.as_ref()
+    .and_then(|m| m.job_id.as_ref())
+    .expect("job_id required for interact");
+
+let result = client.interact(job_id, ScrapeExecuteOptions {
+    code: Some("document.title".to_string()),
+    language: None,  // defaults to Node
+    prompt: None,
+    timeout: Some(30),
+    origin: None,
+}).await?;
+
+println!("{}", result.stdout.unwrap_or_default());
 ```
 
 ### Parameters
 
-- `job_id`
-  - Type: `impl AsRef<str>`
-  - Use when: you have a scrape job ID.
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `impl AsRef<str>` | **Required.** The scrape job ID. |
+| `code` | `Option<String>` | Code to execute. Either `code` or `prompt` must be provided (else `FirecrawlError::Misuse`). |
+| `prompt` | `Option<String>` | Natural-language instruction for the browser agent. Either `code` or `prompt` must be provided. |
+| `language` | `Option<ScrapeExecuteLanguage>` | Language: `Python`, `Node`, `Bash`. Defaults to `Node`. |
+| `timeout` | `Option<u32>` | Execution timeout in seconds. |
+| `origin` | `Option<String>` | Origin tag. Auto-set to SDK version if `None`. |
 
-- `options.code`
-  - Type: `Option<String>`
-  - Use when: you want to run code in the browser session.
+**Return type:** `ScrapeExecuteResponse` with fields: `success`, `live_view_url`, `interactive_live_view_url`, `output`, `stdout`, `result`, `stderr`, `exit_code`, `killed`, `error`.
 
-- `options.prompt`
-  - Type: `Option<String>`
-  - Use when: you want the browser agent to follow a natural-language instruction.
-
-- `options.language`
-  - Type: `ScrapeExecuteLanguage`
-  - Use when: you need a specific runtime.
-  - Confirmed values: `Python`, `Node`, `Bash`
-  - Notes: defaults to `Node` in the SDK if omitted.
-
-- `options.timeout`
-  - Type: u32
-  - Use when: you need an execution timeout in seconds.
-
-- `options.origin`
-  - Type: `Option<String>`
-  - Use when: you need an optional origin label for execution telemetry.
-  - Notes: omit in agent-oriented examples unless your product intentionally sets it.
-
-At least one of `options.code` or `options.prompt` must be non-empty; otherwise the SDK returns `FirecrawlError::Misuse` before calling the API.
-
-### Response types
-
-- `interact` → `Result<ScrapeExecuteResponse, FirecrawlError>`
-  - `success: bool` is always present; `live_view_url`, `interactive_live_view_url`, `output`, `stdout`, `result`, `stderr`, `exit_code`, `killed`, and `error` are `Option` fields on the struct.
-- `stop_interaction` → `Result<ScrapeBrowserDeleteResponse, FirecrawlError>`
-  - `success: bool` is always present; `session_duration_ms`, `credits_billed`, and `error` are optional.
-
-The v2 OpenAPI spec currently models the interact request body with `code` as required; the Rust SDK matches server behavior by accepting **either** `code` **or** `prompt` (see `ScrapeExecuteOptions` in `scrape.rs`).
+Call `client.stop_interaction(job_id).await?` to end the browser session when done.
 
 ## Notes
 
-- Deprecated aliases: `scrape_execute`, `stop_interactive_browser`, and `delete_scrape_browser` map to `interact` and `stop_interaction`.
-- `ScrapeOptions` includes dedicated `json_options`, `screenshot_options`, and `change_tracking_options` for advanced formats.
-- `search_and_scrape(query, limit)` is a convenience helper: it calls `search` with default `ScrapeOptions` and returns `Vec<Document>` built from `SearchResultOrDocument::Document` entries in `data.web` (see `search.rs`).
-- v2 SDK exports all types at the crate root: `use firecrawl::Client` (not `use firecrawl::v2::Client`).
-- Error types simplified in v2: `CrawlJobFailed(String, CrawlStatus)` → `JobFailed(String)`, `Missuse` → `Misuse`.
+- **snake_case fields** — All struct fields use snake_case (e.g. `only_main_content`, `include_tags`). Serialization to the API uses camelCase automatically.
+- **Enum-based formats** — Formats are typed enum variants (e.g. `Format::Markdown`, `Format::Json`), not strings.
+- **Typed actions** — Actions are also typed variants (e.g. `Action::Click { selector }`, `Action::Wait { milliseconds, selector }`).
+- **`ProxyType` enum** — `Basic`, `Stealth`, `Enhanced`, `Auto`.
+- **Convenience methods** — `scrape_with_schema(url, schema, prompt)` for JSON extraction, `search_and_scrape(query, limit)` for search + scrape in one call.
+- **Deprecated aliases** — `scrape_execute` → `interact`, `stop_interactive_browser`/`delete_scrape_browser` → `stop_interaction`. Always use the preferred names.
+- **Error types** — `FirecrawlError::Misuse` (formerly `Missuse`), `FirecrawlError::JobFailed` (formerly `CrawlJobFailed`).
 
 ## Source Of Truth
 
 - `firecrawl/apps/rust-sdk/Cargo.toml`
-- `firecrawl/apps/rust-sdk/src/lib.rs`
 - `firecrawl/apps/rust-sdk/src/client.rs`
 - `firecrawl/apps/rust-sdk/src/scrape.rs`
 - `firecrawl/apps/rust-sdk/src/search.rs`
-- `firecrawl/apps/rust-sdk/src/crawl.rs`
-- `firecrawl/apps/rust-sdk/src/map.rs`
-- `firecrawl/apps/rust-sdk/src/batch_scrape.rs`
-- `firecrawl/apps/rust-sdk/src/agent.rs`
 - `firecrawl/apps/rust-sdk/src/types.rs`
 - `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Refreshed all 6 agent-source-of-truth files (node, python, rust, java, elixir, curl) with parameters and examples derived from the latest SDK source code and OpenAPI spec
- Updated SDK versions: Node.js `@mendable/firecrawl-js` v4.31.1, Rust `firecrawl` v2.12.1, Java `firecrawl-java` v1.12.1, Elixir `:firecrawl` v1.9.1
- Added newly confirmed parameters across all languages: `lockdown`, `threatProtection`, `auditMetadata`, `profile`, `integration`, `enterprise`, `redactPII`
- Standardized document structure across all files: Install → Authenticate → When To Use What → Search/Scrape/Interact (each with Why/Method/Example/Parameters) → Notes → Source Of Truth
- Documented cross-SDK differences explicitly (e.g. prompt-based interact in Node/Python/Rust vs code-only in Java/Elixir)

## Test plan

- [ ] Verify each `.mdx` file renders correctly in Mintlify preview
- [ ] Spot-check parameter tables against SDK source for accuracy
- [ ] Confirm examples compile/run against the current API
- [ ] Verify no localized files were modified

---
_Generated by [Claude Code](https://claude.ai/code/session_0115Wigqo9gToYHMB4ovKzHo)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-docs/pr/1174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788009480&installation_model_id=11126&pr_number=1174&repository=firecrawl%2Ffirecrawl-docs&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-docs%2Fpull%2F1174&signature=e4ff9a7055c6a47b2ba3dac1e5a1acacae87e7617040d9c7ac1345ff9fd12ea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->