### PR TITLE
docs(mcp): explain keyless limit recovery

### DIFF
--- a/mcp-server/connect.mdx
+++ b/mcp-server/connect.mdx
@@ -41,6 +41,21 @@ https://mcp.firecrawl.dev/v2/mcp
 
 Keyless MCP is rate-limited per IP and exposes exactly **Search, Scrape, and Parse** while eligible. Connect an account or use an API key when you need the complete tool surface or higher limits.
 
+## When you reach the free limit
+
+The keyless allowance is a rolling, per-network limit. The MCP error includes the current retry time when it is available; wait for that interval to keep using Search, Scrape, and Parse without an account.
+
+To continue immediately, choose one of these paths:
+
+- **Interactive OAuth:** connect the account endpoint, `https://mcp.firecrawl.dev/v2/mcp-oauth`. For Claude Code:
+
+  ```bash
+  claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/v2/mcp-oauth
+  ```
+
+  Then run `/mcp` and authenticate in the browser.
+- **Unattended API key:** create a key in the [Firecrawl dashboard](https://www.firecrawl.dev/app/api-keys) and configure `Authorization: Bearer <FIRECRAWL_API_KEY>`.
+
 ## Pick the right mode
 
 | Mode | Endpoint | Available tools | Best for | Credentials |


### PR DESCRIPTION
## Summary
Document that keyless limits are rolling per-network limits and explain the two recovery paths: interactive OAuth at `/v2/mcp-oauth` and API-key configuration.

## Validation
- Rebased cleanly on latest `main`.
- Single MDX documentation change; no repository-local docs build script is present.

## Deployment
May ship independently; best paired with the API/MCP recovery rollout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-docs/pr/1196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788331739&installation_model_id=11126&pr_number=1196&repository=firecrawl%2Ffirecrawl-docs&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-docs%2Fpull%2F1196&signature=fe9ce374c4879592c1ee75f63c8fd3ca9c3b04d3ca2d5432020c9645d8f05de6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->