### PR TITLE
docs: add agent quickstart files for all SDK languages

### DIFF
--- a/agent-quickstart/elixir.mdx
+++ b/agent-quickstart/elixir.mdx
@@ -1,0 +1,211 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl` hex package, `firecrawl/apps/elixir-sdk`) and the v2 OpenAPI spec. Function names and parameters match the auto-generated client.
+
+## Install
+
+```elixir
+# mix.exs
+defp deps do
+  [
+    {:firecrawl, "~> 1.9"}
+  ]
+end
+```
+
+## Authenticate
+
+```elixir
+# Option 1: Application config (config/config.exs)
+config :firecrawl, api_key: "fc-YOUR_API_KEY"
+
+# Option 2: Per-request option
+Firecrawl.search_and_scrape([query: "example"], api_key: "fc-YOUR_API_KEY")
+```
+
+All functions accept `api_key` and `base_url` (defaults to `https://api.firecrawl.dev/v2`) as options in the last keyword list argument. If no API key is provided, requests fall back to a keyless free tier (rate-limited per IP).
+
+## When To Use What
+
+- `search_and_scrape`: use when you start with a query and need discovery.
+- `scrape_and_extract_from_url`: use when you already have a URL and want page content.
+- `interact_with_scrape_browser_session`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with.
+
+### Preferred SDK method
+
+`Firecrawl.search_and_scrape(params, opts)` → `{:ok, Req.Response.t()} | {:error, Exception.t()}`
+
+Bang variant: `Firecrawl.search_and_scrape!(params, opts)` raises on error.
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.search_and_scrape(
+  query: "site:docs.firecrawl.dev webhooks",
+  limit: 5,
+  scrape_options: [formats: ["markdown"]]
+)
+
+# response.body contains the parsed JSON response
+for item <- response.body["data"]["web"] || [] do
+  IO.puts("#{item["url"]} #{item["title"]}")
+end
+```
+
+### Parameters
+
+Parameters are passed as a keyword list (first argument). All are optional except `query`.
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `query` | `:string` (required) | The search query. | Always required. |
+| `sources` | `{:list, :any}` | Sources to search. | When you want news or image results. |
+| `categories` | `{:list, :any}` | Filter by category. | When filtering by category. |
+| `include_domains` | `{:list, :string}` | Restrict results to these domains. | When targeting specific sites. |
+| `exclude_domains` | `{:list, :string}` | Exclude results from these domains. | When filtering out specific sites. |
+| `limit` | `:integer` | Max results to return. | When you need to cap results. |
+| `tbs` | `:string` | Time-based filter (e.g. `"qdr:d"`). | When you need time-constrained results. |
+| `location` | `:string` | Location for localized results. | When you want geo-targeted results. |
+| `country` | `:string` | ISO country code for geo-targeting. | When you want country-specific results. |
+| `ignore_invalid_urls` | `:boolean` | Ignore invalid URLs. | When piping into scrape/interact. |
+| `timeout` | `:integer` | Timeout in milliseconds. | When the default is too short. |
+| `highlights` | `:boolean` | Generate query-relevant highlights. | Set `false` for raw descriptions. |
+| `scrape_options` | `:keyword_list` | Scrape options per result (same fields as scrape params). | When you want full page content. |
+| `enterprise` | `{:list, :string}` | Enterprise options (`"anon"`, `"zdr"`). | Enterprise ZDR use cases. |
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`Firecrawl.scrape_and_extract_from_url(params, opts)` → `{:ok, Req.Response.t()} | {:error, Exception.t()}`
+
+Bang variant: `Firecrawl.scrape_and_extract_from_url!(params, opts)` raises on error.
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com/pricing",
+  formats: ["markdown"],
+  only_main_content: true
+)
+
+IO.puts(response.body["data"]["markdown"])
+```
+
+### Parameters
+
+Parameters are passed as a keyword list (first argument). All are optional except `url`.
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `url` | `:string` (required) | The URL to scrape. | Always required. |
+| `formats` | `{:list, :any}` | Output formats (e.g. `["markdown", "html"]`). | Always — controls what data you get back. |
+| `headers` | `:any` | Custom HTTP headers as a map. | When you need cookies, user-agent, etc. |
+| `include_tags` | `{:list, :string}` | HTML tags to include. | When you only want specific tags. |
+| `exclude_tags` | `{:list, :string}` | HTML tags to exclude. | When filtering out specific tags. |
+| `only_main_content` | `:boolean` | Strip nav, footer, boilerplate. | When you want clean content only. |
+| `timeout` | `:integer` | Timeout in milliseconds. | When the default is too short. |
+| `wait_for` | `:integer` | Wait time in ms after page load. | When the page needs JS rendering time. |
+| `mobile` | `:boolean` | Emulate mobile device. | For mobile-specific content. |
+| `parsers` | `{:list, :any}` | Parser configs (e.g. PDF). | When scraping PDF files. |
+| `actions` | `{:list, :any}` | Pre-scrape browser actions. | When you need to interact before scraping. |
+| `location` | `:keyword_list` | Geolocation settings. | For geo-targeted content. |
+| `skip_tls_verification` | `:boolean` | Skip TLS verification. | For sites with invalid certs. |
+| `remove_base64_images` | `:boolean` | Remove base64 images. | For smaller output. |
+| `block_ads` | `:boolean` | Block ads. | When ads interfere with extraction. |
+| `proxy` | `{:in, [:basic, :enhanced, :auto]}` | Proxy type. | For anti-bot protection. |
+| `max_age` | `:integer` | Max cache age. | When cached data is acceptable. |
+| `min_age` | `:integer` | Min cache age. | When you only want cached data. |
+| `store_in_cache` | `:boolean` | Cache the result. | Set `false` for data protection. |
+| `lockdown` | `:boolean` | Serve from cache only. | For ZDR-like behavior. |
+| `redact_pii` | `:boolean` | Redact PII from output. | When output may contain personal info. |
+| `zero_data_retention` | `:boolean` | Enable zero data retention. | For ZDR compliance. |
+| `profile` | `:keyword_list` | Persistent browser profile. | When you need state to persist. |
+| `audit_metadata` | `:keyword_list` | SIEM metadata (keys: `username`). | Enterprise audit logging. |
+
+## Interact
+
+### Why use it
+
+Use `interact_with_scrape_browser_session` for code execution in the browser session tied to a scrape job. For multi-step interactive flows, prefer this over scrape-time `actions`.
+
+### Preferred SDK method
+
+`Firecrawl.interact_with_scrape_browser_session(job_id, params, opts)` → `{:ok, Req.Response.t()} | {:error, Exception.t()}`
+
+Bang variant: `Firecrawl.interact_with_scrape_browser_session!(job_id, params, opts)` raises on error.
+
+### Example
+
+```elixir
+{:ok, scrape_response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown"]
+)
+
+job_id = scrape_response.body["data"]["metadata"]["scrapeId"]
+
+{:ok, result} = Firecrawl.interact_with_scrape_browser_session(job_id,
+  code: "console.log(await page.title());",
+  language: :node
+)
+
+IO.puts(result.body["stdout"])
+
+# Stop the session when done
+Firecrawl.stop_interactive_scrape_browser_session(job_id)
+```
+
+### Parameters
+
+The first argument is the `job_id` (path parameter). Remaining parameters are a keyword list.
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `job_id` | `String.t()` (required, 1st arg) | The scrape job ID. | Always required. |
+| `code` | `:string` (required) | Code to execute in the browser session. | Always required. |
+| `language` | `{:in, [:python, :node, :bash]}` | Runtime language. Default: `:node`. | When your code is in Python or Bash. |
+| `timeout` | `:integer` | Execution timeout in seconds. | When execution may take longer. |
+
+### Return value
+
+The response body contains: `success`, `cdpUrl`, `liveViewUrl`, `interactiveLiveViewUrl`, `output`, `stdout`, `result`, `stderr`, `exitCode`, `killed`, `error`.
+
+### Stop session
+
+`Firecrawl.stop_interactive_scrape_browser_session(job_id, opts)` — ends the browser session.
+
+## Notes
+
+- The Elixir SDK is auto-generated from the OpenAPI spec. Function names follow the OpenAPI operation IDs rather than simplified aliases.
+- Function name mapping to other SDKs:
+  - `search_and_scrape` = `search` in other SDKs
+  - `scrape_and_extract_from_url` = `scrape` in other SDKs
+  - `interact_with_scrape_browser_session` = `interact` in other SDKs
+  - `stop_interactive_scrape_browser_session` = `stopInteraction` / `stop_interaction` in other SDKs
+- All functions have bang (`!`) variants that raise instead of returning error tuples.
+- Parameters use snake_case keys in the keyword list but are serialized to camelCase JSON keys.
+- The proxy parameter is typed as an enum (`:basic`, `:enhanced`, `:auto`) — note that `:stealth` is not in the Elixir SDK's validated values.
+- Additional Req options (custom headers, adapter config, etc.) can be passed through in the `opts` keyword list.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/java.mdx
+++ b/agent-quickstart/java.mdx
@@ -1,0 +1,254 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl-java`, `firecrawl/apps/java-sdk`) and the v2 OpenAPI spec. Method names, parameters, and types match the `FirecrawlClient` public API.
+
+## Install
+
+Maven:
+
+```xml
+<dependency>
+  <groupId>com.firecrawl</groupId>
+  <artifactId>firecrawl-java</artifactId>
+  <version>1.12.1</version>
+</dependency>
+```
+
+Gradle (Kotlin DSL):
+
+```kotlin
+implementation("com.firecrawl:firecrawl-java:1.12.1")
+```
+
+Requires Java 11+.
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+// From explicit API key
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey("fc-YOUR_API_KEY")
+    .build();
+
+// From environment variable FIRECRAWL_API_KEY or system property firecrawl.apiKey
+FirecrawlClient client = FirecrawlClient.fromEnv();
+```
+
+Builder options: `apiKey(String)`, `apiUrl(String)` (defaults to `https://api.firecrawl.dev`), `timeoutMs(long)` (default 300000), `maxRetries(int)` (default 3), `backoffFactor(double)` (default 0.5), `asyncExecutor(Executor)`, `httpClient(OkHttpClient)`. If no API key is provided, requests fall back to a keyless free tier (rate-limited per IP).
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or other browser actions after a scrape has created a session.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with.
+
+### Preferred SDK method
+
+`client.search(query)` or `client.search(query, options)` → `SearchData`
+
+Async variant: `client.searchAsync(query, options)` → `CompletableFuture<SearchData>`
+
+### Example
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.SearchData;
+import com.firecrawl.models.ScrapeOptions;
+import java.util.List;
+
+FirecrawlClient client = FirecrawlClient.fromEnv();
+
+SearchData results = client.search("site:docs.firecrawl.dev webhooks",
+    SearchOptions.builder()
+        .limit(5)
+        .scrapeOptions(ScrapeOptions.builder()
+            .formats(List.of("markdown"))
+            .build())
+        .build());
+
+for (var item : results.getWeb()) {
+    System.out.println(item.get("url") + " " + item.get("title"));
+}
+```
+
+### Parameters
+
+`SearchOptions` uses a builder pattern via `SearchOptions.builder()`.
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `query` | `String` (required, 1st arg) | The search query. | Always required. |
+| `options` | `SearchOptions` (2nd arg, nullable) | Options object. Pass `null` for defaults. | When you need to customize the search. |
+| `sources` | `List<Object>` | Sources: `"web"`, `"news"`, `"images"` or typed maps. | When you want news or image results. |
+| `categories` | `List<Object>` | Categories: `"github"`, `"research"`, `"pdf"`. | When filtering by category. |
+| `includeDomains` | `List<String>` | Restrict results to these domains. | When targeting specific sites. |
+| `excludeDomains` | `List<String>` | Exclude results from these domains. | When filtering out specific sites. |
+| `limit` | `Integer` | Max results to return. | When you need to cap results. |
+| `tbs` | `String` | Time-based filter (e.g. `"qdr:d"` for past day). | When you need time-constrained results. |
+| `location` | `String` | Location for localized results. | When you want geo-targeted results. |
+| `ignoreInvalidURLs` | `Boolean` | Ignore invalid URLs in results. | When piping into scrape/interact. |
+| `timeout` | `Integer` | Timeout in milliseconds. | When the default is too short. |
+| `highlights` | `Boolean` | Generate highlights (defaults to true). | Set `false` for raw descriptions. |
+| `scrapeOptions` | `ScrapeOptions` | Scrape options per result. | When you want full page content. |
+| `integration` | `String` | Integration identifier. | When attributing requests. |
+
+### Return value
+
+`SearchData` has three `List<Map<String, Object>>` fields: `web`, `news`, `images`.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url)` or `client.scrape(url, options)` → `Document`
+
+Async variant: `client.scrapeAsync(url, options)` → `CompletableFuture<Document>`
+
+### Example
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.Document;
+import com.firecrawl.models.JsonFormat;
+import java.util.List;
+
+FirecrawlClient client = FirecrawlClient.fromEnv();
+
+Document doc = client.scrape("https://example.com/pricing",
+    ScrapeOptions.builder()
+        .formats(List.of("markdown", new JsonFormat("Extract plan names and prices.")))
+        .onlyMainContent(true)
+        .build());
+
+System.out.println(doc.getMarkdown());
+System.out.println(doc.getJson());
+```
+
+### Parameters
+
+`ScrapeOptions` uses a builder pattern via `ScrapeOptions.builder()`.
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `url` | `String` (required, 1st arg) | The URL to scrape. | Always required. |
+| `options` | `ScrapeOptions` (2nd arg, nullable) | Options object. Pass `null` for defaults. | When customizing the scrape. |
+| `formats` | `List<Object>` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"screenshot"`, `"json"`, `"audio"`, `"video"`. Or format config objects like `JsonFormat`, `QuestionFormat`, `HighlightsFormat`. | Always — controls what data you get back. |
+| `headers` | `Map<String, String>` | Custom HTTP headers. | When you need cookies, user-agent, etc. |
+| `includeTags` | `List<String>` | HTML tags to include. | When you only want specific tags. |
+| `excludeTags` | `List<String>` | HTML tags to exclude. | When filtering out specific tags. |
+| `onlyMainContent` | `Boolean` | Strip nav, footer, boilerplate. | When you want clean content only. |
+| `timeout` | `Integer` | Timeout in milliseconds. | When the default is too short. |
+| `waitFor` | `Integer` | Wait time in ms for JS rendering. | When the page needs rendering time. |
+| `mobile` | `Boolean` | Emulate mobile device. | For mobile-specific content. |
+| `parsers` | `List<Object>` | Parser configs (e.g. `"pdf"` or `Map.of("type", "pdf", "maxPages", 10)`). | When scraping PDF files. |
+| `actions` | `List<Map<String, Object>>` | Pre-scrape browser actions. | When you need to interact before scraping. |
+| `location` | `LocationConfig` | Geolocation (builder: `.country("US").languages(List.of("en-US"))`). | For geo-targeted content. |
+| `skipTlsVerification` | `Boolean` | Skip TLS verification. | For sites with invalid certs. |
+| `removeBase64Images` | `Boolean` | Remove base64 images. | For smaller output. |
+| `blockAds` | `Boolean` | Block ads. | When ads interfere with extraction. |
+| `proxy` | `String` | Proxy: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. | For anti-bot protection. |
+| `maxAge` | `Long` | Max cache age in milliseconds. | When cached data is acceptable. |
+| `storeInCache` | `Boolean` | Cache the result. | Set `false` for data protection. |
+| `lockdown` | `Boolean` | Serve from cache only. | For ZDR-like behavior. |
+| `redactPII` | `Boolean` | Redact PII from output. | When output may contain personal info. |
+| `auditMetadata` | `AuditMetadata` | SIEM logging metadata (constructor takes `String username`). | Enterprise audit logging. |
+| `integration` | `String` | Integration identifier. | When attributing requests. |
+
+### Return value
+
+`Document` fields: `markdown`, `html`, `rawHtml`, `json` (Object), `summary`, `metadata` (Map), `links` (List), `images` (List), `screenshot`, `audio`, `video`, `attributes`, `actions`, `answer`, `highlights`, `warning`, `changeTracking`, `branding`, `product`, `menu`.
+
+## Interact
+
+### Why use it
+
+Use `interact` for code execution in the browser session tied to a scrape job. For multi-step interactive flows, prefer `interact` over scrape-time `actions`.
+
+### Preferred SDK method
+
+`client.interact(jobId, code)` → `BrowserExecuteResponse`
+
+Overloads:
+
+- `interact(jobId, code)` — defaults: language `"node"`, no timeout
+- `interact(jobId, code, language, timeout)` — explicit language and timeout
+- `interact(jobId, code, language, timeout, origin)` — full form
+
+Async variants: `interactAsync(...)` → `CompletableFuture<BrowserExecuteResponse>`
+
+### Example
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.Document;
+import com.firecrawl.models.BrowserExecuteResponse;
+import java.util.List;
+
+FirecrawlClient client = FirecrawlClient.fromEnv();
+
+Document doc = client.scrape("https://example.com",
+    ScrapeOptions.builder().formats(List.of("markdown")).build());
+
+String jobId = (String) doc.getMetadata().get("scrapeId");
+
+BrowserExecuteResponse result = client.interact(jobId,
+    "console.log(await page.title());");
+System.out.println(result.getStdout());
+
+// Stop the session when done
+client.stopInteractiveBrowser(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `jobId` | `String` (required, 1st arg) | The scrape job ID. | Always required. |
+| `code` | `String` (required, 2nd arg) | Code to execute in the browser session. | Always required. |
+| `language` | `String` (3rd arg, optional) | Runtime: `"python"`, `"node"`, `"bash"`. Default: `"node"`. | When your code is in Python or Bash. |
+| `timeout` | `Integer` (4th arg, optional) | Execution timeout in seconds (1-300). Server default: 30s. | When execution may take longer. |
+| `origin` | `String` (5th arg, optional) | Attribution tag for telemetry. | When tracking request sources. |
+
+### Return value
+
+`BrowserExecuteResponse` fields: `success` (boolean), `stdout`, `result`, `stderr`, `exitCode` (Integer), `killed` (Boolean), `error`.
+
+### Stop session
+
+`client.stopInteractiveBrowser(jobId)` → `BrowserDeleteResponse` — ends the browser session. Response fields: `success`, `sessionDurationMs`, `creditsBilled`, `error`.
+
+## Notes
+
+- Java SDK uses camelCase parameter names matching the API JSON keys.
+- `ScrapeOptions` and `SearchOptions` use builder pattern with `.builder()...build()`.
+- `ScrapeOptions` also supports `toBuilder()` for mutation.
+- Deprecated aliases: `scrapeExecute` → `interact`; `deleteScrapeBrowser` → `stopInteractiveBrowser`.
+- The Java SDK `interact` method requires `code` as a parameter; the `prompt` field (natural-language browser agent instruction) is not exposed as a top-level parameter in the current Java SDK.
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/build.gradle.kts`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/node.mdx
+++ b/agent-quickstart/node.mdx
@@ -1,0 +1,202 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl/apps/js-sdk/firecrawl`) and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+npm install firecrawl
+```
+
+## Authenticate
+
+```ts
+import { Firecrawl } from "firecrawl";
+
+const client = new Firecrawl({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+  // apiUrl: "https://api.firecrawl.dev" // optional; falls back to FIRECRAWL_API_URL or cloud default
+});
+```
+
+Constructor accepts a string (treated as the API key) or an options object with `apiKey`, `apiUrl`, `timeoutMs`, `maxRetries`, and `backoffFactor`. If no API key is provided, requests fall back to a keyless free tier (rate-limited per IP).
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or other browser actions after a scrape has created a session.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:` in the query.
+
+### Preferred SDK method
+
+`client.search(query, options?)` → `Promise<SearchData>`
+
+### Example
+
+```ts
+const results = await client.search("site:docs.firecrawl.dev webhook retries", {
+  limit: 5,
+  scrapeOptions: {
+    formats: ["markdown"],
+  },
+});
+
+for (const item of results.web ?? []) {
+  console.log(item.url, item.title);
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `query` | `string` (required, 1st arg) | The search query. Use `site:example.com` to limit to a domain. | Always required. |
+| `options.sources` | `Array<"web" \| "news" \| "images" \| { type: ... }>` | Which search sources to query. | When you want news or image results alongside web. |
+| `options.categories` | `Array<"github" \| "research" \| "pdf" \| { type: ... }>` | Filter results by category. | When you want results from a specific category. |
+| `options.includeDomains` | `string[]` | Restrict results to these domains. Cannot be used with `excludeDomains`. | When you want results only from specific sites. |
+| `options.excludeDomains` | `string[]` | Exclude results from these domains. Cannot be used with `includeDomains`. | When you want to filter out specific sites. |
+| `options.limit` | `number` | Max results to return. | When you need to cap the number of results. |
+| `options.tbs` | `string` | Time-based search filter (e.g. `qdr:d` for past day, `qdr:w` for past week, `sbd:1,qdr:m` for sorted by date within past month). | When you need time-constrained results. |
+| `options.location` | `string` | Location for localized results (e.g. `"San Francisco,California,United States"`). Note: this is a plain string, not the `LocationConfig` object used by scrape. | When you want geo-targeted results. |
+| `options.ignoreInvalidURLs` | `boolean` | Exclude URLs that are invalid for other Firecrawl endpoints. | When piping search results into scrape/interact. |
+| `options.timeout` | `number` | Request timeout in milliseconds. | When the default timeout is too short. |
+| `options.highlights` | `boolean` | Generate query-relevant highlights. Defaults to `true`. | Set `false` to get raw provider descriptions instead. |
+| `options.scrapeOptions` | `ScrapeOptions` | Options applied to scrape each search result (same fields as the scrape `options` parameter). | When you want full page content for each result. |
+| `options.enterprise` | `Array<"default" \| "anon" \| "zdr">` | Enterprise search options (Zero Data Retention or anonymized search). | Enterprise ZDR use cases. |
+| `options.threatProtection` | `ThreatProtectionOptions` | Per-request threat protection override. | Enterprise threat protection. |
+| `options.integration` | `string` | Integration identifier. | When attributing requests to a specific integration. |
+
+### Return value
+
+`SearchData` has optional arrays. Do not access `result.data` — it throws. Use:
+
+- `result.web` — web index hits
+- `result.news` — news hits
+- `result.images` — image hits
+- `result.developer` — developer-specific hits
+
+Each entry is a lightweight result object or a full `Document` when `scrapeOptions` hydrated the hit.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options?)` → `Promise<Document>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com/pricing", {
+  formats: [
+    "markdown",
+    { type: "json", prompt: "Extract plan names and prices." },
+  ],
+  onlyMainContent: true,
+});
+console.log(doc.markdown);
+console.log(doc.json);
+```
+
+### Parameters
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `url` | `string` (required, 1st arg) | The URL to scrape. | Always required. |
+| `options.formats` | `Array<FormatString \| FormatObject>` | Output formats. Plain strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Object forms for structured extraction: `{ type: "json", prompt?, schema? }`, `{ type: "question", question }`, `{ type: "highlights", query }`, `{ type: "screenshot", fullPage?, quality?, viewport? }`, `{ type: "changeTracking", modes, schema?, prompt?, tag? }`, `{ type: "attributes", selectors }`. Note: `"json"` as a plain string is rejected — use the object form. | Always — controls what data you get back. |
+| `options.headers` | `Record<string, string>` | Custom HTTP headers sent with the request. | When you need specific cookies, user-agent, etc. |
+| `options.includeTags` | `string[]` | HTML tags to exclusively include in output. | When you only want content from specific tags. |
+| `options.excludeTags` | `string[]` | HTML tags to exclude from output. | When you want to filter out specific tags. |
+| `options.onlyMainContent` | `boolean` | Strip nav, footer, and boilerplate. | When you want clean article/main content only. |
+| `options.timeout` | `number` | Timeout in milliseconds. Min 1000, max 300000. | When the default 60s timeout is too short. |
+| `options.waitFor` | `number` | Wait time in ms after page load before fetching content. | When the page needs time for JS rendering. |
+| `options.mobile` | `boolean` | Emulate a mobile device. | When you need mobile-specific content or screenshots. |
+| `options.parsers` | `Array<string \| { type: "pdf", mode?: "fast" \| "auto" \| "ocr", maxPages?: number }>` | Controls file processing (e.g. PDF parsing). | When scraping PDF files. |
+| `options.actions` | `ActionOption[]` | Browser actions to perform before grabbing content. Types: `wait` (with `milliseconds` or `selector`), `screenshot`, `click` (with `selector`), `write` (with `text`), `press` (with `key`), `scroll` (with `direction`), `scrape`, `executeJavascript` (with `script`), `pdf`. | When you need to dismiss popups, click tabs, or fill forms before scraping. |
+| `options.location` | `{ country?: string, languages?: string[] }` | Geolocation and language settings for the request. | When you need geo-targeted content. |
+| `options.skipTlsVerification` | `boolean` | Skip TLS certificate verification. | When scraping sites with invalid certificates. |
+| `options.removeBase64Images` | `boolean` | Remove base64 images from markdown output. | When you want smaller markdown output. |
+| `options.fastMode` | `boolean` | Faster scrapes with reduced fidelity. | When speed matters more than completeness. |
+| `options.blockAds` | `boolean` | Block ads and cookie popups. | When ads interfere with content extraction. |
+| `options.proxy` | `"basic" \| "stealth" \| "enhanced" \| "auto"` | Proxy type. `auto` retries with enhanced on failure. | When the target site has anti-bot protection. |
+| `options.maxAge` | `number` | Use cached result if younger than this (milliseconds). | When fresh data is not critical and you want speed. |
+| `options.minAge` | `number` | Only serve from cache; never trigger a fresh scrape. Set to `1` to accept any cached version. | When you only want cached data. |
+| `options.storeInCache` | `boolean` | Cache the result in the Firecrawl index. | Set `false` for data protection concerns. |
+| `options.lockdown` | `boolean` | Serve from cache only, never make an outbound request. | When you want ZDR-like behavior from the cache. |
+| `options.redactPII` | `boolean \| RedactPIIOptions` | Redact PII from markdown. `true` for defaults or pass `{ mode, entities, replaceStyle }`. | When output may contain personal information. |
+| `options.profile` | `{ name: string, saveChanges?: boolean }` | Persistent browser profile shared across scrapes. | When you need login state or cookies to persist. |
+| `options.auditMetadata` | `{ username: string }` | User attribution for SIEM logging. | Enterprise audit logging. |
+| `options.integration` | `string` | Integration identifier. | When attributing requests to a specific integration. |
+| `options.threatProtection` | `ThreatProtectionOptions` | Per-request threat protection override. | Enterprise threat protection. |
+
+## Interact
+
+### Why use it
+
+Use `interact` for code or natural-language control of the browser session tied to a scrape job (via `metadata.scrapeId`). For flows that go beyond quick pre-scrape tweaks, prefer `interact` over scrape-time `actions`.
+
+### Preferred SDK method
+
+`client.interact(jobId, args)` → `Promise<ScrapeExecuteResponse>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com", { formats: ["markdown"] });
+const jobId = doc.metadata?.scrapeId;
+if (!jobId) throw new Error("Missing scrapeId from scrape response");
+
+const result = await client.interact(jobId, {
+  prompt: "Click the pricing tab and summarize the plans.",
+});
+console.log(result.output);
+
+// Stop the session when done
+await client.stopInteraction(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `jobId` | `string` (required, 1st arg) | The scrape job ID from `document.metadata.scrapeId`. | Always required. |
+| `args.code` | `string` | Code to execute in the browser session. At least one of `code` or `prompt` must be non-empty. | When you want to run Playwright-style code against the page. |
+| `args.prompt` | `string` | Natural-language instruction for the browser agent. At least one of `code` or `prompt` must be non-empty. | When you want the AI agent to perform browser actions by description. |
+| `args.language` | `"python" \| "node" \| "bash"` | Runtime for `code` execution. Defaults to `"node"`. | When your code is in Python or Bash instead of Node.js. |
+| `args.timeout` | `number` | Execution timeout in seconds (1-300). | When execution may take longer than the default 30s. |
+
+### Return value
+
+`ScrapeExecuteResponse` fields: `success`, `output` (agent response when using `prompt`), `stdout`, `result`, `stderr`, `exitCode`, `killed`, `liveViewUrl`, `interactiveLiveViewUrl`, `error`.
+
+### Stop session
+
+`client.stopInteraction(jobId)` → `Promise<ScrapeBrowserDeleteResponse>` — ends the browser session. Response fields: `success`, `sessionDurationMs`, `creditsBilled`, `error`.
+
+## Notes
+
+- The default `Firecrawl` export is the v2 client. V1 remains under `client.v1`.
+- Zod schemas passed to `formats` (for `json` or `changeTracking`) are converted to JSON Schema by the SDK.
+- Deprecated aliases: `scrapeUrl` → `scrape`; `scrapeExecute` → `interact`; `stopInteractiveBrowser` and `deleteScrapeBrowser` → `stopInteraction`.
+- The package declares Node.js >= 22 in `engines`.
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/python.mdx
+++ b/agent-quickstart/python.mdx
@@ -1,0 +1,199 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl-py` / `firecrawl/apps/python-sdk`) and the v2 OpenAPI spec. Method names, parameters, and return types match the v2 client.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+import os
+from firecrawl import Firecrawl
+
+client = Firecrawl(api_key=os.environ.get("FIRECRAWL_API_KEY"))
+# client = Firecrawl(api_key="fc-...", api_url="https://api.firecrawl.dev")
+```
+
+Constructor accepts `api_key` (falls back to `FIRECRAWL_API_KEY` env var), `api_url` (defaults to `https://api.firecrawl.dev`), `timeout`, `max_retries`, and `backoff_factor`. If no API key is provided, requests fall back to a keyless free tier (rate-limited per IP).
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:` in the query.
+
+### Preferred SDK method
+
+`client.search(query, **options)` → `SearchData`
+
+### Example
+
+```python
+results = client.search(
+    "site:docs.firecrawl.dev webhook retries",
+    limit=5,
+    scrape_options=ScrapeOptions(formats=["markdown"]),
+)
+
+for item in results.web or []:
+    print(getattr(item, "url", None), getattr(item, "title", None))
+```
+
+### Parameters
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `query` | `str` (required, 1st arg) | The search query. Use `site:example.com` to limit to a domain. | Always required. |
+| `sources` | `list[str \| Source]` | Which sources to search: `"web"`, `"news"`, `"images"`. | When you want news or image results alongside web. |
+| `categories` | `list[str \| Category]` | Filter by category: `"github"`, `"research"`, `"pdf"`. | When you want results from a specific category. |
+| `include_domains` | `list[str]` | Restrict results to these domains. Cannot be used with `exclude_domains`. | When you want results only from specific sites. |
+| `exclude_domains` | `list[str]` | Exclude results from these domains. Cannot be used with `include_domains`. | When you want to filter out specific sites. |
+| `limit` | `int` | Max results to return. Default: `5`. | When you need to cap the number of results. |
+| `tbs` | `str` | Time-based filter (e.g. `qdr:d` for past day, `qdr:w` for past week). | When you need time-constrained results. |
+| `location` | `str` | Location for localized results. Note: plain string, not the dict used by scrape. | When you want geo-targeted results. |
+| `ignore_invalid_urls` | `bool` | Exclude URLs invalid for other Firecrawl endpoints. | When piping search results into scrape/interact. |
+| `timeout` | `int` | Request timeout in milliseconds. Default: `300000`. | When the default timeout is too short. |
+| `highlights` | `bool` | Generate query-relevant highlights. Defaults to `True`. | Set `False` for raw provider descriptions. |
+| `scrape_options` | `ScrapeOptions` | Options applied to scrape each search result. | When you want full page content for each result. |
+| `enterprise` | `list[str]` | Enterprise search options (`"anon"`, `"zdr"`). | Enterprise ZDR use cases. |
+| `threat_protection` | `ThreatProtectionOptions` | Per-request threat protection override. | Enterprise threat protection. |
+| `integration` | `str` | Integration identifier. | When attributing requests to a specific integration. |
+
+### Return value
+
+`SearchData` has optional lists. Do not access `result.data` — it raises `AttributeError`. Use:
+
+- `result.web` — web hits
+- `result.news` — news hits
+- `result.images` — image hits
+- `result.developer` — developer-specific hits
+
+Each entry is a lightweight result object or a full `Document` when `scrape_options` hydrated the hit.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, **options)` → `Document`
+
+### Example
+
+```python
+doc = client.scrape(
+    "https://example.com/pricing",
+    formats=[
+        "markdown",
+        {"type": "json", "prompt": "Extract plan names and prices."},
+    ],
+    only_main_content=True,
+)
+print(doc.markdown)
+print(doc.json)
+```
+
+### Parameters
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `url` | `str` (required, 1st arg) | The URL to scrape. | Always required. |
+| `formats` | `list` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Object forms: `{"type": "json", "prompt": ..., "schema": ...}`, `{"type": "question", "question": ...}`, `{"type": "highlights", "query": ...}`, `{"type": "screenshot", "full_page": ..., "quality": ..., "viewport": ...}`, `{"type": "changeTracking", "modes": [...], "schema": ..., "prompt": ..., "tag": ...}`, `{"type": "attributes", "selectors": [...]}`. | Always — controls what data you get back. |
+| `headers` | `dict[str, str]` | Custom HTTP headers sent with the request. | When you need specific cookies, user-agent, etc. |
+| `include_tags` | `list[str]` | HTML tags to exclusively include in output. | When you only want content from specific tags. |
+| `exclude_tags` | `list[str]` | HTML tags to exclude from output. | When you want to filter out specific tags. |
+| `only_main_content` | `bool` | Strip nav, footer, and boilerplate. | When you want clean article/main content only. |
+| `timeout` | `int` | Timeout in milliseconds. | When the default timeout is too short. |
+| `wait_for` | `int` | Wait time in ms after page load before fetching content. | When the page needs time for JS rendering. |
+| `mobile` | `bool` | Emulate a mobile device. | When you need mobile-specific content or screenshots. |
+| `parsers` | `list` | Controls file processing. E.g. `[{"type": "pdf", "mode": "auto", "max_pages": 5}]`. | When scraping PDF files. |
+| `actions` | `list[dict]` | Browser actions before grabbing content. Types: `wait` (with `milliseconds` or `selector`), `screenshot`, `click` (with `selector`), `write` (with `text`), `press` (with `key`), `scroll` (with `direction`), `scrape`, `executeJavascript` (with `script`), `pdf`. | When you need to dismiss popups, click tabs, or fill forms. |
+| `location` | `dict \| Location` | Geolocation: `{"country": "US", "languages": ["en-US"]}`. | When you need geo-targeted content. |
+| `skip_tls_verification` | `bool` | Skip TLS certificate verification. | When scraping sites with invalid certificates. |
+| `remove_base64_images` | `bool` | Remove base64 images from markdown output. | When you want smaller markdown output. |
+| `fast_mode` | `bool` | Faster scrapes with reduced fidelity. | When speed matters more than completeness. |
+| `block_ads` | `bool` | Block ads and cookie popups. | When ads interfere with content extraction. |
+| `proxy` | `str` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. | When the target site has anti-bot protection. |
+| `max_age` | `int` | Use cached result if younger than this (milliseconds). | When fresh data is not critical and you want speed. |
+| `store_in_cache` | `bool` | Cache the result. | Set `False` for data protection concerns. |
+| `lockdown` | `bool` | Serve from cache only, never make an outbound request. | When you want ZDR-like behavior from the cache. |
+| `threat_protection` | `ThreatProtectionOptions` | Per-request threat protection override. | Enterprise threat protection. |
+| `profile` | `dict` | Persistent browser profile: `{"name": "my-session", "save_changes": True}`. | When you need login state or cookies to persist. |
+| `audit_metadata` | `AuditMetadata` | User attribution for SIEM logging: `{"username": "..."}`. | Enterprise audit logging. |
+| `integration` | `str` | Integration identifier. | When attributing requests to a specific integration. |
+
+## Interact
+
+### Why use it
+
+Use `interact` for code or natural-language control of the browser session tied to a scrape job (via `metadata.scrape_id`). For multi-step interactive flows, prefer `interact` over scrape-time `actions`.
+
+### Preferred SDK method
+
+`client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None)`
+
+At least one of `code` or `prompt` must be non-empty.
+
+### Example
+
+```python
+doc = client.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.scrape_id if doc.metadata else None
+if not job_id:
+    raise RuntimeError("Missing scrape_id from scrape response")
+
+result = client.interact(job_id, prompt="Click the pricing tab and summarize the plans.")
+print(result.output)
+
+# Stop the session when done
+client.stop_interaction(job_id)
+```
+
+### Parameters
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `job_id` | `str` (required, 1st arg) | The scrape job ID from `document.metadata.scrape_id`. | Always required. |
+| `code` | `str` (positional, optional) | Code to execute in the browser session. At least one of `code` or `prompt` required. | When you want to run code against the page. |
+| `prompt` | `str` (keyword-only) | Natural-language instruction for the browser agent. At least one of `code` or `prompt` required. | When you want the AI agent to perform browser actions by description. |
+| `language` | `str` | Runtime: `"python"`, `"node"`, `"bash"`. Default: `"node"`. | When your code is in Python or Bash. |
+| `timeout` | `int` | Execution timeout in seconds (1-300). | When execution may take longer than the default 30s. |
+
+### Return value
+
+`BrowserExecuteResponse` fields: `success`, `output` (agent response when using `prompt`), `stdout`, `result`, `stderr`, `exit_code`, `killed`, `live_view_url`, `interactive_live_view_url`, `error`.
+
+### Stop session
+
+`client.stop_interaction(job_id)` → `BrowserDeleteResponse` — ends the browser session. Response fields: `success`, `session_duration_ms`, `credits_billed`, `error`.
+
+## Notes
+
+- The top-level `Firecrawl` client exposes v2 methods directly. V1 remains under `client.v1`.
+- Class alias: `FirecrawlApp = Firecrawl`.
+- Deprecated aliases: `scrape_url` → `scrape`; `scrape_execute` → `interact`; `stop_interactive_browser` and `delete_scrape_browser` → `stop_interaction`.
+- The `scrape` method does not expose `min_age` as a top-level kwarg; pass it through `ScrapeOptions` via `scrape_options` in `search`.
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/rust.mdx
+++ b/agent-quickstart/rust.mdx
@@ -1,0 +1,253 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl` crate, `firecrawl/apps/rust-sdk`) and the v2 OpenAPI spec. Method names, parameters, and types match the v2 async client.
+
+## Install
+
+```toml
+# Cargo.toml
+[dependencies]
+firecrawl = "2"
+tokio = { version = "1", features = ["full"] }
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+// Cloud (API key from code)
+let client = Client::new("fc-YOUR_API_KEY")?;
+
+// Cloud (no key — keyless free tier, rate-limited per IP)
+let client = Client::new("")?;
+
+// Self-hosted
+let client = Client::new_selfhosted(
+    "https://firecrawl.example.com",
+    Some("fc-YOUR_API_KEY"), // or None for no auth
+)?;
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Use search to discover relevant pages from a query, then pick URLs to scrape or interact with.
+
+### Preferred SDK method
+
+`client.search(query, options)` → `Result<SearchResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions, ScrapeOptions, Format};
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+
+let response = client.search("site:docs.firecrawl.dev webhooks", SearchOptions {
+    limit: Some(5),
+    scrape_options: Some(ScrapeOptions {
+        formats: Some(vec![Format::Markdown]),
+        ..Default::default()
+    }),
+    ..Default::default()
+}).await?;
+
+if let Some(web_results) = response.data.web {
+    for item in web_results {
+        println!("{:?}", item);
+    }
+}
+```
+
+### Parameters
+
+All fields on `SearchOptions` are `Option` and the struct derives `Default`.
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `query` | `impl AsRef<str>` (required, 1st arg) | The search query. | Always required. |
+| `options` | `impl Into<Option<SearchOptions>>` (2nd arg) | Options struct. Pass `None` for defaults. | When you need to customize the search. |
+| `limit` | `Option<u32>` | Max results (default 5, max 20). | When you need to cap results. |
+| `sources` | `Option<Vec<SearchSource>>` | Sources: `Web`, `News`, `Images`. | When you want news or image results. |
+| `categories` | `Option<Vec<SearchCategory>>` | Categories: `Github`, `Research`, `Pdf`. | When filtering by category. |
+| `include_domains` | `Option<Vec<String>>` | Restrict results to these domains. | When targeting specific sites. |
+| `exclude_domains` | `Option<Vec<String>>` | Exclude results from these domains. | When filtering out specific sites. |
+| `tbs` | `Option<String>` | Time-based filter (e.g. `"qdr:d"`). | When you need time-constrained results. |
+| `location` | `Option<String>` | Geographic location string. | When you want localized results. |
+| `ignore_invalid_urls` | `Option<bool>` | Ignore invalid URLs in results. | When piping into scrape/interact. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. | When the default is too short. |
+| `highlights` | `Option<bool>` | Generate highlights (defaults true). | Set `false` for raw descriptions. |
+| `scrape_options` | `Option<ScrapeOptions>` | Scrape options per result. | When you want full page content. |
+| `integration` | `Option<String>` | Integration identifier. | When attributing requests. |
+
+### Return value
+
+`SearchResponse` contains `success: bool`, `data: SearchData`, `warning: Option<String>`. `SearchData` has:
+
+- `web: Option<Vec<SearchResultOrDocument>>` — web results or full documents
+- `news: Option<Vec<SearchResultNews>>` — news results
+- `images: Option<Vec<SearchResultImage>>` — image results
+
+### Convenience method
+
+`client.search_and_scrape(query, limit)` → `Result<Vec<Document>, FirecrawlError>` — calls search with default scrape options and returns only `Document` results.
+
+## Scrape
+
+### Why use it
+
+Use scrape when you already have a URL and want structured content in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options)` → `Result<Document, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format, JsonOptions};
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+
+let doc = client.scrape("https://example.com/pricing", ScrapeOptions {
+    formats: Some(vec![Format::Markdown, Format::Json]),
+    json_options: Some(JsonOptions {
+        prompt: Some("Extract plan names and prices.".into()),
+        ..Default::default()
+    }),
+    only_main_content: Some(true),
+    ..Default::default()
+}).await?;
+
+println!("{:?}", doc.markdown);
+```
+
+### Parameters
+
+All fields on `ScrapeOptions` are `Option` and the struct derives `Default`.
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `url` | `impl AsRef<str>` (required, 1st arg) | The URL to scrape. | Always required. |
+| `options` | `impl Into<Option<ScrapeOptions>>` (2nd arg) | Options struct. Pass `None` for defaults. | When you need to customize the scrape. |
+| `formats` | `Option<Vec<Format>>` | Output formats: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Product`, `Menu`, `Audio`, `Video`, `Question`, `Highlights`. | Always — controls what data you get back. |
+| `headers` | `Option<HashMap<String, String>>` | Custom HTTP headers. | When you need cookies, user-agent, etc. |
+| `include_tags` | `Option<Vec<String>>` | HTML tags to include. | When you only want specific tags. |
+| `exclude_tags` | `Option<Vec<String>>` | HTML tags to exclude. | When filtering out specific tags. |
+| `only_main_content` | `Option<bool>` | Strip nav, footer, boilerplate. | When you want clean content only. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. | When the default is too short. |
+| `wait_for` | `Option<u32>` | Wait time in ms after page load. | When the page needs JS rendering time. |
+| `mobile` | `Option<bool>` | Emulate mobile device. | For mobile-specific content. |
+| `parsers` | `Option<Vec<ParserConfig>>` | Parser configs (e.g. PDF). | When scraping PDF files. |
+| `actions` | `Option<Vec<Action>>` | Pre-scrape browser actions. | When you need to interact before scraping. |
+| `location` | `Option<LocationConfig>` | Geolocation settings. | For geo-targeted content. |
+| `skip_tls_verification` | `Option<bool>` | Skip TLS verification. | For sites with invalid certs. |
+| `remove_base64_images` | `Option<bool>` | Remove base64 images from output. | For smaller output. |
+| `fast_mode` | `Option<bool>` | Faster scrapes, reduced accuracy. | When speed matters more. |
+| `block_ads` | `Option<bool>` | Block ads. | When ads interfere with extraction. |
+| `proxy` | `Option<ProxyType>` | Proxy: `Basic`, `Stealth`, `Enhanced`, `Auto`. | For anti-bot protection. |
+| `max_age` | `Option<u32>` | Max cache age in seconds. | When cached data is acceptable. |
+| `min_age` | `Option<u32>` | Min cache age in seconds. | When you only want cached data. |
+| `store_in_cache` | `Option<bool>` | Cache the result. | Set `false` for data protection. |
+| `lockdown` | `Option<bool>` | Serve from cache only. | For ZDR-like behavior. |
+| `redact_pii` | `Option<bool>` | Redact PII from output. | When output may contain personal info. |
+| `profile` | `Option<ProfileConfig>` | Persistent browser profile. | When you need state to persist. |
+| `audit_metadata` | `Option<AuditMetadata>` | SIEM logging metadata. | Enterprise audit logging. |
+| `integration` | `Option<String>` | Integration identifier. | When attributing requests. |
+| `json_options` | `Option<JsonOptions>` | JSON extraction config: `schema`, `system_prompt`, `prompt`. | When using `Format::Json`. |
+| `screenshot_options` | `Option<ScreenshotOptions>` | Screenshot config: `full_page`, `quality`, `viewport`. | When customizing screenshots. |
+| `change_tracking_options` | `Option<ChangeTrackingOptions>` | Change tracking config: `modes`, `schema`, `prompt`, `tag`. | When using `Format::ChangeTracking`. |
+| `attribute_selectors` | `Option<Vec<AttributeSelector>>` | Attribute extraction selectors. | When using `Format::Attributes`. |
+
+### Convenience method
+
+`client.scrape_with_schema(url, schema, prompt)` → `Result<Value, FirecrawlError>` — scrapes with JSON extraction and returns the parsed JSON.
+
+## Interact
+
+### Why use it
+
+Use `interact` for code or natural-language control of the browser session tied to a scrape job. For multi-step interactive flows, prefer `interact` over scrape-time `actions`.
+
+### Preferred SDK method
+
+`client.interact(job_id, options)` → `Result<ScrapeExecuteResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, ScrapeExecuteOptions, Format};
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+
+let doc = client.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown]),
+    ..Default::default()
+}).await?;
+
+let job_id = doc.metadata.as_ref()
+    .and_then(|m| m.get("scrapeId"))
+    .and_then(|v| v.as_str())
+    .expect("Missing scrapeId");
+
+let result = client.interact(job_id, ScrapeExecuteOptions {
+    prompt: Some("Click the pricing tab and summarize the plans.".into()),
+    ..Default::default()
+}).await?;
+println!("{:?}", result.output);
+
+// Stop the session when done
+client.stop_interaction(job_id).await?;
+```
+
+### Parameters
+
+All fields on `ScrapeExecuteOptions` are `Option` and the struct derives `Default`.
+
+| Parameter | Type | Description | When to use |
+|---|---|---|---|
+| `job_id` | `impl AsRef<str>` (required, 1st arg) | The scrape job ID. | Always required. |
+| `options` | `ScrapeExecuteOptions` (required, 2nd arg) | Execution options. At least one of `code` or `prompt` must be non-empty. | Always required. |
+| `code` | `Option<String>` | Code to execute in the browser session. | When you want to run code against the page. |
+| `prompt` | `Option<String>` | Natural-language instruction for the browser agent. | When you want AI-driven browser actions. |
+| `language` | `Option<ScrapeExecuteLanguage>` | Runtime: `Python`, `Node`, `Bash`. Default: `Node`. | When your code is in Python or Bash. |
+| `timeout` | `Option<u32>` | Execution timeout in seconds. | When execution may take longer than default. |
+
+### Return value
+
+`ScrapeExecuteResponse` fields: `success`, `output`, `stdout`, `result`, `stderr`, `exit_code`, `killed`, `live_view_url`, `interactive_live_view_url`, `error`.
+
+### Stop session
+
+`client.stop_interaction(job_id)` → `Result<ScrapeBrowserDeleteResponse, FirecrawlError>` — ends the browser session. Response fields: `success`, `session_duration_ms`, `credits_billed`, `error`.
+
+## Notes
+
+- All methods are `async` and require a tokio runtime.
+- Options use plain structs with `#[derive(Default)]` and struct update syntax (`..Default::default()`), not a builder pattern.
+- All option fields use serde camelCase serialization with `skip_serializing_none`.
+- Parameters accept `impl AsRef<str>` for string arguments and `impl Into<Option<T>>` for optional options structs.
+- Deprecated aliases: `scrape_execute` → `interact`; `stop_interactive_browser` and `delete_scrape_browser` → `stop_interaction`.
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/Cargo.toml`
+- `firecrawl/apps/rust-sdk/src/v2/client.rs`
+- `firecrawl/apps/rust-sdk/src/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/search.rs`
+- `firecrawl/apps/rust-sdk/src/types.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds canonical agent quickstart documents for **Node.js**, **Python**, **Rust**, **Java**, and **Elixir** in `agent-quickstart/`
- Each file covers `search`, `scrape`, and `interact` endpoints with complete parameter tables, realistic examples, and language-specific notes
- All content is generated from SDK source code and the v2 OpenAPI spec — no invented parameters or behavior

## What's in each file

- Install command and auth pattern
- "When To Use What" decision guide (search vs scrape vs interact)
- For each endpoint: why use it, preferred SDK method, working example, full parameter table with types/descriptions/when-to-use, return value documentation
- Deprecated alias migration notes
- Source of truth file listing

## Languages covered

| Language | File | SDK source |
|---|---|---|
| Node.js/TypeScript | `agent-quickstart/node.mdx` | `firecrawl/apps/js-sdk/firecrawl/` |
| Python | `agent-quickstart/python.mdx` | `firecrawl/apps/python-sdk/firecrawl/` |
| Rust | `agent-quickstart/rust.mdx` | `firecrawl/apps/rust-sdk/src/` |
| Java | `agent-quickstart/java.mdx` | `firecrawl/apps/java-sdk/src/` |
| Elixir | `agent-quickstart/elixir.mdx` | `firecrawl/apps/elixir-sdk/lib/` |

## Test plan

- [ ] Verify each `.mdx` file renders cleanly as a Mintlify docs page
- [ ] Spot-check parameter names against SDK source for each language
- [ ] Confirm examples compile/run against the current SDK versions

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoYRZbbwr88pGSdEDWdL81)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-docs/pr/1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788095745&installation_model_id=11126&pr_number=1183&repository=firecrawl%2Ffirecrawl-docs&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-docs%2Fpull%2F1183&signature=a45c3a5a6d6d69740473d36137f6053bf0cc8978ef370e60dda92d74431507c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->