### PR TITLE
docs: developer index wording and CLI command reference

### DIFF
--- a/api-reference/endpoint/developer-search.mdx
+++ b/api-reference/endpoint/developer-search.mdx
@@ -3,7 +3,7 @@ title: "Search the Developer Index"
 openapi: "/api-reference/v2-openapi.json GET /search/developer"
 ---
 
-Search GitHub issues, merged pull requests, repository READMEs, and curated documentation sites. Results are ranked and carry the matched passages in markdown.
+Search issues, merged pull requests, and READMEs from public code repositories, alongside curated documentation sites. Results are ranked and carry the matched passages in markdown.
 
 `POST` is available on the same path when you want to pass array filters as JSON.
 
@@ -13,20 +13,20 @@ Repeatable filters accept either form on `GET`: a repeated query parameter such 
 
 The index has two halves, and these two filters scope them independently:
 
-- `repos` scopes the GitHub half, meaning the `issue`, `pull_request`, and `readme` types
+- `repos` scopes the repository half, meaning the `issue`, `pull_request`, and `readme` types
 - `sources` scopes the documentation half, meaning the `doc` type
 - Passing both combines the two halves rather than intersecting them, so you get matching results from either
 
 Because each filter only applies to one half, a filter that cannot match any requested type is rejected rather than silently returning nothing:
 
-- `repos` with no GitHub type in `types` returns `400` with `repos cannot match any requested type; add github types or drop repos`
+- `repos` with no repository type in `types` returns `400`, reporting that `repos` cannot match any requested type and that you should add repository types or drop `repos`
 - `sources` with no `doc` in `types` returns `400` with `sources cannot match any requested type; add doc or drop sources`
 
 ## How the repository filters scope a search
 
-The seven repository filters — `language` (such as `Rust`), `topic` (such as `async`), `license` (such as `MIT`), `min_stars`, `max_stars`, `archived`, and `fork` — describe a GitHub repository. Most documentation pages in the index come from a crawled website with no repository behind it, and no repository fact can admit or exclude such a page.
+The seven repository filters — `language` (such as `Rust`), `topic` (such as `async`), `license` (such as `MIT`), `min_stars`, `max_stars`, `archived`, and `fork` — describe a code repository. Most documentation pages in the index come from a crawled website with no repository behind it, and no repository fact can admit or exclude such a page.
 
-A request that sends one of these filters and no `sources` scope therefore gets no `doc` results. Its response holds GitHub evidence only: the `issue`, `pull_request`, and `readme` types. The `coverage` map reports `doc` as `unavailable`, because the documentation half of the index never ran. This is the design, not an index fault.
+A request that sends one of these filters and no `sources` scope therefore gets no `doc` results. Its response holds repository evidence only: the `issue`, `pull_request`, and `readme` types. The `coverage` map reports `doc` as `unavailable`, because the documentation half of the index never ran. This is the design, not an index fault.
 
 To keep documentation results, drop the repository filters. You can also scope the documentation half with `sources`, then read `coverage` to confirm that the `doc` type answered.
 

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -5107,7 +5107,7 @@
             "name": "repos",
             "in": "query",
             "required": false,
-            "description": "Repository slugs to scope the GitHub half of the index to, such as `firecrawl/firecrawl`. Applies to the `issue`, `pull_request`, and `readme` types only. Sent together with `sources`, the two halves are combined rather than intersected, so matching results come back from either. Returns 400 with `repos cannot match any requested type; add github types or drop repos` when no GitHub type is in `types`.",
+            "description": "Repository slugs to scope the repository half of the index to, such as `firecrawl/firecrawl`. Applies to the `issue`, `pull_request`, and `readme` types only. Sent together with `sources`, the two halves are combined rather than intersected, so matching results come back from either. Returns 400 when no repository type is in `types`, reporting that `repos` cannot match any requested type and that you should add repository types or drop `repos`.",
             "schema": {
               "type": "array",
               "items": {
@@ -5158,7 +5158,7 @@
             "name": "language",
             "in": "query",
             "required": false,
-            "description": "Repository primary language, such as `Rust`. Applies to GitHub results only; sending it with no `sources` scope returns no `doc` results. See [how the repository filters scope a search](/api-reference/endpoint/developer-search#how-the-repository-filters-scope-a-search).",
+            "description": "Repository primary language, such as `Rust`. Applies to repository results only; sending it with no `sources` scope returns no `doc` results. See [how the repository filters scope a search](/api-reference/endpoint/developer-search#how-the-repository-filters-scope-a-search).",
             "schema": {
               "type": "string",
               "example": "Rust"
@@ -5168,7 +5168,7 @@
             "name": "topic",
             "in": "query",
             "required": false,
-            "description": "Repository topic, such as `async`. Applies to GitHub results only; sending it with no `sources` scope returns no `doc` results.",
+            "description": "Repository topic, such as `async`. Applies to repository results only; sending it with no `sources` scope returns no `doc` results.",
             "schema": {
               "type": "string",
               "example": "async"
@@ -5178,7 +5178,7 @@
             "name": "license",
             "in": "query",
             "required": false,
-            "description": "Repository license, such as `MIT`. Applies to GitHub results only; sending it with no `sources` scope returns no `doc` results.",
+            "description": "Repository license, such as `MIT`. Applies to repository results only; sending it with no `sources` scope returns no `doc` results.",
             "schema": {
               "type": "string",
               "example": "MIT"
@@ -5188,7 +5188,7 @@
             "name": "min_stars",
             "in": "query",
             "required": false,
-            "description": "Lower bound on repository stars. Applies to GitHub results only; sending it with no `sources` scope returns no `doc` results.",
+            "description": "Lower bound on repository stars. Applies to repository results only; sending it with no `sources` scope returns no `doc` results.",
             "schema": {
               "type": "integer",
               "minimum": 0
@@ -5198,7 +5198,7 @@
             "name": "max_stars",
             "in": "query",
             "required": false,
-            "description": "Upper bound on repository stars. Applies to GitHub results only; sending it with no `sources` scope returns no `doc` results.",
+            "description": "Upper bound on repository stars. Applies to repository results only; sending it with no `sources` scope returns no `doc` results.",
             "schema": {
               "type": "integer",
               "minimum": 0
@@ -5208,7 +5208,7 @@
             "name": "archived",
             "in": "query",
             "required": false,
-            "description": "Include or exclude archived repositories. Applies to GitHub results only; sending it with no `sources` scope returns no `doc` results.",
+            "description": "Include or exclude archived repositories. Applies to repository results only; sending it with no `sources` scope returns no `doc` results.",
             "schema": {
               "type": "boolean"
             }
@@ -5217,7 +5217,7 @@
             "name": "fork",
             "in": "query",
             "required": false,
-            "description": "Include or exclude forks. Applies to GitHub results only; sending it with no `sources` scope returns no `doc` results.",
+            "description": "Include or exclude forks. Applies to repository results only; sending it with no `sources` scope returns no `doc` results.",
             "schema": {
               "type": "boolean"
             }
@@ -5316,7 +5316,7 @@
                   },
                   "repos": {
                     "type": "array",
-                    "description": "Repository slugs to scope the GitHub half of the index to. Applies to the `issue`, `pull_request`, and `readme` types only. Sent together with `sources`, the two halves are combined rather than intersected. Returns 400 with `repos cannot match any requested type; add github types or drop repos` when no GitHub type is in `types`.",
+                    "description": "Repository slugs to scope the repository half of the index to. Applies to the `issue`, `pull_request`, and `readme` types only. Sent together with `sources`, the two halves are combined rather than intersected. Returns 400 when no repository type is in `types`, reporting that `repos` cannot match any requested type and that you should add repository types or drop `repos`.",
                     "items": {
                       "type": "string"
                     }
@@ -5346,36 +5346,36 @@
                   },
                   "language": {
                     "type": "string",
-                    "description": "Repository primary language, such as `Rust`. Applies to GitHub results only; sending it with no `sources` scope returns no `doc` results. See [how the repository filters scope a search](/api-reference/endpoint/developer-search#how-the-repository-filters-scope-a-search).",
+                    "description": "Repository primary language, such as `Rust`. Applies to repository results only; sending it with no `sources` scope returns no `doc` results. See [how the repository filters scope a search](/api-reference/endpoint/developer-search#how-the-repository-filters-scope-a-search).",
                     "example": "Rust"
                   },
                   "topic": {
                     "type": "string",
-                    "description": "Repository topic, such as `async`. Applies to GitHub results only; sending it with no `sources` scope returns no `doc` results.",
+                    "description": "Repository topic, such as `async`. Applies to repository results only; sending it with no `sources` scope returns no `doc` results.",
                     "example": "async"
                   },
                   "license": {
                     "type": "string",
-                    "description": "Repository license, such as `MIT`. Applies to GitHub results only; sending it with no `sources` scope returns no `doc` results.",
+                    "description": "Repository license, such as `MIT`. Applies to repository results only; sending it with no `sources` scope returns no `doc` results.",
                     "example": "MIT"
                   },
                   "min_stars": {
                     "type": "integer",
                     "minimum": 0,
-                    "description": "Lower bound on repository stars. Applies to GitHub results only; sending it with no `sources` scope returns no `doc` results."
+                    "description": "Lower bound on repository stars. Applies to repository results only; sending it with no `sources` scope returns no `doc` results."
                   },
                   "max_stars": {
                     "type": "integer",
                     "minimum": 0,
-                    "description": "Upper bound on repository stars. Applies to GitHub results only; sending it with no `sources` scope returns no `doc` results."
+                    "description": "Upper bound on repository stars. Applies to repository results only; sending it with no `sources` scope returns no `doc` results."
                   },
                   "archived": {
                     "type": "boolean",
-                    "description": "Include or exclude archived repositories. Applies to GitHub results only; sending it with no `sources` scope returns no `doc` results."
+                    "description": "Include or exclude archived repositories. Applies to repository results only; sending it with no `sources` scope returns no `doc` results."
                   },
                   "fork": {
                     "type": "boolean",
-                    "description": "Include or exclude forks. Applies to GitHub results only; sending it with no `sources` scope returns no `doc` results."
+                    "description": "Include or exclude forks. Applies to repository results only; sending it with no `sources` scope returns no `doc` results."
                   }
                 }
               },
@@ -9640,7 +9640,7 @@
                 },
                 "types": {
                   "type": "object",
-                  "description": "Which GitHub result types are indexed for this repository.",
+                  "description": "Which result types are indexed for this repository: `issue`, `pullRequest`, and `readme`.",
                   "properties": {
                     "issue": {
                       "type": "boolean"

--- a/features/developer.mdx
+++ b/features/developer.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Developer Index"
-description: "Search GitHub issues, merged pull requests, repository READMEs, and curated documentation sites"
+description: "Search issues, merged pull requests, repository READMEs, and curated documentation sites"
 og:title: "Developer Index | Firecrawl"
-og:description: "Use Firecrawl's developer index to answer coding questions from GitHub issues, merged pull requests, READMEs, and documentation."
+og:description: "Use Firecrawl's developer index to answer coding questions from issues, merged pull requests, READMEs, and documentation."
 icon: "code"
 ---
 
-Firecrawl Developer is an index built for coding agents. It covers GitHub issues, merged pull requests, repository READMEs, and curated documentation sites, so an agent can answer a question about code behavior, a library or framework, an API contract, an error message, or a known bug from primary sources rather than from a general web page.
+Firecrawl Developer is an index built for coding agents. It covers issues, merged pull requests, and READMEs from public code repositories, alongside curated documentation sites, so an agent can answer a question about code behavior, a library or framework, an API contract, an error message, or a known bug from primary sources rather than from a general web page.
 
 - Find the issue or pull request where a bug was reported and fixed
 - Read the passages of a README or a documentation page that answer one specific question
@@ -67,11 +67,11 @@ Optional filters narrow the search:
 
 - `k` sets how many results come back, defaulting to 10, and `passages` how many matched passages each one carries
 - `types` picks which of `doc`, `issue`, `pull_request`, and `readme` to search
-- `repos` scopes the GitHub half of the index, and `sources` scopes the documentation half
+- `repos` scopes the repository half of the index, and `sources` scopes the documentation half
 - `skills` set to `only` limits the search to indexed agent-skill files
 - `language`, `topic`, `license`, `min_stars`, `max_stars`, `archived`, and `fork` filter on repository attributes, such as `language=Rust`, `topic=async`, or `license=MIT`
 
-Those seven repository filters describe a GitHub repository, so sending one without a `sources` scope returns no `doc` results and reports `doc` as `unavailable` in `coverage`. Read [how the repository filters scope a search](/api-reference/endpoint/developer-search#how-the-repository-filters-scope-a-search) before you send one.
+Those seven filters describe a code repository, so sending one without a `sources` scope returns no `doc` results and reports `doc` as `unavailable` in `coverage`. Read [how the repository filters scope a search](/api-reference/endpoint/developer-search#how-the-repository-filters-scope-a-search) before you send one.
 
 See the [developer search reference](/api-reference/endpoint/developer-search) for every filter's type and bounds, how `repos` and `sources` scope a search, and the full response schema.
 

--- a/features/research.mdx
+++ b/features/research.mdx
@@ -225,4 +225,4 @@ Modes:
 
 ## Search GitHub history
 
-GitHub issues, merged pull requests, and repository READMEs now live in the [Developer Index](/features/developer), which ranks them with the matched passages and adds curated documentation sources alongside them. Use [`GET` or `POST /search/developer`](/api-reference/endpoint/developer-search), or `/search` with `categories: ["developer"]`.
+Issues, merged pull requests, and repository READMEs now live in the [Developer Index](/features/developer), which ranks them with the matched passages and adds curated documentation sources alongside them. Use [`GET` or `POST /search/developer`](/api-reference/endpoint/developer-search), or `/search` with `categories: ["developer"]`.

--- a/features/search.mdx
+++ b/features/search.mdx
@@ -104,7 +104,7 @@ Filter search results by specific categories using the `categories` parameter:
 - `github`: Search within GitHub repositories, code, issues, and documentation
 - `research`: Search academic and research websites (arXiv, Nature, IEEE, PubMed, etc.)
 - `pdf`: Search for PDFs
-- `developer`: Search the [Developer Index](/features/developer) — GitHub issues, merged pull requests, repository READMEs, and curated documentation sites
+- `developer`: Search the [Developer Index](/features/developer) — issues, merged pull requests, and READMEs from public code repositories, alongside curated documentation sites
 
 ### GitHub Category Search
 

--- a/mcp-server/tools.mdx
+++ b/mcp-server/tools.mdx
@@ -432,11 +432,11 @@ Use the read-only research tools for literature review, paper inspection, and ci
 | `firecrawl_research_related_papers` | Find papers related to an anchor paper |
 | `firecrawl_research_read_paper` | Read available paper content |
 
-These tools are not part of the hosted keyless surface. For GitHub issues, merged pull requests, and READMEs, use [`firecrawl_developer_search`](#12b-developer-search-tool-firecrawl_developer_search).
+These tools are not part of the hosted keyless surface. For repository issues, merged pull requests, and READMEs, use [`firecrawl_developer_search`](#12b-developer-search-tool-firecrawl_developer_search).
 
 ### 12b. Developer Search Tool (`firecrawl_developer_search`)
 
-Search the [Developer Index](/features/developer) on its own: GitHub issues, merged pull requests, repository READMEs, and curated documentation sites. Read-only, and returns ranked results with the matched passages.
+Search the [Developer Index](/features/developer) on its own: issues, merged pull requests, and READMEs from public code repositories, alongside curated documentation sites. Read-only, and returns ranked results with the matched passages.
 
 ```json
 {

--- a/sdks/cli.mdx
+++ b/sdks/cli.mdx
@@ -178,6 +178,26 @@ Search the web and optionally scrape the results.
 
 ---
 
+### Developer
+
+Search the [Developer Index](/features/developer) — issues, merged pull requests, and READMEs from public code repositories, alongside curated documentation sites.
+
+```bash CLI
+firecrawl developer "how do I configure retries" --limit 10
+```
+
+**Available Options:**
+
+| Option              | Description                                    |
+| -------------------- | ----------------------------------------------- |
+| `--limit <number>`  | Number of results to return (default: 10, max: 100) |
+| `--skills-only`     | Search only indexed agent-skill files (default: false) |
+| `--json`            | Output as compact JSON                          |
+| `--output <path>`   | Save output to file                             |
+| `--pretty`          | Pretty print JSON output                        |
+
+---
+
 ### Map
 
 Discover all URLs on a website quickly.


### PR DESCRIPTION
## Summary

Two small follow-ups to the Developer Index docs.

## 1. Wording

The Developer Index pages no longer name the source host in prose. They describe what the index holds — issues, merged pull requests, repository READMEs, and curated documentation sources — and refer to the repository half and the documentation half where the distinction matters.

Applies to the feature page (including its frontmatter description fields), the endpoint reference, the `/search/developer` descriptions in the spec, the developer category section on the search page, the tool section on the MCP tools page, and the pointer body on the research page.

Unchanged, deliberately:

- Code identifiers and literal values — the `categories` enum value, result `type` values, every filter name, and the `owner/name` format. These are the API contract.
- URLs, including the skill link in the feature page's note.
- The retained section heading on the research page, whose anchor catches old inbound links.
- Pages outside the Developer Index, which are a separate decision.

This was reviewed as part of the page restructure but did not make it in, because that PR was squash-merged at an earlier commit. The two commits are cherry-picked here unchanged.

## 2. CLI reference

The CLI page documented the `--categories` option but never the `developer` command itself, so a reader of that page alone could not discover it. Adds a section matching the page's existing command entries, with the flags confirmed against the published package.

## Verification

- No occurrence of the host name in prose across the touched files; the only match is the skill link URL
- The spec parses, path count unchanged at 41, and the endpoint keeps both methods and its tag
- The documented CLI invocation was run against the live API and returned results
- All six touched pages render locally
- No localized file modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-docs/pr/1215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788476188&installation_model_id=11126&pr_number=1215&repository=firecrawl%2Ffirecrawl-docs&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-docs%2Fpull%2F1215&signature=4effa74c46cf2b6df7b2ecb9a303959c733a70d00dd4dfab7161e5f860095910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->