### PR TITLE
docs(developer): MCP tools for the developer index are live

### DIFF
--- a/features/developer.mdx
+++ b/features/developer.mdx
@@ -237,11 +237,11 @@ Check `coverage` when a result type you expected is missing. A `degraded` or `un
 
 ## Use it from MCP
 
-<Warning>
-  **Not available on the MCP server yet.** The tools below are not shipped: the hosted server exposes no `firecrawl_developer_search`, and its `firecrawl_search` `categories` enum accepts only `github`, `research`, and `pdf`, so passing `developer` is rejected. Until MCP support lands, reach the index over HTTP with the endpoint above. This section describes the intended shape.
-</Warning>
+<Note>
+  **On the MCP server, behind the same beta gate.** Both tools below are live on the hosted server, and both need a key from an enabled organization. Without that access, `firecrawl_developer_search` returns `403`, and `firecrawl_search` with `categories: ["developer"]` still succeeds but comes back with no `developer` group.
+</Note>
 
-Once released, the [MCP server](/mcp-server) will expose both surfaces. Neither writes anything.
+The hosted [MCP server](/mcp-server) exposes both surfaces. Neither writes anything.
 
 | Tool | Purpose |
 | --- | --- |

--- a/features/developer.mdx
+++ b/features/developer.mdx
@@ -237,16 +237,11 @@ Check `coverage` when a result type you expected is missing. A `degraded` or `un
 
 ## Use it from MCP
 
-<Note>
-  **On the MCP server, behind the same beta gate.** Both tools below are live on the hosted server, and both need a key from an enabled organization. Without that access, `firecrawl_developer_search` returns `403`, and `firecrawl_search` with `categories: ["developer"]` still succeeds but comes back with no `developer` group.
-</Note>
+The hosted [MCP server](/mcp-server) exposes both surfaces, and neither writes anything. Connect with account OAuth or an API key belonging to an enabled organization, as described in [Connect Firecrawl MCP](/mcp-server/connect). A keyless connection cannot reach the index: `firecrawl_developer_search` returns `403`, and `firecrawl_search` returns its web results with the `developer` group absent.
 
-The hosted [MCP server](/mcp-server) exposes both surfaces. Neither writes anything.
+### Developer Search Tool (`firecrawl_developer_search`)
 
-| Tool | Purpose |
-| --- | --- |
-| `firecrawl_search` with `categories: ["developer"]` | Developer results alongside web results |
-| `firecrawl_developer_search` | Ranked developer results with matched passages |
+Search the developer index on its own and get back ranked results with the matched passages.
 
 ```json
 {
@@ -258,4 +253,30 @@ The hosted [MCP server](/mcp-server) exposes both surfaces. Neither writes anyth
 }
 ```
 
-`firecrawl_developer_search` takes `query` and an optional `k` only, and returns each hit as a markdown block with its id, type, url, title, and matched passages. Use the endpoint directly when you need the repository and result type filters.
+#### Developer Search Tool Options:
+
+- `query`: The search query string (required)
+- `k`: Number of ranked results to return, from 1 to 100
+
+**Best for:** Answering a question about code behavior, a library or framework, an API contract, an error message, or a known bug from primary sources.
+**Returns:** Each hit as a markdown block carrying its id, type, url, title, and matched passages.
+
+The tool takes those two arguments and no others. Call the [developer search endpoint](#developer-search-endpoint) over HTTP when you need the result type, repository, or documentation source filters.
+
+### Developer results from the Search Tool (`firecrawl_search`)
+
+Pass `developer` in `categories` to get developer results in a `developer` group beside the ordinary web results, the same shape the `developer` category returns on `/search`.
+
+```json
+{
+  "name": "firecrawl_search",
+  "arguments": {
+    "query": "how do I configure retries",
+    "categories": ["developer"],
+    "limit": 10
+  }
+}
+```
+
+**Best for:** One call when you want developer sources and general web pages weighed together.
+**Returns:** The usual search response, with developer hits grouped under `developer` and each one carrying `category: "developer"`.


### PR DESCRIPTION
## What

The **Use it from MCP** section of the unlisted Developer Index (Beta) page said the MCP tools were not shipped. They are, so the page told readers the opposite of what the server does. This corrects it and rewrites the section as usage guidance.

## Why the old text was wrong

Verified against the hosted MCP server (`mcp.firecrawl.dev`):

- **`firecrawl_developer_search` is advertised in `tools/list`.** Its schema is `query` (required) plus optional `k` (1–100) — exactly the shape the page already described as "intended". Calling it without the beta entitlement returns `403`, which is the gate documented at the top of the page, not a missing tool.
- **`firecrawl_search`'s `categories` enum is now `["github", "research", "pdf", "developer"]`.** The old warning said `developer` was rejected; a live call with `categories: ["developer"]` returns `200`. Without the entitlement the response simply carries no `developer` group — the same silent drop `/search` already does, per the note earlier in the page.

## Change

The section now follows the pattern [MCP tools and operations](https://docs.firecrawl.dev/mcp-server/tools) already uses: a heading per tool, a JSON call, an options list, and **Best for** / **Returns**. `firecrawl_search` with `categories: ["developer"]` gets a worked example instead of a prose mention.

The beta gate is one sentence in the intro, next to the connection guidance, rather than a callout — the page already opens with a warning about per-organization access, so repeating it at length here buried the usage.

Also drops the two-row tool table, which duplicated the "Two ways in" table at the top of the page.

One file. No localized files touched. `mcp-server/tools.mdx` deliberately still omits `firecrawl_developer_search`, consistent with keeping this page unlisted for the duration of the beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)