### PR TITLE
docs: general feedback bounty CTA on the introduction page

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -30,6 +30,8 @@ import GeneralFeedbackCTA from "/snippets/general-feedback-cta.mdx";
   **For AI agents:** Use [llms.txt](/llms.txt) for a full index of all documentation.
 </Note>
 
+<GeneralFeedbackCTA src="docs-introduction" />
+
 ## Get started
 
 <McpClientSelector />
@@ -96,8 +98,6 @@ Provide your agent with this Firecrawl setup prompt.
 - **Reliable**: Built for production with high uptime and consistent results.
 - **Fast**: Results in seconds, optimized for high throughput.
 - **MCP Server**: Connect Firecrawl to any AI tool via the [Model Context Protocol](/mcp-server).
-
-<GeneralFeedbackCTA src="docs-introduction" />
 
 ---
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -24,6 +24,7 @@ import {
   AgentSetupButton,
   McpClientSelector,
 } from "/snippets/shared/agent-first-onboarding.jsx";
+import GeneralFeedbackCTA from "/snippets/general-feedback-cta.mdx";
 
 <Note>
   **For AI agents:** Use [llms.txt](/llms.txt) for a full index of all documentation.
@@ -95,6 +96,8 @@ Provide your agent with this Firecrawl setup prompt.
 - **Reliable**: Built for production with high uptime and consistent results.
 - **Fast**: Results in seconds, optimized for high throughput.
 - **MCP Server**: Connect Firecrawl to any AI tool via the [Model Context Protocol](/mcp-server).
+
+<GeneralFeedbackCTA src="docs-introduction" />
 
 ---
 

--- a/snippets/general-feedback-cta.mdx
+++ b/snippets/general-feedback-cta.mdx
@@ -1,0 +1,24 @@
+<div className="firecrawl-cta-box">
+  <div style={{ display: "flex", alignItems: "flex-start", gap: "8px", marginBottom: "8px" }}>
+    <Icon icon="sack-dollar" color="#ff4d00" size={22} />
+    <div className="firecrawl-cta-title" style={{ margin: 0 }}>
+      <span style={{ color: "#ff4d00" }}>Bounty: 5,000 credit reward</span>
+      <span style={{ fontWeight: 400 }}> for solid feedback on Firecrawl</span>
+    </div>
+  </div>
+  <p className="firecrawl-cta-description">
+    To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with our Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human/agent-friendly (just paste the link into your agentic harness!). New to Firecrawl? Your take still counts.
+  </p>
+  <a
+    href={"https://www.firecrawl.dev/survey/dsag9?src=" + (props.src || "docs-introduction")}
+    className="firecrawl-cta-btn-primary firecrawl-cta-btn-inline"
+  >
+    Start the interview
+  </a>
+  <p
+    className="firecrawl-cta-description"
+    style={{ fontSize: "12px", fontStyle: "italic", margin: "12px 0 0 0" }}
+  >
+    Include your email to be eligible. Interviews are reviewed for quality at the end of each week.
+  </p>
+</div>


### PR DESCRIPTION
Adds the general Firecrawl feedback bounty to https://docs.firecrawl.dev/introduction, directly under the "Why Firecrawl?" bullets.

- `snippets/general-feedback-cta.mdx`: house bounty convention per firebrain `skills/docs-feedback-bounty-cta` (shared snippet, `firecrawl-cta-box`, sack-dollar icon, two-span title, qualify copy, src-attributed link, italic footer). One extra sentence invites readers who have not used Firecrawl yet: the study explicitly interviews both populations.
- `introduction.mdx`: import + `<GeneralFeedbackCTA src="docs-introduction" />` under the Why Firecrawl bullets.
- Links to `https://www.firecrawl.dev/survey/dsag9?src=docs-introduction`.
- Localized copies untouched (translation pipeline).

**The dsag9 survey is now published and the link resolves (verified 200)** — this PR is clear to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)