### PR TITLE
docs: rebuild the self-hosting quickstart

### DIFF
--- a/contributing/guide.mdx
+++ b/contributing/guide.mdx
@@ -1,156 +1,158 @@
 ---
-title: "Running Locally"
-description: "Set up Firecrawl on your local machine for development and contribution."
-og:title: "Running Locally | Firecrawl"
-og:description: "Set up Firecrawl on your local machine for development and contribution."
+title: "Run Firecrawl locally for development"
 sidebarTitle: "Running Locally"
+description: "Set up the Firecrawl API development environment, verify a local scrape, and run the source-owned test harness before contributing."
+og:title: "Run Firecrawl locally for development | Firecrawl"
+og:description: "Set up the Firecrawl API development environment, verify a local scrape, and run the source-owned test harness before contributing."
 ---
 
-This guide walks you through running the Firecrawl API server on your local machine. Follow these steps to set up the development environment, start the services, and send your first request.
+Run Firecrawl locally when you are changing the API, workers, or tests. This path installs development dependencies and starts source-owned services with the API harness.
 
-If you're contributing, the process follows standard open-source conventions: fork the repo, make changes, run tests, and open a pull request. For questions or help getting started, reach out to help@firecrawl.com or [submit an issue](https://github.com/mendableai/firecrawl/issues).
+<Warning>
+  This is a contributor development environment, not a deployment guide. If
+  you want to run Firecrawl on infrastructure you control without changing the
+  product, use [Self-hosting Firecrawl](/contributing/self-host).
+</Warning>
 
-## Prerequisites
+## Choose local development or self-hosting
 
-Install the following before proceeding:
+- **Develop locally** when you need fast code-test-debug loops against the current source revision.
+- **Self-host a pinned release** when you want a stable Docker Compose baseline on your own infrastructure.
+- **Use Firecrawl Cloud** when you want the fastest managed path without operating either environment.
 
-| Dependency | Required | Install guide |
-|------------|----------|---------------|
-| Node.js | Yes | [nodejs.org](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs) |
-| pnpm (v9+) | Yes | [pnpm.io](https://pnpm.io/installation) |
-| Redis | Yes | [redis.io](https://redis.io/docs/latest/operate/oss_and_stack/install/install-redis/) |
-| PostgreSQL | Yes | Via Docker (see below) or installed directly |
-| Docker | Optional | Required for the PostgreSQL container setup |
+Keep these environments separate. The API development file at `apps/api/.env` and the root Compose `.env` serve different processes and are not interchangeable.
 
-## Set up the database
+## Start the Firecrawl development environment
 
-You need a PostgreSQL database initialized with the schema at `apps/nuq-postgres/nuq.sql`. The easiest approach is to use the Docker image inside `apps/nuq-postgres`.
+### Install the prerequisites
 
-With Docker running, build and start the container:
+Install:
 
-```bash
-docker build -t nuq-postgres apps/nuq-postgres
-```
+- [Git](https://git-scm.com/downloads)
+- Node.js 22
+- pnpm `11.4.0`
+- [Redis](https://redis.io/docs/latest/operate/oss_and_stack/install/install-redis/)
+- Docker or Podman for the PostgreSQL and RabbitMQ containers managed by the API harness
+- [Rust](https://www.rust-lang.org/tools/install) when you are changing or rebuilding native packages
 
-```bash
-docker run --name nuqdb \
-  -e POSTGRES_PASSWORD=postgres \
-  -p 5433:5432 \
-  -v nuq-data:/var/lib/postgresql/data \
-  -d nuq-postgres
-```
-
-## Configure environment variables
-
-Copy the template to create your `.env` file in the `apps/api/` directory:
+Enable the package manager version used by the API:
 
 ```bash
-cp apps/api/.env.example apps/api/.env
+corepack enable
+corepack prepare pnpm@11.4.0 --activate
 ```
 
-For a minimal local setup without authentication or optional sub-services (PDF parsing, JS blocking, AI features), use the following configuration:
+### Clone Firecrawl and install dependencies
 
-```bash apps/api/.env
-# ===== Required =====
-NUM_WORKERS_PER_QUEUE=8
+```bash
+git clone https://github.com/firecrawl/firecrawl.git
+cd firecrawl/apps/api
+pnpm install
+```
+
+Create `apps/api/.env` with the smallest unauthenticated development configuration:
+
+```bash
+cat > .env <<'EOF'
 PORT=3002
 HOST=0.0.0.0
 REDIS_URL=redis://localhost:6379
 REDIS_RATE_LIMIT_URL=redis://localhost:6379
-
-## To turn on DB authentication, you need to set up supabase.
 USE_DB_AUTHENTICATION=false
-
-## PostgreSQL connection for queuing — change if credentials, host, or DB differ
-NUQ_DATABASE_URL=postgres://postgres:postgres@localhost:5433/postgres
-
-# ===== Optional =====
-# SUPABASE_ANON_TOKEN=
-# SUPABASE_URL=
-# SUPABASE_SERVICE_TOKEN=
-# TEST_API_KEY=               # Set if you've configured authentication and want to test with a real API key
-# OPENAI_API_KEY=             # Required for LLM-dependent features (image alt generation, etc.)
-# BULL_AUTH_KEY=@
-# PLAYWRIGHT_MICROSERVICE_URL= # Set to run a Playwright fallback
-# LLAMAPARSE_API_KEY=         # Set to parse PDFs with LlamaParse
-# SLACK_WEBHOOK_URL=          # Set to send Slack server health status messages
-# POSTHOG_API_KEY=            # Set to send PostHog events like job logs
-# POSTHOG_HOST=               # Set to send PostHog events like job logs
+PLAYWRIGHT_MICROSERVICE_URL=
+EOF
 ```
 
-## Install dependencies
+Leave `NUQ_DATABASE_URL` and `NUQ_RABBITMQ_URL` unset when you want the harness to create local PostgreSQL and RabbitMQ containers. Set them only when you intentionally operate those dependencies yourself.
 
-From the `apps/api/` directory, install packages with pnpm:
+### Start Redis and Firecrawl
 
-```bash
-cd apps/api
-pnpm install
-```
-
-## Start the services
-
-You need three terminal sessions running simultaneously: Redis, the API server, and a terminal for sending requests.
-
-### Terminal 1 — Redis
-
-Start the Redis server from anywhere in the project:
+Start Redis in one terminal:
 
 ```bash
 redis-server
 ```
 
-### Terminal 2 — API server
-
-Navigate to `apps/api/` and start the service:
+Then start Firecrawl from `apps/api` in another terminal:
 
 ```bash
 pnpm start
 ```
 
-This starts the API server and the workers responsible for processing crawl jobs.
+The start command builds the API, launches the API and worker processes, and manages the local queue containers. Keep that terminal open while you develop.
 
-<Note>
-If you plan to use the [LLM extract feature](https://github.com/firecrawl/firecrawl/pull/586/), export your OpenAI key first: `export OPENAI_API_KEY=sk-...`
-</Note>
+### Verify one local scrape
 
-### Terminal 3 — Send a test request
-
-Verify the server is running with a health check:
+Check that the API process responds:
 
 ```bash
-curl -X GET http://localhost:3002/test
+curl \
+  --fail \
+  --silent \
+  --show-error \
+  http://localhost:3002/v0/health/readiness
 ```
 
-This should return `Hello, world!`.
+Expected response:
 
-To test the crawl endpoint:
+```json
+{"status":"ok"}
+```
+
+Then exercise the scraping path:
 
 ```bash
-curl -X POST http://localhost:3002/v1/crawl \
+curl \
+  --fail-with-body \
+  --silent \
+  --show-error \
+  --max-time 75 \
+  -X POST \
+  http://localhost:3002/v2/scrape \
   -H 'Content-Type: application/json' \
   -d '{
-    "url": "https://mendable.ai"
+    "url": "https://example.com",
+    "formats": ["markdown"],
+    "timeout": 60000
   }'
 ```
 
-## Alternative: Docker Compose
+A successful response includes `success: true`, Markdown in `data.markdown`, and an HTTP status in `data.metadata.statusCode`.
 
-For a simpler setup, Docker Compose runs all services (Redis, API server, and workers) in a single command.
+## Change and test Firecrawl
 
-1. Make sure Docker and Docker Compose are installed.
-2. Copy `.env.example` to `.env` in the `apps/api/` directory and configure as needed.
-3. From the project root, run:
+Keep each change focused, add a successful path and relevant failure coverage, and run the narrowest source-owned test command that proves the behavior.
 
-```bash
-docker compose up
-```
-
-This starts all services automatically in the correct configuration.
-
-## Running tests
-
-Run the test suite with:
+From `apps/api`, run the API snippet suite with its dependencies:
 
 ```bash
-npm run test:snips
+pnpm harness pnpm test:snips
 ```
+
+The harness starts the API, workers, PostgreSQL, and RabbitMQ for the test command, then cleans up the processes it started. Use a more targeted Vitest path when the full snippet suite is unnecessary.
+
+For the contribution workflow, review the repository's [`CONTRIBUTING.md`](https://github.com/firecrawl/firecrawl/blob/main/CONTRIBUTING.md) before opening a pull request.
+
+## Troubleshoot the development environment
+
+### Redis does not connect
+
+Confirm Redis is listening on `localhost:6379` and that both Redis URLs in `apps/api/.env` use that address.
+
+### The harness cannot start PostgreSQL or RabbitMQ
+
+Start Docker or Podman, then rerun `pnpm start`. If you manage the services yourself, set their connection URLs explicitly instead of relying on harness-managed containers.
+
+### Port 3002 is already in use
+
+Stop the other process or change `PORT` in `apps/api/.env`, then use the same port in your verification requests.
+
+### Basic fetch works but browser rendering does not
+
+An empty `PLAYWRIGHT_MICROSERVICE_URL` leaves the separate Playwright service disabled. Start and configure that service only when the change you are testing requires it.
+
+## Where to go next
+
+- **Deploying instead of developing?** Follow [Self-hosting Firecrawl](/contributing/self-host).
+- **Still choosing a path?** Compare [Open source or Firecrawl Cloud](/contributing/open-source-or-cloud).
+- **Ready to contribute?** Use the source-owned [contribution guide](https://github.com/firecrawl/firecrawl/blob/main/CONTRIBUTING.md).

--- a/contributing/guide.mdx
+++ b/contributing/guide.mdx
@@ -33,7 +33,8 @@ Install:
 - pnpm `11.4.0`
 - [Redis](https://redis.io/docs/latest/operate/oss_and_stack/install/install-redis/)
 - Docker or Podman for the PostgreSQL and RabbitMQ containers managed by the API harness
-- [Rust](https://www.rust-lang.org/tools/install) when you are changing or rebuilding native packages
+- [Go](https://go.dev/dl/) 1.23 or newer, rebuilt by the API harness on every start
+- [Rust](https://www.rust-lang.org/tools/install), built during `pnpm install` for the `@mendable/firecrawl-rs` native package
 
 Enable the package manager version used by the API:
 

--- a/contributing/open-source-or-cloud.mdx
+++ b/contributing/open-source-or-cloud.mdx
@@ -1,41 +1,55 @@
 ---
-title: "Open Source vs Cloud"
-description: "Understand the differences between Firecrawl's open-source and cloud offerings"
-og:title: "Open Source vs Cloud | Firecrawl"
-og:description: "Compare Firecrawl's open-source version with our feature-rich cloud solution"
+title: "Open source or Firecrawl Cloud"
+sidebarTitle: "Open Source vs Cloud"
+description: "Choose between self-hosting Firecrawl for infrastructure control and Firecrawl Cloud for the fastest managed path to production."
+og:title: "Open source or Firecrawl Cloud | Firecrawl"
+og:description: "Choose between self-hosting Firecrawl for infrastructure control and Firecrawl Cloud for the fastest managed path to production."
 ---
 
-Firecrawl is open source under the [AGPL-3.0 license](https://github.com/firecrawl/firecrawl/blob/main/LICENSE). To deliver the best possible product, we also offer a hosted cloud version at [firecrawl.dev](https://firecrawl.dev) with additional features and managed infrastructure.
+Choose open source when you need source or infrastructure control. Choose Firecrawl Cloud when you want to start scraping without operating the stack. Both paths expose Firecrawl's core APIs; the difference is who configures, secures, and runs the supporting services.
 
-## Feature comparison
+<Note>
+  Running Firecrawl for product development and operating a self-hosted
+  deployment are different jobs. Use [Running Locally](/contributing/guide)
+  when you are changing Firecrawl code. Use the [self-hosting
+  guide](/contributing/self-host) when you want an API running on infrastructure
+  you control.
+</Note>
 
-The open-source version includes the core scraping and crawling engine. Firecrawl Cloud adds infrastructure-level capabilities, a management dashboard, and enterprise features on top of everything in the open-source edition.
+## Choose your Firecrawl deployment
+
+### Use open source when
+
+- **You need control over source or infrastructure.** You can inspect the code, choose where the stack runs, and connect your own providers.
+- **You are prepared to operate it.** Your team owns authentication, TLS, persistence, monitoring, capacity, upgrades, and recovery.
+- **You can add capabilities deliberately.** Core scraping works in the default stack; LLM-backed formats, advanced scraping services, and specialized extraction paths need additional configuration.
+
+### Use Firecrawl Cloud when
+
+- **You want the fastest supported path to production.** Firecrawl operates the infrastructure and managed services.
+- **You need Cloud-only product surfaces.** Agent, Browser, managed dashboards, enhanced proxy paths, and enterprise controls are delivered through Cloud.
+- **You want one account for usage and support.** API keys, credits, limits, and operational support stay in the managed service.
+
+**Our recommendation:** start with Firecrawl Cloud unless source access or infrastructure control is worth the operational work. If you self-host, prove one scrape first and add services only when your use case requires them.
+
+## Compare the operating model
+
+| Decision | Open source | Firecrawl Cloud |
+| --- | --- | --- |
+| Core scrape, crawl, map, and search APIs | Included | Included and managed |
+| Fetch and Playwright processing | Included in the default stack | Managed |
+| LLM-backed extraction and formats | Connect an OpenAI-compatible provider or Ollama | Managed provider path |
+| Advanced anti-bot or specialized extraction services | Run and configure the required service separately | Managed where the Cloud product supports it |
+| Agent, Browser, Interact, dashboard, and enterprise controls | Not included in the default stack | Included by product and plan availability |
+| Security, persistence, availability, and upgrades | You own them | Firecrawl operates them |
+| Usage, limits, and billing | Your infrastructure and provider costs | Firecrawl plan and credit model |
 
 ![Firecrawl Cloud vs Open Source](/images/open-source-cloud.png)
 
-| Feature | Open Source | Cloud |
-|---------|:----------:|:-----:|
-| Scrape | ✔ | ✔ |
-| Crawl | ✔ | ✔ |
-| Map | ✔ | ✔ |
-| Search | ✔ | ✔ |
-| Batch scrape | ✔ | ✔ |
-| Extract | ✔ | ✔ |
-| JSON mode | ✔ | ✔ |
-| LLM-ready formats | ✔ | ✔ |
-| Change tracking | ✔ | ✔ |
-| SDKs | ✔ | ✔ |
-| Agent | ✘ | ✔ |
-| Browser sandbox | ✘ | ✔ |
-| Actions | ✘ | ✔ |
-| Enhanced proxies | ✘ | ✔ |
-| Proxy rotations | ✘ | ✔ |
-| Dashboard | ✘ | ✔ |
-| Enterprise features | ✘ | ✔ |
+## Start with the path you chose
 
-## Why both?
+- **Self-host Firecrawl:** follow the [Docker Compose self-hosting guide](/contributing/self-host) from a pinned release to one verified scrape.
+- **Change Firecrawl code:** use [Running Locally](/contributing/guide) for the contributor development environment.
+- **Use Firecrawl Cloud:** [create an account](https://firecrawl.dev) and follow the [quickstart](/quickstart).
 
-The cloud solution allows us to continuously innovate and maintain a high-quality, sustainable service for all users. Revenue from Firecrawl Cloud funds ongoing development of the open-source project.
-
-- **Open source** — Run Firecrawl on your own infrastructure with full control over the core scraping engine. See [Running locally](/contributing/guide) and [Self-hosting](/contributing/self-host).
-- **Cloud** — Get started immediately with a managed service that includes enhanced proxies, a usage dashboard, and enterprise features. Sign up at [firecrawl.dev](https://firecrawl.dev).
+Open source keeps the core engine inspectable and adaptable. Firecrawl Cloud funds that work while giving builders a managed path with additional product and infrastructure capabilities.

--- a/contributing/self-host.mdx
+++ b/contributing/self-host.mdx
@@ -7,57 +7,59 @@ og:description: "Learn how to self-host Firecrawl to run on your own and contrib
 
 <span id="self-hosting-firecrawl" />
 
-Use this guide to decide whether the Docker Compose path fits your goal, then build Firecrawl from source and verify one successful scrape. At the end, a local API on port `3002` will return Markdown from `POST /v2/scrape`.
+Run Firecrawl on your own infrastructure and get your first scrape working with Docker Compose. This guide helps you choose the right path, builds a verified release from source, and finishes with Markdown from a local `POST /v2/scrape` request on port `3002`.
 
 <Warning>
-  This path is an evaluation and reference deployment, not a production
-  architecture. It deliberately starts without API authentication, durable
-  storage, TLS, high availability, or every Firecrawl Cloud capability.
+  This Compose setup is the fastest way to try self-hosting, not a production
+  architecture. It starts without API authentication, durable storage, TLS,
+  high availability, or every Firecrawl Cloud capability.
 </Warning>
 
-## Why?
+## Choose your path
 
-### Choose this path when
+### Self-host when
 
-- **If you need source or infrastructure control, follow this guide.** You will operate the API and every supporting service.
-- **If you want a working API without operating infrastructure, choose Firecrawl Cloud.** Compare [Open Source vs Cloud](/contributing/open-source-or-cloud) to see which managed-only capabilities matter to you.
-- **If you need an authenticated, highly available, or compliance-sensitive production service, use this guide only to validate compatibility.** You must still design and verify the controls in [Production considerations](#production-considerations).
+- **You want control over the source or infrastructure.** This guide gets the API and its supporting services running on your machine.
+- **You are comfortable operating the stack.** You will own upgrades, security, storage, monitoring, and recovery.
+- **You want to validate Firecrawl against your environment.** Get the baseline working here, then design the controls in [Before production](#before-production).
 
-**Recommendation:** use Docker Compose when infrastructure control or source access is worth the operational responsibility. If your priority is the fastest supported path to production, start with Firecrawl Cloud.
+Choose [Firecrawl Cloud](https://firecrawl.dev) when you want to start scraping without running infrastructure. See [Open Source vs Cloud](/contributing/open-source-or-cloud) for the capability differences.
 
-### Considerations
+**Our recommendation:** self-host when source access or infrastructure control is worth the operational work. If you want the fastest supported path to production, start with Firecrawl Cloud.
+
+### What you take on
 
 - You own upgrades, secrets, storage, monitoring, recovery, and incident response.
 - Scraping still sends outbound requests to target websites. Optional proxy, parsing, or AI providers add more data flows.
-- The quickstart uses known-safe evaluation defaults. Keep them until the first scrape succeeds, then change one decision at a time.
-- The commands are pinned to `v2.11.162`. Another release can change its Compose contract.
+- This guide keeps the first run intentionally simple. Get one scrape working, then change one decision at a time.
+- The commands are pinned to `v2.11.162`. A different release may use a different Compose contract.
 
-## Steps
+## Get Firecrawl running
 
-### Decisions this quickstart makes
+### Start with these defaults
 
-- **Source revision → Firecrawl `v2.11.162`.** Change it only after reviewing the target release's `docker-compose.yaml` and self-hosting notes.
-- **API authentication → disabled.** Change it only when you have a complete supported identity and database design; one environment variable is not enough.
-- **Queue backend → PostgreSQL.** Change it only when you intentionally want to operate the optional FoundationDB backend.
-- **Queue admin UI → disabled.** Enable it only with a strong `BULL_AUTH_KEY` and network controls.
-- **Optional AI and advanced scraping providers → not configured.** Add one only when the capability you need explicitly requires it.
+- **Release: Firecrawl `v2.11.162`.** Pin the code and configuration first. Upgrade after reviewing the target release's `docker-compose.yaml` and self-hosting notes.
+- **API authentication: off for this local run.** Add it only with a complete supported identity and database design; one environment variable is not enough.
+- **Queue: PostgreSQL.** Keep it unless you intentionally want to operate the optional FoundationDB backend.
+- **Queue admin UI: off.** Enable it only with a strong `BULL_AUTH_KEY` and network controls.
+- **AI and advanced scraping providers: not configured.** Add a provider when a capability you need requires it.
 
-These defaults reduce the number of variables in the first run. Defer customization until the functional smoke test passes.
+Keep the first run boring: get one scrape working, then add what your use case needs.
 
 ### Prerequisites
 
-Install the following:
+Before you start, install:
 
 - [Git](https://git-scm.com/downloads)
 - [Docker Engine](https://docs.docker.com/engine/install/) or Docker Desktop
 - Docker Compose v2, invoked as `docker compose`
 - `curl` for the verification requests
 
-Make sure port `3002` is available on the host and Docker has enough capacity to build and run several services. The project does not publish a verified minimum host size.
+Make sure port `3002` is available and Docker has enough capacity to build and run several services. Firecrawl does not publish a verified minimum host size for this stack.
 
 ### Clone the verified release
 
-This guide was source-verified against Firecrawl `v2.11.162`. Check out that exact release so the commands and configuration below match the source:
+This guide was verified against Firecrawl `v2.11.162`. Check out that exact release to keep the code, commands, and configuration in sync:
 
 ```bash
 git clone https://github.com/firecrawl/firecrawl.git
@@ -65,11 +67,11 @@ cd firecrawl
 git checkout v2.11.162
 ```
 
-If you choose another release, review that release's `docker-compose.yaml` and self-hosting notes before reusing these values.
+Want to use another release? Review its `docker-compose.yaml` and self-hosting notes before reusing these values.
 
 ### Configure the evaluation deployment
 
-Create `.env` in the repository root:
+Create the smallest working `.env` in the repository root:
 
 ```bash
 cat > .env <<'EOF'
@@ -80,30 +82,30 @@ POSTGRES_DB=postgres
 EOF
 ```
 
-Replace the PostgreSQL password before starting the stack. Keep `POSTGRES_DB=postgres` for `v2.11.162` because the bundled `pg_cron` configuration targets that database. Compose uses these values consistently for the API and PostgreSQL service. Do not commit `.env`.
+Replace the PostgreSQL password before starting the stack, and do not commit `.env`. Keep `POSTGRES_DB=postgres` for `v2.11.162` because the bundled `pg_cron` configuration targets that database. Compose passes these values to both the API and PostgreSQL service.
 
 <Note>
-  `apps/api/.env.example` is an API development template, not a drop-in root
-  Compose configuration. The evaluation path disables database authentication,
-  so requests do not need an API key or `Authorization` header.
+  `apps/api/.env.example` is for API development, not a drop-in Compose file.
+  This first run disables database authentication, so requests do not need an
+  API key or `Authorization` header.
 </Note>
 
-Leave `NUQ_BACKEND` and `BULL_AUTH_KEY` unset. This keeps PostgreSQL as the queue backend and the queue administration UI disabled.
+Leave `NUQ_BACKEND` and `BULL_AUTH_KEY` unset. You will use the PostgreSQL queue without running the queue administration UI—fewer moving parts for the first scrape.
 
 ### Build and start Firecrawl
 
-Build the checked-out source and start the stack in the background:
+Build the checked-out source and start everything in the background:
 
 ```bash
 docker compose up --build -d
 docker compose ps --all
 ```
 
-Compose may warn that optional variables are unset; they can remain blank for this baseline deployment. `docker compose ps --all` should show the API and supporting services running, and one-shot initialization services completed successfully. Some services may take additional time to initialize.
+Warnings about unset optional variables are expected for this baseline. `docker compose ps --all` should show the API and supporting services running, with one-shot initialization services completed. Give the stack a little time if services are still starting.
 
 ### Check API reachability
 
-Once the API container is running, check that its HTTP process is reachable:
+First, make sure the API can answer an HTTP request:
 
 ```bash
 curl \
@@ -121,14 +123,14 @@ Expected response:
 ```
 
 <Warning>
-  This endpoint only confirms that the API process can respond. It does not check
-  Redis, PostgreSQL, RabbitMQ, Playwright, workers, or outbound network access.
-  Complete the functional smoke test below before treating the deployment as usable.
+  This is a heartbeat, not an end-to-end test. It does not check Redis,
+  PostgreSQL, RabbitMQ, Playwright, workers, or outbound network access. Run the
+  scrape below before treating the deployment as usable.
 </Warning>
 
 ### Run a functional smoke test
 
-Send one synchronous scrape request. The request timeout is in milliseconds; curl's client timeout is in seconds and is slightly longer:
+Now test the path that matters: one real scrape. The request timeout is in milliseconds; curl's client timeout is in seconds and is slightly longer:
 
 ```bash
 curl \
@@ -160,47 +162,47 @@ A successful response has this shape:
 }
 ```
 
-This verifies the API, scraping pipeline, one scraping-engine path, and outbound access together. Exact metadata can vary with the target response.
+This checks the API, scraping pipeline, one scraping-engine path, and outbound access together. Exact metadata can vary with the target response.
 
-If the response contains these success fields, the evaluation journey is complete. Decide what to add next instead of changing the baseline configuration preemptively.
+If you get these success fields, Firecrawl is working end to end on your infrastructure. Keep this baseline, then choose what to add next.
 
 ## Capability boundaries
 
-Use the capability you need to choose the next path:
+Your first scrape works. Add the next capability because you need it, not because it exists:
 
 | If you need | Decision |
 | --- | --- |
-| Core scrape, crawl, map, and search routes | Continue with the default stack. Fetch and Playwright processing are included. |
-| LLM-backed extraction or formats | Add an OpenAI-compatible provider or Ollama, then verify that path separately. |
-| Fire-engine or its advanced anti-bot behavior | Operate and configure that service separately; it is not included. |
-| Agent, Browser, interact, feedback, or specialized product, menu, audio, and video formats | Use Firecrawl Cloud or verify the external service requirements for the specific capability. |
+| Core scrape, crawl, map, and search routes | Keep the default stack. Fetch and Playwright processing are included. |
+| LLM-backed extraction or formats | Connect an OpenAI-compatible provider or Ollama, then test that path separately. |
+| Fire-engine or its advanced anti-bot behavior | Run and configure that service separately; it is not included. |
+| Agent, Browser, interact, feedback, or specialized product, menu, audio, and video formats | Use Firecrawl Cloud, or verify the external service requirements for the specific capability. |
 
 For the broader product comparison, see [Open Source vs Cloud](/contributing/open-source-or-cloud). For release-specific configuration, use the pinned [`docker-compose.yaml`](https://github.com/firecrawl/firecrawl/blob/v2.11.162/docker-compose.yaml) as the companion source.
 
-## Production considerations
+## Before production
 
-A successful smoke test proves that the evaluation path works. It does not prove production readiness. Before moving beyond a trusted network, make these decisions:
+Compose gets you to first success. Production needs a few explicit choices before the API leaves a trusted network:
 
 - **If data must survive service replacement,** add durable storage for PostgreSQL, Redis, and RabbitMQ, then define and test backup and restore procedures. The provided Compose file does not add those volumes.
 - **If users or untrusted networks can reach the API,** add a supported authentication design, network access controls, and TLS at a reverse proxy or ingress. Do not expose this unauthenticated baseline publicly.
-- **If you have availability or capacity requirements,** define service-level objectives, monitoring, resource sizing, scaling triggers, and upgrade and rollback procedures. The Compose limits are not verified minimum requirements.
+- **If you have availability or capacity requirements,** set uptime targets, monitoring, resource sizing, scaling triggers, and upgrade and rollback procedures. The Compose limits are not verified minimum requirements.
 - **If data location or compliance matters,** map requests to target websites and every optional AI, proxy, or parsing provider before enabling them.
 - **If secrets must be managed centrally,** move the database password out of `.env` and into your platform's secret-management system.
 
-These are architecture decisions, not additional quickstart environment variables.
+These are infrastructure decisions. No single `.env` switch makes the stack production-ready.
 
-## Next steps
+## Where to go next
 
-- **If you are only evaluating Firecrawl,** keep the API on a trusted network and run `docker compose down` when you are finished.
-- **If you need another open-source capability,** use [Capability boundaries](#capability-boundaries) to identify the required provider or service and verify it as a separate path.
-- **If you need managed infrastructure or Cloud-only capabilities,** compare [Open Source vs Cloud](/contributing/open-source-or-cloud).
-- **If you are preparing for production,** complete every decision in [Production considerations](#production-considerations) before exposing the API.
+- **Still evaluating?** Keep the API on a trusted network and run `docker compose down` when you are finished.
+- **Adding an open-source capability?** Use [Capability boundaries](#capability-boundaries) to find the required provider or service, then test that path on its own.
+- **Want managed infrastructure or Cloud-only capabilities?** Compare [Open Source vs Cloud](/contributing/open-source-or-cloud).
+- **Going to production?** Complete every decision in [Before production](#before-production) before exposing the API.
 
 ## Troubleshooting
 
 ### You're bypassing authentication
 
-If you see this warning with `USE_DB_AUTHENTICATION=false`, continue: it is expected for the evaluation deployment. Requests use a self-hosted identity and need no API key. If the API is reachable from an untrusted network, stop and add the controls described in [Production considerations](#production-considerations).
+If you see this warning with `USE_DB_AUTHENTICATION=false`, you are on the expected first-run path. Requests use a self-hosted identity and need no API key. If the API is reachable from an untrusted network, stop and add the controls in [Before production](#before-production).
 
 ### Docker containers fail to start
 

--- a/contributing/self-host.mdx
+++ b/contributing/self-host.mdx
@@ -4,249 +4,245 @@ description: "Learn how to self-host Firecrawl to run on your own and contribute
 og:title: "Self-hosting | Firecrawl"
 og:description: "Learn how to self-host Firecrawl to run on your own and contribute to the project."
 ---
-#### Contributor?
 
-Welcome to [Firecrawl](https://firecrawl.dev) 🔥! Here are some instructions on how to get the project locally so you can run it on your own and contribute.
+<span id="self-hosting-firecrawl" />
 
-If you're contributing, note that the process is similar to other open-source repos, i.e., fork Firecrawl, make changes, run tests, PR.
+Use this guide to decide whether the Docker Compose path fits your goal, then build Firecrawl from source and verify one successful scrape. At the end, a local API on port `3002` will return Markdown from `POST /v2/scrape`.
 
-If you have any questions or would like help getting on board, join our Discord community [here](https://discord.gg/firecrawl) for more information or submit an issue on Github [here](https://github.com/firecrawl/firecrawl/issues/new/choose)!
-
-## Self-hosting Firecrawl
-
-Refer to [SELF_HOST.md](https://github.com/firecrawl/firecrawl/blob/main/SELF_HOST.md) for instructions on how to run it locally.
+<Warning>
+  This path is an evaluation and reference deployment, not a production
+  architecture. It deliberately starts without API authentication, durable
+  storage, TLS, high availability, or every Firecrawl Cloud capability.
+</Warning>
 
 ## Why?
 
-Self-hosting Firecrawl is particularly beneficial for organizations with stringent security policies that require data to remain within controlled environments. Here are some key reasons to consider self-hosting:
+### Choose this path when
 
-- **Enhanced Security and Compliance:** By self-hosting, you ensure that all data handling and processing complies with internal and external regulations, keeping sensitive information within your secure infrastructure. Note that Firecrawl is a Mendable product and relies on SOC2 Type2 certification, which means that the platform adheres to high industry standards for managing data security.
-- **Customizable Services:** Self-hosting allows you to tailor the services, such as the Playwright service, to meet specific needs or handle particular use cases that may not be supported by the standard cloud offering.
-- **Learning and Community Contribution:** By setting up and maintaining your own instance, you gain a deeper understanding of how Firecrawl works, which can also lead to more meaningful contributions to the project.
+- **If you need source or infrastructure control, follow this guide.** You will operate the API and every supporting service.
+- **If you want a working API without operating infrastructure, choose Firecrawl Cloud.** Compare [Open Source vs Cloud](/contributing/open-source-or-cloud) to see which managed-only capabilities matter to you.
+- **If you need an authenticated, highly available, or compliance-sensitive production service, use this guide only to validate compatibility.** You must still design and verify the controls in [Production considerations](#production-considerations).
+
+**Recommendation:** use Docker Compose when infrastructure control or source access is worth the operational responsibility. If your priority is the fastest supported path to production, start with Firecrawl Cloud.
 
 ### Considerations
 
-However, there are some limitations and additional responsibilities to be aware of:
-
-1. **Limited Access to Fire-engine:** Currently, self-hosted instances of Firecrawl do not have access to Fire-engine, which includes advanced features for handling IP blocks, robot detection mechanisms, and more. This means that while you can manage basic scraping tasks, more complex scenarios might require additional configuration or might not be supported.
-2. **Manual Configuration Required:** If you need to use scraping methods beyond the basic fetch and Playwright options, you will need to manually configure these in the `.env` file. This requires a deeper understanding of the technologies and might involve more setup time.
-| Capability | Cloud | Self-hosting |
-| --- | --- | --- |
-| All API endpoints supported | Yes | Not always; `/agent` and `/browser` are not supported in self-hosting |
-| Screenshot support | Yes | Yes, when the Playwright service is running |
-| Local LLMs (e.g., Ollama) | Not supported | Supported via `OLLAMA_BASE_URL` (experimental) |
-
-Self-hosting Firecrawl is ideal for those who need full control over their scraping and data processing environments but comes with the trade-off of additional maintenance and configuration efforts.
+- You own upgrades, secrets, storage, monitoring, recovery, and incident response.
+- Scraping still sends outbound requests to target websites. Optional proxy, parsing, or AI providers add more data flows.
+- The quickstart uses known-safe evaluation defaults. Keep them until the first scrape succeeds, then change one decision at a time.
+- The commands are pinned to `v2.11.162`. Another release can change its Compose contract.
 
 ## Steps
 
-1. First, start by installing the dependencies
+### Decisions this quickstart makes
 
-- Docker [instructions](https://docs.docker.com/get-docker/)
+- **Source revision → Firecrawl `v2.11.162`.** Change it only after reviewing the target release's `docker-compose.yaml` and self-hosting notes.
+- **API authentication → disabled.** Change it only when you have a complete supported identity and database design; one environment variable is not enough.
+- **Queue backend → PostgreSQL.** Change it only when you intentionally want to operate the optional FoundationDB backend.
+- **Queue admin UI → disabled.** Enable it only with a strong `BULL_AUTH_KEY` and network controls.
+- **Optional AI and advanced scraping providers → not configured.** Add one only when the capability you need explicitly requires it.
 
+These defaults reduce the number of variables in the first run. Defer customization until the functional smoke test passes.
 
-2. Set environment variables
+### Prerequisites
 
-Create an `.env` in the root directory you can copy over the template in `apps/api/.env.example`
+Install the following:
 
-To start, we wont set up authentication, or any optional sub services (pdf parsing, JS blocking support, AI features)
+- [Git](https://git-scm.com/downloads)
+- [Docker Engine](https://docs.docker.com/engine/install/) or Docker Desktop
+- Docker Compose v2, invoked as `docker compose`
+- `curl` for the verification requests
 
+Make sure port `3002` is available on the host and Docker has enough capacity to build and run several services. The project does not publish a verified minimum host size.
+
+### Clone the verified release
+
+This guide was source-verified against Firecrawl `v2.11.162`. Check out that exact release so the commands and configuration below match the source:
+
+```bash
+git clone https://github.com/firecrawl/firecrawl.git
+cd firecrawl
+git checkout v2.11.162
 ```
-# .env
 
-# ===== Required ENVS ======
-PORT=3002
-HOST=0.0.0.0
+If you choose another release, review that release's `docker-compose.yaml` and self-hosting notes before reusing these values.
 
-# Note: PORT is used by both the main API server and worker liveness check endpoint
+### Configure the evaluation deployment
 
-# To turn on DB authentication, you need to set up Supabase.
+Create `.env` in the repository root:
+
+```bash
+cat > .env <<'EOF'
 USE_DB_AUTHENTICATION=false
-
-# ===== Optional ENVS ======
-
-## === AI features (JSON format on scrape, /extract API) ===
-# Provide your OpenAI API key here to enable AI features
-# OPENAI_API_KEY=
-
-# Experimental: Use Ollama
-# OLLAMA_BASE_URL=http://localhost:11434/api
-# MODEL_NAME=deepseek-r1:7b
-# MODEL_EMBEDDING_NAME=nomic-embed-text
-
-# Experimental: Use any OpenAI-compatible API
-# OPENAI_BASE_URL=https://example.com/v1
-# OPENAI_API_KEY=
-
-## === Proxy ===
-# PROXY_SERVER can be a full URL (e.g. http://0.1.2.3:1234) or just an IP and port combo (e.g. 0.1.2.3:1234)
-# Do not uncomment PROXY_USERNAME and PROXY_PASSWORD if your proxy is unauthenticated
-# PROXY_SERVER=
-# PROXY_USERNAME=
-# PROXY_PASSWORD=
-
-## === /search API ===
-
-# You can specify a SearXNG server with the JSON format enabled, if you'd like to use that instead of direct Google.
-# You can also customize the engines and categories parameters, but the defaults should also work just fine.
-# SEARXNG_ENDPOINT=http://your.searxng.server
-# SEARXNG_ENGINES=
-# SEARXNG_CATEGORIES=
-
-## === Other ===
-
-# Supabase Setup (used to support DB authentication, advanced logging, etc.)
-# SUPABASE_ANON_TOKEN=
-# SUPABASE_URL=
-# SUPABASE_SERVICE_TOKEN=
-
-# Use if you've set up authentication and want to test with a real API key
-# TEST_API_KEY=
-
-# This key lets you access the queue admin panel. Change this if your deployment is publicly accessible.
-BULL_AUTH_KEY=CHANGEME
-
-# This is now autoconfigured by the docker-compose.yaml. You shouldn't need to set it.
-# PLAYWRIGHT_MICROSERVICE_URL=http://playwright-service:3000/scrape
-# REDIS_URL=redis://redis:6379
-# REDIS_RATE_LIMIT_URL=redis://redis:6379
-
-# Set if you have a llamaparse key you'd like to use to parse pdfs
-# LLAMAPARSE_API_KEY=
-
-# Set if you'd like to send server health status messages to Slack
-# SLACK_WEBHOOK_URL=
-
-# Set if you'd like to send posthog events like job logs
-# POSTHOG_API_KEY=
-# POSTHOG_HOST=
-
-## === System Resource Configuration ===
-# Maximum CPU usage threshold (0.0-1.0). Worker will reject new jobs when CPU usage exceeds this value.
-# Default: 0.8 (80%)
-# MAX_CPU=0.8
-
-# Maximum RAM usage threshold (0.0-1.0). Worker will reject new jobs when memory usage exceeds this value.
-# Default: 0.8 (80%)
-# MAX_RAM=0.8
-
-# Set if you'd like to allow local webhooks to be sent to your self-hosted instance
-# ALLOW_LOCAL_WEBHOOKS=true
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=replace-with-at-least-32-random-characters
+POSTGRES_DB=postgres
+EOF
 ```
+
+Replace the PostgreSQL password before starting the stack. Keep `POSTGRES_DB=postgres` for `v2.11.162` because the bundled `pg_cron` configuration targets that database. Compose uses these values consistently for the API and PostgreSQL service. Do not commit `.env`.
 
 <Note>
-  The following AI features require an LLM provider configured (e.g., `OPENAI_API_KEY` or alternatives in the AI features section above):
-  - JSON format on scrape
-  - /extract API
-  - Summary format
-  - Branding format
-  - Change tracking format
+  `apps/api/.env.example` is an API development template, not a drop-in root
+  Compose configuration. The evaluation path disables database authentication,
+  so requests do not need an API key or `Authorization` header.
 </Note>
 
-3.  *(Optional) Running with TypeScript Playwright Service*
-    
-    *   Update the `docker-compose.yml` file to change the Playwright service:
-        
-        ```plaintext
-            build: apps/playwright-service
-        ```
-        TO
-        ```plaintext
-            build: apps/playwright-service-ts
-        ```
-        
-    *   Set the `PLAYWRIGHT_MICROSERVICE_URL` in your `.env` file:
-        
-        ```plaintext
-        PLAYWRIGHT_MICROSERVICE_URL=http://localhost:3000/scrape
-        ```
-        
-    *   Don't forget to set the proxy server in your `.env` file as needed.
+Leave `NUQ_BACKEND` and `BULL_AUTH_KEY` unset. This keeps PostgreSQL as the queue backend and the queue administration UI disabled.
 
-4.  Build and run the Docker containers:
-    
-    ```bash
-    docker compose build
-    docker compose up
-    ```
+### Build and start Firecrawl
 
-This will run a local instance of Firecrawl which can be accessed at `http://localhost:3002`.
+Build the checked-out source and start the stack in the background:
 
-You should be able to see the Bull Queue Manager UI on `http://localhost:3002/admin/{BULL_AUTH_KEY}/queues`.
+```bash
+docker compose up --build -d
+docker compose ps --all
+```
 
-5. *(Optional)* Test the API
+Compose may warn that optional variables are unset; they can remain blank for this baseline deployment. `docker compose ps --all` should show the API and supporting services running, and one-shot initialization services completed successfully. Some services may take additional time to initialize.
 
-If you’d like to test the crawl endpoint, you can run this:
+### Check API reachability
 
-  ```bash
-  curl -X POST http://localhost:3002/v2/crawl \
-      -H 'Content-Type: application/json' \
-      -d '{
-        "url": "https://docs.firecrawl.dev"
-      }'
-  ```   
+Once the API container is running, check that its HTTP process is reachable:
+
+```bash
+curl \
+  --fail \
+  --silent \
+  --show-error \
+  --max-time 5 \
+  http://localhost:3002/v0/health/readiness
+```
+
+Expected response:
+
+```json
+{"status":"ok"}
+```
+
+<Warning>
+  This endpoint only confirms that the API process can respond. It does not check
+  Redis, PostgreSQL, RabbitMQ, Playwright, workers, or outbound network access.
+  Complete the functional smoke test below before treating the deployment as usable.
+</Warning>
+
+### Run a functional smoke test
+
+Send one synchronous scrape request. The request timeout is in milliseconds; curl's client timeout is in seconds and is slightly longer:
+
+```bash
+curl \
+  --fail-with-body \
+  --silent \
+  --show-error \
+  --max-time 75 \
+  -X POST \
+  http://localhost:3002/v2/scrape \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "url": "https://example.com",
+    "formats": ["markdown"],
+    "timeout": 60000
+  }'
+```
+
+A successful response has this shape:
+
+```json
+{
+  "success": true,
+  "data": {
+    "markdown": "...",
+    "metadata": {
+      "statusCode": 200
+    }
+  }
+}
+```
+
+This verifies the API, scraping pipeline, one scraping-engine path, and outbound access together. Exact metadata can vary with the target response.
+
+If the response contains these success fields, the evaluation journey is complete. Decide what to add next instead of changing the baseline configuration preemptively.
+
+## Capability boundaries
+
+Use the capability you need to choose the next path:
+
+| If you need | Decision |
+| --- | --- |
+| Core scrape, crawl, map, and search routes | Continue with the default stack. Fetch and Playwright processing are included. |
+| LLM-backed extraction or formats | Add an OpenAI-compatible provider or Ollama, then verify that path separately. |
+| Fire-engine or its advanced anti-bot behavior | Operate and configure that service separately; it is not included. |
+| Agent, Browser, interact, feedback, or specialized product, menu, audio, and video formats | Use Firecrawl Cloud or verify the external service requirements for the specific capability. |
+
+For the broader product comparison, see [Open Source vs Cloud](/contributing/open-source-or-cloud). For release-specific configuration, use the pinned [`docker-compose.yaml`](https://github.com/firecrawl/firecrawl/blob/v2.11.162/docker-compose.yaml) as the companion source.
+
+## Production considerations
+
+A successful smoke test proves that the evaluation path works. It does not prove production readiness. Before moving beyond a trusted network, make these decisions:
+
+- **If data must survive service replacement,** add durable storage for PostgreSQL, Redis, and RabbitMQ, then define and test backup and restore procedures. The provided Compose file does not add those volumes.
+- **If users or untrusted networks can reach the API,** add a supported authentication design, network access controls, and TLS at a reverse proxy or ingress. Do not expose this unauthenticated baseline publicly.
+- **If you have availability or capacity requirements,** define service-level objectives, monitoring, resource sizing, scaling triggers, and upgrade and rollback procedures. The Compose limits are not verified minimum requirements.
+- **If data location or compliance matters,** map requests to target websites and every optional AI, proxy, or parsing provider before enabling them.
+- **If secrets must be managed centrally,** move the database password out of `.env` and into your platform's secret-management system.
+
+These are architecture decisions, not additional quickstart environment variables.
+
+## Next steps
+
+- **If you are only evaluating Firecrawl,** keep the API on a trusted network and run `docker compose down` when you are finished.
+- **If you need another open-source capability,** use [Capability boundaries](#capability-boundaries) to identify the required provider or service and verify it as a separate path.
+- **If you need managed infrastructure or Cloud-only capabilities,** compare [Open Source vs Cloud](/contributing/open-source-or-cloud).
+- **If you are preparing for production,** complete every decision in [Production considerations](#production-considerations) before exposing the API.
 
 ## Troubleshooting
 
-This section provides solutions to common issues you might encounter while setting up or running your self-hosted instance of Firecrawl.
-
-### Supabase client is not configured
-
-**Symptom:**
-```bash
-[YYYY-MM-DDTHH:MM:SS.SSSz]ERROR - Attempted to access Supabase client when it's not configured.
-[YYYY-MM-DDTHH:MM:SS.SSSz]ERROR - Error inserting scrape event: Error: Supabase client is not configured.
-```
-
-**Explanation:**
-This error occurs because the Supabase client setup is not completed. You should be able to scrape and crawl with no problems. Right now it's not possible to configure Supabase in self-hosted instances.
-
 ### You're bypassing authentication
 
-**Symptom:**
-```bash
-[YYYY-MM-DDTHH:MM:SS.SSSz]WARN - You're bypassing authentication
-```
-
-**Explanation:**
-This error occurs because the Supabase client setup is not completed. You should be able to scrape and crawl with no problems. Right now it's not possible to configure Supabase in self-hosted instances.
+If you see this warning with `USE_DB_AUTHENTICATION=false`, continue: it is expected for the evaluation deployment. Requests use a self-hosted identity and need no API key. If the API is reachable from an untrusted network, stop and add the controls described in [Production considerations](#production-considerations).
 
 ### Docker containers fail to start
 
-**Symptom:**
-Docker containers exit unexpectedly or fail to start.
+If any long-running service exits, inspect container state and recent logs:
 
-**Solution:**
-Check the Docker logs for any error messages using the command:
 ```bash
-docker logs [container_name]
+docker compose ps --all
+docker compose logs --tail=200
 ```
 
-- Ensure all required environment variables are set correctly in the .env file.
-- Verify that all Docker services defined in docker-compose.yml are correctly configured and the necessary images are available.
+- If the source revision differs, either check out `v2.11.162` or use that release's configuration.
+- If a build or container is resource-constrained, increase Docker CPU, memory, or disk capacity.
+- If PostgreSQL fails, check `.env` syntax, keep `POSTGRES_DB=postgres`, and make sure the user and password values are consistent.
 
 ### Connection issues with Redis
 
-**Symptom:**
-Errors related to connecting to Redis, such as timeouts or "Connection refused".
+If a container cannot connect to Redis, keep the Compose service address `redis://redis:6379`. `localhost` points back to that container, not the Redis service.
 
-**Solution:**
-- Ensure that the Redis service is up and running in your Docker environment.
-- Verify that the REDIS_URL and REDIS_RATE_LIMIT_URL in your .env file point to the correct Redis instance.
-- Check network settings and firewall rules that may block the connection to the Redis port.
+```bash
+docker compose ps redis
+docker compose logs --tail=100 redis
+```
+
+If you added `REDIS_URL` or `REDIS_RATE_LIMIT_URL`, remove the override to restore the default or use an address that resolves from inside the Compose network.
 
 ### API endpoint does not respond
 
-**Symptom:**
-API requests to the Firecrawl instance timeout or return no response.
+If port `3002` does not respond, check the API container and its logs:
 
-**Solution:**
-- Ensure that the Firecrawl service is running by checking the Docker container status.
-- Verify that the PORT and HOST settings in your .env file are correct and that no other service is using the same port.
-- Check the network configuration to ensure that the host is accessible from the client making the API request.
+```bash
+docker compose ps api
+docker compose logs --tail=200 api
+```
 
-By addressing these common issues, you can ensure a smoother setup and operation of your self-hosted Firecrawl instance.
+If another process owns port `3002`, stop it or change the published port consistently. During initial startup, retry only after the API container reports as running.
 
-## Install Firecrawl on a Kubernetes Cluster (Simple Version)
+If `/v0/health/readiness` succeeds but `/v2/scrape` fails, inspect the API and Playwright logs because the reachability endpoint does not validate those dependencies:
 
-Read the [examples/kubernetes-cluster-install/README.md](https://github.com/firecrawl/firecrawl/tree/main/examples/kubernetes/cluster-install#readme) for instructions on how to install Firecrawl on a Kubernetes Cluster.
+```bash
+docker compose logs --tail=200 api playwright-service
+```
+
+### Scrape request times out
+
+If the scrape times out, confirm the deployment can reach `https://example.com` and that the API and Playwright services are running. Keep curl's `--max-time` longer than the request body's `timeout` so the API can return its own timeout response.

--- a/contributing/self-host.mdx
+++ b/contributing/self-host.mdx
@@ -1,23 +1,24 @@
 ---
-title: "Self-hosting"
-description: "Learn how to self-host Firecrawl to run on your own and contribute to the project."
-og:title: "Self-hosting | Firecrawl"
-og:description: "Learn how to self-host Firecrawl to run on your own and contribute to the project."
+title: "Self-hosting Firecrawl"
+sidebarTitle: "Self-hosting"
+description: "Self-host Firecrawl with Docker Compose, verify a local scrape, understand open-source limits, and prepare the stack for production."
+og:title: "Self-hosting Firecrawl | Firecrawl"
+og:description: "Self-host Firecrawl with Docker Compose, verify a local scrape, understand open-source limits, and prepare the stack for production."
 ---
 
 <span id="self-hosting-firecrawl" />
 
-Run Firecrawl on your own infrastructure and get your first scrape working with Docker Compose. This guide helps you choose the right path, builds a verified release from source, and finishes with Markdown from a local `POST /v2/scrape` request on port `3002`.
+Self-host Firecrawl with Docker Compose when you need source or infrastructure control. This guide pins release `v2.11.162`, starts the API at `http://localhost:3002`, and verifies a successful `POST /v2/scrape` response with Markdown.
 
 <Warning>
-  This Compose setup is the fastest way to try self-hosting, not a production
-  architecture. It starts without API authentication, durable storage, TLS,
-  high availability, or every Firecrawl Cloud capability.
+  This trusted-network quickstart disables API authentication and is not a
+  production architecture. It starts without durable storage, TLS, high
+  availability, or every Firecrawl Cloud capability.
 </Warning>
 
-## Choose your path
+## Choose self-hosting or Firecrawl Cloud
 
-### Self-host when
+### Self-host Firecrawl when
 
 - **You want control over the source or infrastructure.** This guide gets the API and its supporting services running on your machine.
 - **You are comfortable operating the stack.** You will own upgrades, security, storage, monitoring, and recovery.
@@ -27,14 +28,14 @@ Choose [Firecrawl Cloud](https://firecrawl.dev) when you want to start scraping 
 
 **Our recommendation:** self-host when source access or infrastructure control is worth the operational work. If you want the fastest supported path to production, start with Firecrawl Cloud.
 
-### What you take on
+### What self-hosting requires
 
 - You own upgrades, secrets, storage, monitoring, recovery, and incident response.
 - Scraping still sends outbound requests to target websites. Optional proxy, parsing, or AI providers add more data flows.
 - This guide keeps the first run intentionally simple. Get one scrape working, then change one decision at a time.
 - The commands are pinned to `v2.11.162`. A different release may use a different Compose contract.
 
-## Get Firecrawl running
+## Self-host Firecrawl with Docker Compose
 
 ### Start with these defaults
 
@@ -166,7 +167,7 @@ This checks the API, scraping pipeline, one scraping-engine path, and outbound a
 
 If you get these success fields, Firecrawl is working end to end on your infrastructure. Keep this baseline, then choose what to add next.
 
-## Capability boundaries
+## Self-hosted feature support
 
 Your first scrape works. Add the next capability because you need it, not because it exists:
 
@@ -194,7 +195,7 @@ These are infrastructure decisions. No single `.env` switch makes the stack prod
 ## Where to go next
 
 - **Still evaluating?** Keep the API on a trusted network and run `docker compose down` when you are finished.
-- **Adding an open-source capability?** Use [Capability boundaries](#capability-boundaries) to find the required provider or service, then test that path on its own.
+- **Adding an open-source capability?** Use [Self-hosted feature support](#self-hosted-feature-support) to find the required provider or service, then test that path on its own.
 - **Want managed infrastructure or Cloud-only capabilities?** Compare [Open Source vs Cloud](/contributing/open-source-or-cloud).
 - **Going to production?** Complete every decision in [Before production](#before-production) before exposing the API.
 

--- a/contributing/self-host.mdx
+++ b/contributing/self-host.mdx
@@ -176,6 +176,7 @@ Your first scrape works. Add the next capability because you need it, not becaus
 | Core scrape, crawl, map, and search routes | Keep the default stack. Fetch and Playwright processing are included. |
 | LLM-backed extraction or formats | Connect an OpenAI-compatible provider or Ollama, then test that path separately. |
 | Fire-engine or its advanced anti-bot behavior | Run and configure that service separately; it is not included. |
+| Screenshots or page actions | Not available in the default stack. Fetch and Playwright both report no support; both require Fire-engine. |
 | Agent, Browser, interact, feedback, or specialized product, menu, audio, and video formats | Use Firecrawl Cloud, or verify the external service requirements for the specific capability. |
 
 For the broader product comparison, see [Open Source vs Cloud](/contributing/open-source-or-cloud). For release-specific configuration, use the pinned [`docker-compose.yaml`](https://github.com/firecrawl/firecrawl/blob/v2.11.162/docker-compose.yaml) as the companion source.

--- a/contributing/self-host.mdx
+++ b/contributing/self-host.mdx
@@ -196,6 +196,9 @@ These are infrastructure decisions. No single `.env` switch makes the stack prod
 
 - **Still evaluating?** Keep the API on a trusted network and run `docker compose down` when you are finished.
 - **Adding an open-source capability?** Use [Self-hosted feature support](#self-hosted-feature-support) to find the required provider or service, then test that path on its own.
+- **Changing Firecrawl code?** Switch to [Running Locally](/contributing/guide) for the contributor development environment.
+- **Connecting a client?** Point the [Firecrawl CLI](/sdks/cli#connect-the-cli-to-self-hosted-firecrawl) or [local MCP server](/mcp-server/local#connect-mcp-to-self-hosted-firecrawl) at your verified API URL.
+- **Moving to Kubernetes?** Start with the versioned Kubernetes or Helm references linked from [`SELF_HOST.md`](https://github.com/firecrawl/firecrawl/blob/main/SELF_HOST.md), then make the production decisions above explicit for your platform.
 - **Want managed infrastructure or Cloud-only capabilities?** Compare [Open Source vs Cloud](/contributing/open-source-or-cloud).
 - **Going to production?** Complete every decision in [Before production](#before-production) before exposing the API.
 

--- a/docs.json
+++ b/docs.json
@@ -783,14 +783,6 @@
                     "pages": [
                       "dashboard"
                     ]
-                  },
-                  {
-                    "group": "Contributing",
-                    "pages": [
-                      "contributing/open-source-or-cloud",
-                      "contributing/guide",
-                      "contributing/self-host"
-                    ]
                   }
                 ],
                 "tab": "Documentation"
@@ -814,8 +806,7 @@
                       "sdks/rust",
                       "sdks/dotnet",
                       "sdks/php",
-                      "sdks/elixir",
-                      "sdks/cli"
+                      "sdks/elixir"
                     ]
                   },
                   {

--- a/mcp-server/local.mdx
+++ b/mcp-server/local.mdx
@@ -1,32 +1,72 @@
 ---
 title: Run Firecrawl MCP locally
-description: Install and configure the local Firecrawl MCP server.
+description: Run the Firecrawl MCP server as a local process and connect it to Firecrawl Cloud or a self-hosted Firecrawl API.
 sidebarTitle: Run locally
 ---
 
-## Prerequisites
+Run Firecrawl MCP locally when your agent launches tools over stdio, needs local-file access, or connects to a Firecrawl API on infrastructure you control. The MCP server and the Firecrawl API are separate services: choose the API backend first, then start MCP with the matching environment variables.
+
+## Choose the Firecrawl API backend
+
+| If you need | Use |
+| --- | --- |
+| The fastest managed path | Firecrawl Cloud with `FIRECRAWL_API_KEY` |
+| Source or infrastructure control | A verified self-hosted API with `FIRECRAWL_API_URL` |
+| Direct local-file Parse | Local MCP connected to a self-hosted Firecrawl API |
+| Safe remote MCP without operating this process | The hosted Firecrawl MCP server |
+
+If you have not started the API yet, follow [Self-hosting Firecrawl](/contributing/self-host) and verify one scrape before adding MCP.
+
+## Install the prerequisites
 
 - Node.js 22 or newer
 - npm and `npx`, included with Node.js
-- A Firecrawl API key for the cloud API, or a self-hosted Firecrawl API URL
+- A Firecrawl Cloud API key or a working self-hosted Firecrawl API URL
 
-Confirm the installed Node.js version:
+Confirm Node.js:
 
 ```bash
 node --version
 ```
 
-## Run over stdio
+## Run MCP with Firecrawl Cloud
+
+For clients that launch MCP as a local stdio process:
 
 ```bash
 env FIRECRAWL_API_KEY=fc-YOUR_API_KEY npx -y firecrawl-mcp@3.23.0
 ```
 
-This is the default transport for clients that launch the MCP server as a local process.
+This is the smallest managed path. Firecrawl Cloud supplies the API backend while the MCP process runs on your machine.
 
-## Run with Streamable HTTP
+## Connect MCP to self-hosted Firecrawl
 
-Use HTTP transport for clients such as n8n that connect to an already-running MCP server:
+For the unauthenticated trusted-network quickstart:
+
+```bash
+env FIRECRAWL_API_URL=http://localhost:3002 \
+  npx -y firecrawl-mcp@3.23.0
+```
+
+For a self-hosted API with an API-key-compatible authentication layer:
+
+```bash
+env FIRECRAWL_API_URL=https://firecrawl.your-domain.com \
+  FIRECRAWL_API_KEY=your-api-key \
+  npx -y firecrawl-mcp@3.23.0
+```
+
+Use the key only when your deployment requires it. MCP can expose only the tools supported by the services configured in that deployment; see [self-hosted feature support](/contributing/self-host#self-hosted-feature-support).
+
+<Warning>
+  Do not expose the unauthenticated self-hosting quickstart publicly. Add TLS,
+  network controls, and a supported authentication design before using a
+  remote API URL.
+</Warning>
+
+## Run MCP over Streamable HTTP
+
+Use HTTP transport when a client such as n8n connects to an already-running MCP server:
 
 ```bash
 env HTTP_STREAMABLE_SERVER=true \
@@ -40,15 +80,19 @@ Connect the client to:
 http://localhost:3000/mcp
 ```
 
-Confirm the server is ready:
+Confirm the MCP process is ready:
 
 ```bash
 curl http://localhost:3000/health
 ```
 
-The health check returns `ok`. The local route is `/mcp`; `/v2/mcp` is the hosted Firecrawl route.
+The health check returns `ok`. The local MCP route is `/mcp`; `/v2/mcp` is the hosted Firecrawl route.
 
-## Install globally
+To use HTTP transport with self-hosted Firecrawl, replace `FIRECRAWL_API_KEY` with the `FIRECRAWL_API_URL` configuration from the previous section and add a key only when the API requires one.
+
+## Persist local MCP configuration
+
+Install the package globally when you prefer a stable local command:
 
 ```bash
 npm install -g firecrawl-mcp@3.23.0
@@ -60,44 +104,14 @@ Then run:
 env FIRECRAWL_API_KEY=fc-YOUR_API_KEY firecrawl-mcp
 ```
 
-## Configuration
-
-### Environment Variables
-
-#### Cloud and self-hosted API
-
-- `FIRECRAWL_API_KEY`: Your Firecrawl API key
-  - Required when using cloud API (default)
-  - Optional when using self-hosted instance with `FIRECRAWL_API_URL`
-- `FIRECRAWL_API_URL` (Optional): Custom API endpoint for self-hosted instances
-  - Example: `https://firecrawl.your-domain.com`
-  - If not provided, the cloud API will be used (requires API key)
-
-### Configuration Examples
-
-For cloud API usage:
-
-```bash
-export FIRECRAWL_API_KEY=your-api-key
-```
-
-For self-hosted instance:
-
-```bash
-export FIRECRAWL_API_URL=https://firecrawl.your-domain.com
-export FIRECRAWL_API_KEY=your-api-key  # If your instance requires auth
-```
-
-### Custom configuration with Claude Desktop
-
-Add this to your `claude_desktop_config.json`:
+For Claude Desktop, add a local stdio server to `claude_desktop_config.json`:
 
 ```json
 {
   "mcpServers": {
-    "mcp-server-firecrawl": {
+    "firecrawl": {
       "command": "npx",
-      "args": ["-y", "firecrawl-mcp"],
+      "args": ["-y", "firecrawl-mcp@3.23.0"],
       "env": {
         "FIRECRAWL_API_KEY": "YOUR_API_KEY_HERE"
       }
@@ -106,18 +120,18 @@ Add this to your `claude_desktop_config.json`:
 }
 ```
 
-### Hosted MCP vs local MCP
+For self-hosted Firecrawl, replace `FIRECRAWL_API_KEY` with `FIRECRAWL_API_URL`, or include both when your API requires the key.
 
-The hosted MCP server is optimized for safe remote use. Some options that are available when running the MCP server locally are narrowed or unavailable remotely:
+## Understand local and hosted boundaries
 
-- Hosted keyless mode exposes only Search, Scrape, and Parse and is rate-limited per IP.
-- Local-only file reads are available only when you run the MCP server locally.
-- Webhooks and local file paths should be configured from a local or self-hosted MCP server when the agent needs access to local resources.
+- Hosted keyless MCP exposes only Search, Scrape, and Parse and is rate-limited per IP.
+- Local-only file reads require a local MCP process.
+- Direct local-file parsing with `firecrawl_parse` requires `FIRECRAWL_API_URL` pointing to a self-hosted Firecrawl API. A local MCP server configured only with a Cloud API key cannot upload a local file through that tool.
+- Webhooks and local file paths should be configured from local or self-hosted MCP when the agent must reach resources on your network.
+- Firecrawl API rate limits still apply. Use a Cloud API key for higher managed limits, or define and monitor capacity for your self-hosted deployment.
 
-<Note>
-Direct local-file parsing with `firecrawl_parse` requires `FIRECRAWL_API_URL` pointing to a self-hosted Firecrawl API. A local MCP server configured only with a cloud API key cannot upload a local file through that tool.
-</Note>
+## Where to go next
 
-### Rate Limiting
-
-Rate limits are enforced by Firecrawl. Use an API key for higher limits and access to the full tool set.
+- Review [Tools and operations](/mcp-server/tools) for the current tool inventory and self-hosted availability notes.
+- Use [Connect an MCP client](/mcp-server/connect) for client-specific setup.
+- Return to [Self-hosting Firecrawl](/contributing/self-host) for capability and production decisions.

--- a/sdks/cli.mdx
+++ b/sdks/cli.mdx
@@ -65,13 +65,21 @@ Before using the CLI, you need to authenticate with your Firecrawl API key.
 
 <AuthLogout />
 
-### Self-Hosted / Local Development
+### Connect the CLI to self-hosted Firecrawl
 
-For self-hosted Firecrawl instances or local development, use the `--api-url` option:
+First, get one scrape working with the [self-hosting guide](/contributing/self-host). Then point the CLI at that API with `--api-url` or `FIRECRAWL_API_URL`:
 
 <AuthSelfHosted />
 
-When using a custom API URL (anything other than `https://api.firecrawl.dev`), API key authentication is automatically skipped, allowing you to use local instances without an API key.
+When you use a custom API URL instead of `https://api.firecrawl.dev`, the CLI skips Firecrawl Cloud API-key authentication. That matches the trusted-network quickstart, where `USE_DB_AUTHENTICATION=false`.
+
+<Warning>
+  Keep an unauthenticated API on a trusted network. If you add an authentication
+  proxy or another access-control layer, verify that the CLI can send the
+  credentials that layer requires before depending on this path.
+</Warning>
+
+The CLI can call only the capabilities enabled in your deployment. Check [self-hosted feature support](/contributing/self-host#self-hosted-feature-support) before using Cloud-only or provider-dependent commands.
 
 ### Check Status
 


### PR DESCRIPTION
**Why**

Firecrawl's self-hosting journey spans several pages, but the surrounding decision, contributor, CLI, and MCP guidance did not consistently distinguish choosing a deployment, changing product code, operating a self-hosted API, and connecting clients. This change gives each page one clear job and connects them into a coherent path in Firecrawl's direct, builder-first voice.

**Summary**

- Turn `/contributing/open-source-or-cloud` into the deployment decision page: choose Cloud for the fastest managed path, or open source when source or infrastructure control is worth the operational work.
- Rebuild `/contributing/guide` as the contributor development path using Node.js 22, pnpm `11.4.0`, Redis, the source-owned API harness, one verified scrape, and the current snippet test command.
- Keep `/contributing/self-host` as the canonical Docker Compose deployment guide and add explicit handoffs to contributor setup, Kubernetes references, CLI, and MCP.
- Add a dedicated self-hosted connection path to `/sdks/cli`, including the custom API URL and trusted-network authentication boundary.
- Rework `/mcp-server/local` around the API-backend decision, preserving the pinned package version, stdio and Streamable HTTP transports, client configuration, and local-versus-hosted boundaries.
- Remove duplicate English hidden-v1 navigation references for the three Contributing routes and `/sdks/cli`; keep their visible v2 routes, labels, order, and localized navigation unchanged so Mintlify can index the current pages.
- Preserve all five routes, navigation intent, sidebar labels, localized source files, and the self-hosting page's established search and deep-link intent.
- Keep revision-specific contributor, Kubernetes, and Helm guidance in the companion product documentation change: https://github.com/firecrawl/firecrawl/pull/4209.

**Test plan**

- [x] All five routes render locally with one H1, expected metadata, working internal handoffs, and no page-level console errors.
- [x] Desktop checks at 1280×900 and mobile checks at 390×844 show no horizontal overflow; decision tables and code blocks stay within the page layout.
- [x] The CLI and MCP deep links resolve to `#connect-the-cli-to-self-hosted-firecrawl` and `#connect-mcp-to-self-hosted-firecrawl`.
- [x] The contributor path matches the current API source: Node.js 22, pnpm `11.4.0`, Redis, harness-managed PostgreSQL and RabbitMQ, `/v0/health/readiness`, `/v2/scrape`, and `pnpm harness pnpm test:snips`.
- [x] The existing Docker Compose first-scrape path remains runtime-verified against release `v2.11.162`.
- [x] A matched 12-prompt source-grounded benchmark across the associated journeys improves from 1/12 to 12/12 task success and from 0.4375 to 1.0 mean answer accuracy on one model and surface.
- [x] The current live baseline is recorded: the three Contributing routes and `/sdks/cli` emit `noindex` and are absent from `sitemap.xml` and `llms.txt`, while `/mcp-server/local` is indexable and included. The duplicate hidden-v1 references match that pattern.
- [x] After removing only the duplicate English hidden-v1 references, all five local routes respond without `noindex`; `jq empty docs.json` passes and visible v2 plus localized navigation remain unchanged.
- [x] `mint validate` remains at the 22 unrelated missing-snippet warnings; `mint broken-links` remains at 214 links in 101 unrelated files; `mint a11y` remains at the theme contrast failure plus 108 issues in 30 unrelated files. None of the five changed pages appears in those reports.
- [x] `git diff --check` passes, and only the five intended English source pages plus `docs.json` change. Localized files remain untouched under the repository's translation policy.
- [ ] Pull-request CI completes without a change-related regression.
- [ ] After deployment, verify the five live routes, handoffs, metadata, canonical tags, `robots` directives, and inclusion in `sitemap.xml` and `llms.txt`; rerun the matched prompts before claiming live search or answer-engine lift.
