### PR TITLE
docs: /interact feedback bounty CTA

### DIFF
--- a/features/interact.mdx
+++ b/features/interact.mdx
@@ -45,8 +45,11 @@ import ProfilePython from "/snippets/v2/interact/profile/python.mdx";
 import ProfileJS from "/snippets/v2/interact/profile/js.mdx";
 import ProfileCURL from "/snippets/v2/interact/profile/curl.mdx";
 import ProfileCLI from "/snippets/v2/interact/profile/cli.mdx";
+import InteractFeedbackCTA from "/snippets/interact-feedback-cta.mdx";
 
 Scrape a page to get clean data, then call `/interact` to start taking actions in that page: click buttons, fill forms, extract dynamic content, or navigate deeper. Just describe what you want, or write code if you need full control.
+
+<InteractFeedbackCTA src="docs-interact" />
 
 ## Choose the right interaction model
 

--- a/snippets/interact-feedback-cta.mdx
+++ b/snippets/interact-feedback-cta.mdx
@@ -1,0 +1,24 @@
+<div className="firecrawl-cta-box">
+  <div style={{ display: "flex", alignItems: "flex-start", gap: "8px", marginBottom: "8px" }}>
+    <Icon icon="sack-dollar" color="#ff4d00" size={22} />
+    <div className="firecrawl-cta-title" style={{ margin: 0 }}>
+      <span style={{ color: "#ff4d00" }}>Bounty: 5,000 credit reward</span>
+      <span style={{ fontWeight: 400 }}> for solid feedback on /interact</span>
+    </div>
+  </div>
+  <p className="firecrawl-cta-description">
+    To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with our Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human/agent-friendly (just paste the link into your agentic harness!). Never used /interact? Your take still counts.
+  </p>
+  <a
+    href={"https://www.firecrawl.dev/survey/ogu30?src=" + (props.src || "docs-interact")}
+    className="firecrawl-cta-btn-primary firecrawl-cta-btn-inline"
+  >
+    Start the interview
+  </a>
+  <p
+    className="firecrawl-cta-description"
+    style={{ fontSize: "12px", fontStyle: "italic", margin: "12px 0 0 0" }}
+  >
+    Include your email to be eligible. Interviews are reviewed for quality at the end of each week.
+  </p>
+</div>


### PR DESCRIPTION
Adds the /interact interview bounty to https://docs.firecrawl.dev/features/interact, directly under the intro text.

- `snippets/interact-feedback-cta.mdx`: same convention as the retired /monitor and /search (GitHub) bounty CTAs (recoverable at `git show 300bac7^:snippets/monitor-feedback-cta.mdx` / `git show 53da3fa^:snippets/research-feedback-cta.mdx`): `firecrawl-cta-box`, sack-dollar icon, two-span title, qualify copy, "Start the interview" button, italic email/weekly-review footer. One deliberate addition to the qualify copy: a sentence inviting readers who have never used /interact, since this study explicitly interviews both populations.
- `features/interact.mdx`: import + `<InteractFeedbackCTA src="docs-interact" />` under the intro paragraph.
- Links to the v2 survey surface: `https://www.firecrawl.dev/survey/ogu30?src=docs-interact`.
- Localized copies untouched (translation pipeline).

Note: the ogu30 survey is currently a draft; Nick publishes it manually. Merge once it is live so the link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-docs/pr/1177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788047613&installation_model_id=11126&pr_number=1177&repository=firecrawl%2Ffirecrawl-docs&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-docs%2Fpull%2F1177&signature=d5c0cedc77bddc7b696f2ea4fd53764edc7aaee297999c8f93d5e3bc61373e58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->