### PR TITLE
docs(developer): fix k default, filter examples, and filter scope

### DIFF
--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -5082,7 +5082,7 @@
               "type": "integer",
               "minimum": 1,
               "maximum": 100,
-              "default": 20
+              "default": 10
             }
           },
           {
@@ -5145,27 +5145,30 @@
             "name": "language",
             "in": "query",
             "required": false,
-            "description": "Repository language.",
+            "description": "Repository primary language, such as `Rust`. Applies to GitHub results only; see the Developer Index guide for how the repository filters scope a search.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "example": "Rust"
             }
           },
           {
             "name": "topic",
             "in": "query",
             "required": false,
-            "description": "Repository topic.",
+            "description": "Repository topic, such as `async`. Applies to GitHub results only.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "example": "async"
             }
           },
           {
             "name": "license",
             "in": "query",
             "required": false,
-            "description": "Repository license.",
+            "description": "Repository license, such as `MIT`. Applies to GitHub results only.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "example": "MIT"
             }
           },
           {
@@ -5284,7 +5287,7 @@
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 100,
-                    "default": 20
+                    "default": 10
                   },
                   "types": {
                     "type": "array",

--- a/features/developer.mdx
+++ b/features/developer.mdx
@@ -151,20 +151,22 @@ All filters are optional.
 
 | Filter | Meaning |
 | --- | --- |
-| `k` | Number of ranked results to return. Defaults to 20, maximum 100 |
+| `k` | Number of ranked results to return. Defaults to 10, maximum 100 |
 | `types` | Result kinds to search. Any of `doc`, `issue`, `pull_request`, `readme`. Defaults to all four |
 | `repos` | Repository slugs to scope to, such as `firecrawl/firecrawl` |
 | `sources` | Documentation source ids to scope to, at most 20. See below |
 | `passages` | Matched passages to return per result. Defaults to 1, maximum 5 |
-| `language` | Repository language |
-| `topic` | Repository topic |
-| `license` | Repository license |
+| `language` | Repository primary language, such as `Rust` |
+| `topic` | Repository topic, such as `async` |
+| `license` | Repository license, such as `MIT` |
 | `min_stars` | Lower bound on repository stars |
 | `max_stars` | Upper bound on repository stars |
 | `archived` | Include or exclude archived repositories |
 | `fork` | Include or exclude forks |
 
 Repeatable filters accept either form on `GET`: a repeated query parameter such as `types=issue&types=pull_request`, or one comma separated value such as `types=issue,pull_request`. On `POST`, pass an array in the JSON body.
+
+The `language`, `topic`, `license`, `min_stars`, `max_stars`, `archived`, and `fork` filters describe a GitHub repository. They do not scope the index the way `repos` and `sources` do. Read [how the repository filters scope a search](#how-the-repository-filters-scope-a-search) before you send one.
 
 ### How `repos` and `sources` scope a search
 
@@ -200,6 +202,36 @@ To confirm an id resolves, pass it and read the `sources` array the response add
 
 `repos` echoes back the same way, as a `repos` array reporting `indexed` plus a per type breakdown of `issue`, `pullRequest`, and `readme`.
 
+### How the repository filters scope a search
+
+The seven repository filters — `language`, `topic`, `license`, `min_stars`, `max_stars`, `archived`, and `fork` — describe a GitHub repository. Most documentation pages in the index come from a crawled website with no repository behind it. No repository fact can admit or exclude such a page.
+
+A request that sends one of these filters and no `sources` scope therefore gets no `doc` results. Its response holds GitHub evidence only: the `issue`, `pull_request`, and `readme` types. The `coverage` map reports `doc` as `unavailable`, because the documentation half of the index never ran. This is the design, not an index fault.
+
+To keep documentation results, drop the repository filters. You can also scope the documentation half with `sources`, then read `coverage` to confirm that the `doc` type answered.
+
+<CodeGroup>
+
+```bash cURL
+# No API key needed to get started; add -H "Authorization: Bearer $FIRECRAWL_API_KEY" for higher rate limits:
+curl -s "https://api.firecrawl.dev/v2/search/developer?query=how%20do%20I%20configure%20retries&k=10&language=Rust&license=MIT"
+```
+
+```bash cURL (POST)
+curl -X POST https://api.firecrawl.dev/v2/search/developer \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "how do I configure retries",
+    "k": 10,
+    "types": ["issue", "pull_request"],
+    "language": "Rust",
+    "license": "MIT"
+  }'
+```
+
+</CodeGroup>
+
 ### Response
 
 ```json
@@ -232,10 +264,10 @@ To confirm an id resolves, pass it and read the `sources` array the response add
 - `type` is one of `doc`, `issue`, `pull_request`, or `readme`
 - `title` is optional and is frequently absent on `doc` results, where the source page carries no usable title. Fall back to `url` rather than assuming the field is present
 - `passages` holds the matched passages in markdown, so tables and code blocks survive
-- `coverage` reports index health per result type, one of `ok`, `degraded`, `unavailable`, or `skipped`
+- `coverage` reports the outcome for each result type, one of `ok`, `degraded`, `unavailable`, or `skipped`
 - `reranked` reports whether the ranked list went through the reranking stage
 
-Check `coverage` when a result type you expected is missing. A `degraded` or `unavailable` status means the gap came from the index rather than from the query.
+Check `coverage` when a result type you expected is missing. `skipped` means your `types` value did not ask for that type. A `degraded` or `unavailable` status means the gap came from the index or from a filter, not from the query. A repository filter is one such cause, as [how the repository filters scope a search](#how-the-repository-filters-scope-a-search) describes.
 
 ## Use it from MCP
 


### PR DESCRIPTION
Three corrections to the Developer Index docs that the GA pass (#1207) did not cover. Rebased onto GA, so this PR now contains only what is still wrong.

Every claim is verified live against `api.firecrawl.dev` and against the route contract in `firecrawl/search`.

### 1. `k` defaults to 10, not 20 — in the page and in the OpenAPI spec

A request with no `k` returns 10 results. Measured on all four combinations (GET and POST, keyed and keyless). The route contract agrees: `params.limit("k", 10, 100)`, documented as `1-100 (default 10)`.

`features/developer.mdx` said 20. The GA pass also carried 20 into `api-reference/v2-openapi.json`, on both the GET query parameter and the POST body, where it renders as the documented default and feeds client codegen. Both are fixed.

### 2. Filter examples use the values GitHub reports

`language` and `license` match against repository facts, and GitHub reports them capitalised. Measured: `language=Rust` and `license=MIT` return results; `rust` and `mit` return none. The filter table now carries `Rust`, `MIT`, and `async` as example values, the OpenAPI parameters carry matching `example` values, and a new filtered request example sends `language=Rust&license=MIT`.

Stated as examples rather than as a case-sensitivity rule, so the examples stay correct if value matching is normalised later.

### 3. A repository filter drops the documentation half of the index

This is the one a caller cannot guess, and nothing in the docs said it. The seven repository filters describe a GitHub repository. Most documentation pages come from a crawled website with no repository, so no repository fact can decide them. A request with one of these filters and no `sources` scope gets no `doc` results, and `coverage` reports `doc` as `unavailable`:

```
GET /v2/search/developer?query=rust%20async%20runtime&k=5&language=Rust
→ 5 results, coverage {"doc":"unavailable","issue":"ok","pull_request":"ok","readme":"ok"}
```

`src/code_search/filter_serving.rs` confirms this is deliberate: an unscoped doc request refuses because doc-source membership is not enumerable from the repository profile store, and `NotCovered` maps to `unavailable` coverage.

The new section states the outcome, names the cause, and sends readers to `coverage`. The response prose is corrected too: it previously said a `degraded` or `unavailable` status "means the gap came from the index rather than from the query," which reads as an index fault when a filter is a legitimate cause.

### Scope notes

- **Rebased, not merged over GA.** This branch previously also corrected the canonical path and the removed beta gate. #1207 fixed both, and its versions are better — it has the correct credit cost (2 credits per 10 results, which my draft still called "one search") and a more precise MCP keyless paragraph. I reset onto GA and kept only the three items above, so nothing in GA is reverted.
- The five localized copies of the page and of `v2-openapi.json` still carry `k` = 20, inherited from the English source. `CLAUDE.md` says not to modify localized files, and locadex regenerated them from GA within the hour, so it will pick up this fix on its next run.
- `mint validate` reports 17 warnings, a byte-identical set to the baseline on unmodified `main`; none reference either changed file.
