### PR TITLE
docs(developer): correct endpoint paths, entitlement, and MCP availability

### DIFF
--- a/features/developer.mdx
+++ b/features/developer.mdx
@@ -7,6 +7,10 @@ description: "Search GitHub issues, merged pull requests, repository READMEs, an
   **Private beta.** The developer index is in beta test. This page is unlisted (not linked from the navigation, the Search feature page, or the MCP tools page) so it can be shared for reference while the feature is in beta. Result types, ranking signals, and filters may still change.
 </Note>
 
+<Warning>
+  **Access is granted per organization.** Every request below requires an API key belonging to an organization that has been enabled for the developer beta. Requests without that access get `403` with `Developer search is in beta and is not enabled for this team.` on the developer endpoint, and on `/search` the `developer` category is dropped from the response with no error. Contact us to have your organization enabled.
+</Warning>
+
 Firecrawl Developer is an index built for coding agents. It covers GitHub issues, merged pull requests, repository READMEs, and curated documentation sites, so an agent can answer a question about code behavior, a library or framework, an API contract, an error message, or a known bug from primary sources rather than from a general web page.
 
 - Find the issue or pull request where a bug was reported and fixed
@@ -27,13 +31,13 @@ Throughout this page, `categories` is the request parameter and always takes an 
 
 Pass `developer` in the `categories` array on `/search`. The API returns developer results in a `developer` group next to `web`, and both SDKs expose that group as `.developer`.
 
-`/search` accepts keyless requests, so the examples below run without an API key. Add one for higher rate limits. See [Rate limits](/rate-limits#keyless-no-api-key) for the current keyless allowance.
+`/search` itself accepts keyless requests, but the `developer` category does not: a request without an enabled API key still returns `200` with ordinary `web` results and no `developer` group at all. Send a key from an enabled organization to get developer results.
 
 <CodeGroup>
 
 ```bash cURL
-# No API key needed to get started; add -H "Authorization: Bearer $FIRECRAWL_API_KEY" for higher rate limits:
 curl -X POST https://api.firecrawl.dev/v2/search \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "query": "how do I configure retries",
@@ -46,8 +50,7 @@ curl -X POST https://api.firecrawl.dev/v2/search \
 from firecrawl import Firecrawl
 
 firecrawl = Firecrawl(
-  # No API key needed to get started; add one for higher rate limits:
-  # api_key="fc-YOUR-API-KEY",
+    api_key="fc-YOUR-API-KEY",
 )
 
 result = firecrawl.search(
@@ -63,8 +66,7 @@ for item in result.developer or []:
 import { Firecrawl } from "firecrawl";
 
 const firecrawl = new Firecrawl({
-  // No API key needed to get started; add one for higher rate limits:
-  // apiKey: "fc-YOUR-API-KEY",
+  apiKey: "fc-YOUR-API-KEY",
 });
 
 const result = await firecrawl.search("how do I configure retries", {
@@ -78,7 +80,7 @@ for (const item of result.developer ?? []) {
 
 </CodeGroup>
 
-Developer results in this group carry `url`, `title`, and `description`, the same shape as a web result.
+Developer results in this group carry `url`, `title`, `description`, and `position`, the same shape as a web result, plus `category: "developer"`. Web results in the same response have no `category`, so it is the field to key on if you merge the two groups.
 
 ```json
 {
@@ -95,7 +97,9 @@ Developer results in this group carry `url`, `title`, and `description`, the sam
       {
         "url": "https://github.com/firecrawl/firecrawl/issues/1234",
         "title": "Retries are not applied to 429 responses",
-        "description": "Reported behavior and the fix that landed"
+        "description": "Reported behavior and the fix that landed",
+        "position": 1,
+        "category": "developer"
       }
     ]
   }
@@ -110,20 +114,21 @@ Developer results in this group carry `url`, `title`, and `description`, the sam
 
 | Task | Endpoint |
 | --- | --- |
-| Search the developer index | `GET` or `POST /v2/search/developer/search` |
+| Search the developer index | `GET` or `POST /v2/developer/search` |
+| Same search, alias path | `GET` or `POST /v2/search/developer` |
 
-The canonical path is `/v2/search/developer/search`, and it accepts requests without an API key so you can try it before signing up. `/v2/developer/search` serves the same search and always requires a key. A developer search bills as one search.
+The canonical path is `/v2/developer/search`. `/v2/search/developer` is an alias that serves the same search. Both require an API key from an organization enabled for the beta; both return `403` otherwise. A developer search bills as one search.
 
 <CodeGroup>
 
 ```bash cURL
-# No API key needed to get started; add -H "Authorization: Bearer $FIRECRAWL_API_KEY" for higher rate limits:
-curl -s "https://api.firecrawl.dev/v2/search/developer/search?query=how%20do%20I%20configure%20retries&k=10"
+curl -s "https://api.firecrawl.dev/v2/developer/search?query=how%20do%20I%20configure%20retries&k=10" \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY"
 ```
 
 ```bash cURL (POST)
-# No API key needed to get started; add -H "Authorization: Bearer $FIRECRAWL_API_KEY" for higher rate limits:
-curl -X POST https://api.firecrawl.dev/v2/search/developer/search \
+curl -X POST https://api.firecrawl.dev/v2/developer/search \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "query": "how do I configure retries",
@@ -223,6 +228,7 @@ To confirm an id resolves, pass it and read the `sources` array the response add
 
 - `id` is a stable result id, such as `issue:owner/repo#123`
 - `type` is one of `doc`, `issue`, `pull_request`, or `readme`
+- `title` is optional and is frequently absent on `doc` results, where the source page carries no usable title. Fall back to `url` rather than assuming the field is present
 - `passages` holds the matched passages in markdown, so tables and code blocks survive
 - `coverage` reports index health per result type, one of `ok`, `degraded`, `unavailable`, or `skipped`
 - `reranked` reports whether the ranked list went through the reranking stage
@@ -231,7 +237,11 @@ Check `coverage` when a result type you expected is missing. A `degraded` or `un
 
 ## Use it from MCP
 
-The [MCP server](/mcp-server) exposes both surfaces. Neither writes anything.
+<Warning>
+  **Not available on the MCP server yet.** The tools below are not shipped: the hosted server exposes no `firecrawl_developer_search`, and its `firecrawl_search` `categories` enum accepts only `github`, `research`, and `pdf`, so passing `developer` is rejected. Until MCP support lands, reach the index over HTTP with the endpoint above. This section describes the intended shape.
+</Warning>
+
+Once released, the [MCP server](/mcp-server) will expose both surfaces. Neither writes anything.
 
 | Tool | Purpose |
 | --- | --- |


### PR DESCRIPTION
## Summary

Checked every claim on `/features/developer` against the live API with a real key and as an anonymous caller. Six were wrong. The filters, `coverage`, `sources`/`repos` echo, and `k` semantics all checked out and are untouched.

## What was wrong

**1. The documented canonical path 404s.** The page says the canonical path is `/v2/search/developer/search`, and both cURL examples use it:

```
GET /v2/search/developer/search  →  404  Cannot GET /v2/search/developer/search
GET /v2/developer/search         →  200
GET /v2/search/developer         →  200
```

That double form was removed in `feat(api)!: drop the /v2/search/developer/search double form`. Canonical is now `/v2/developer/search`, with `/v2/search/developer` as the alias.

**2. "No API key needed to get started" is no longer true.** Developer search is gated on a per-organization beta flag. Anonymous:

```
POST /v2/search/developer  →  403  {"success":false,
  "error":"Developer search is in beta and is not enabled for this team."}
```

Every example on the page was written to run keyless. All now carry an `Authorization` header.

**3. The `/search` category claim was wrong in a quieter way.** `/search` does accept keyless requests, but the `developer` category is dropped for callers without access — `200`, ordinary `web` results, no `developer` group, no error. So the keyless example returned a response that simply never contains what the page is about.

**4. Nothing said access must be granted.** The page said "Private beta" but not that an org has to be enabled. Added a warning up front with both failure modes.

**5. `title` is optional and really is missing.** The page presents it as always present. In a 20-result sample, **5 had no `title` field at all** — all `doc` results, e.g. `doc:732ead218991e469167edf4017ae049eef114363`. Documented as optional with a `url` fallback.

**6. The MCP section documents tools that don't exist.** The hosted server exposes no `firecrawl_developer_search`, and its `firecrawl_search` `categories` enum accepts only `github`, `research`, `pdf` — passing `developer` is rejected. Both are pending on an unmerged MCP PR. Marked as not-yet-available rather than deleted, since the intended shape is still useful.

## Also corrected

Developer results in the `/search` group carry `position` and `category: "developer"` in addition to the documented three. `category` is absent on web results, so it's the field to key on when merging the groups. Added to the prose and the example payload.

## Verified accurate, left alone

- Both documented `400`s, verbatim: `repos cannot match any requested type; add github types or drop repos` and `sources cannot match any requested type; add doc or drop sources`
- `k` defaults to 20 (confirmed: a request with no `k` returned exactly 20)
- `sources` echo shape — `[{"source":"not-enrolled-xyz","indexed":false}]`
- `coverage` per type with `ok` / `degraded` / `unavailable` / `skipped`, and `reranked`
- SDK examples — both the JS and Python SDKs do support `categories: ["developer"]` and expose `.developer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-docs/pr/1186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788125695&installation_model_id=11126&pr_number=1186&repository=firecrawl%2Ffirecrawl-docs&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-docs%2Fpull%2F1186&signature=1459a63e6fd3843bcddf5833d95206b5f9f844f09f91b5ece26822a20969e905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->