### PR TITLE
docs(search): document safe param on v2 /search

### DIFF
--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -3575,6 +3575,10 @@
                     "description": "ISO country code for geo-targeting search results (e.g. `US`). For best results, set both this and the `location` parameter.",
                     "default": "US"
                   },
+                  "safe": {
+                    "type": "boolean",
+                    "description": "When `true`, filters explicit content from search results (SafeSearch). Omit to keep the default behavior, which does not apply the filter."
+                  },
                   "timeout": {
                     "type": "integer",
                     "description": "Timeout in milliseconds",

--- a/features/search.mdx
+++ b/features/search.mdx
@@ -516,6 +516,20 @@ curl -X POST https://api.firecrawl.dev/v2/search \
 
 </CodeGroup>
 
+### Safe Search
+
+Set `safe` to `true` to filter explicit content from your search results (SafeSearch). When omitted, results are returned unfiltered, exactly as before.
+
+```bash cURL
+curl -X POST https://api.firecrawl.dev/v2/search \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
+  -d '{
+    "query": "firecrawl",
+    "safe": true
+  }'
+```
+
 ## Zero Data Retention (ZDR)
 
 For teams with strict data handling requirements, Firecrawl offers Zero Data Retention (ZDR) options for the `/search` endpoint via the `enterprise` parameter. ZDR search is available on Enterprise plans — visit [firecrawl.dev/enterprise](https://www.firecrawl.dev/enterprise) to get started.


### PR DESCRIPTION
## Summary
- Documents the new optional `safe: boolean` on the v2 `/search` endpoint (see firecrawl/firecrawl#4251)
- Adds the parameter to the OpenAPI spec (powers the auto-generated Search API Reference page)
- Adds a Safe Search subsection under Advanced Search Options in the Search feature page

## Test plan
- [x] Validated `api-reference/v2-openapi.json` is well-formed JSON
- [ ] Confirm the Search API Reference page renders the new `safe` field correctly
- [ ] Confirm the new Safe Search section renders correctly in the Search feature page

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-docs/pr/1222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788638958&installation_model_id=11126&pr_number=1222&repository=firecrawl%2Ffirecrawl-docs&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-docs%2Fpull%2F1222&signature=7946590bde39ab642165f6bf25e601a4480d0d1e29eb7171279964ca8ad80857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->