### PR TITLE
docs(mcp): fix the free-limit recovery command

### DIFF
--- a/mcp-server/connect.mdx
+++ b/mcp-server/connect.mdx
@@ -47,13 +47,13 @@ The keyless allowance is a rolling, per-network limit. The MCP error includes th
 
 To continue immediately, choose one of these paths:
 
-- **Interactive OAuth:** connect the account endpoint, `https://mcp.firecrawl.dev/v2/mcp-oauth`. For Claude Code:
+- **Interactive OAuth:** connect the account endpoint, `https://mcp.firecrawl.dev/v2/mcp-oauth`, under a server name you are not already using. Keyless runs on `/v2/mcp`, so reusing that entry's name fails instead of repointing it. For Claude Code:
 
   ```bash
-  claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/v2/mcp-oauth
+  claude mcp add --transport http firecrawl-account https://mcp.firecrawl.dev/v2/mcp-oauth
   ```
 
-  Then run `/mcp` and authenticate in the browser.
+  Then run `/mcp` and authenticate in the browser. Both entries stay configured and their tools both appear; remove the keyless one with `claude mcp remove firecrawl` once the account is connected.
 - **Unattended API key:** create a key in the [Firecrawl dashboard](https://www.firecrawl.dev/app/api-keys) and configure `Authorization: Bearer <FIRECRAWL_API_KEY>`.
 
 ## Pick the right mode


### PR DESCRIPTION
## Why

`mcp-server/connect.mdx` tells a reader who hit the keyless free limit to run:

```bash
claude mcp add --transport http firecrawl https://mcp.firecrawl.dev/v2/mcp-oauth
```

That cannot work in the situation it is written for. Reaching the keyless limit means you already have a server named `firecrawl` pointed at `/v2/mcp` — the "Try keyless" section on the same page is what told you to add it. Claude Code refuses to overwrite it:

```
$ claude mcp add --scope project --transport http firecrawl https://mcp.firecrawl.dev/v2/mcp
Added HTTP MCP server firecrawl with URL: https://mcp.firecrawl.dev/v2/mcp to project config

$ claude mcp add --scope project --transport http firecrawl https://mcp.firecrawl.dev/v2/mcp-oauth
MCP server firecrawl already exists in .mcp.json
```

Exit code 1, config unchanged, still pointed at the keyless endpoint. Anyone following the doc gets no error surfaced by their agent, retries, and is still keyless.

## Summary

Use a distinct server name for the account entry, which succeeds:

```
$ claude mcp add --scope project --transport http firecrawl-account https://mcp.firecrawl.dev/v2/mcp-oauth
Added HTTP MCP server firecrawl-account with URL: https://mcp.firecrawl.dev/v2/mcp-oauth to project config
```

Also says why the name has to differ, and what to do about the keyless entry afterward. Both entries stay configured and both tool sets appear in the client, so the doc now points at `claude mcp remove firecrawl` rather than leaving readers with a silently duplicated tool surface.

Routing is unchanged. Interactive OAuth still goes to `/v2/mcp-oauth`, and the unattended API-key path still attaches to the existing `/v2/mcp` entry.

## Test Plan

- Reproduced the failure and verified the fix with real `claude mcp add` invocations against `--scope project` in a throwaway directory; transcripts above are verbatim.
- Prose-only change to one MDX file. No frontmatter, headings, anchors, or nav entries touched, so no cross-links break.
- Not translated. The `ja`, `es`, `fr`, `pt-BR`, and `zh` trees do not carry `mcp-server/connect.mdx` yet.

## Related

Companion to firecrawl/firecrawl-mcp-server#354, which removes this command from the MCP recovery payload. That PR and this one are independent; the command is wrong in the docs whether or not the payload emits it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-docs/pr/1218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788568595&installation_model_id=11126&pr_number=1218&repository=firecrawl%2Ffirecrawl-docs&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-docs%2Fpull%2F1218&signature=92ad4eca400323368ef15f372f6f0c91f1eceb99957e3d0e776682ce1f2215fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->