### PR TITLE
Add government and legal sources feedback bounty to search and monitoring docs

### DIFF
--- a/features/monitoring.mdx
+++ b/features/monitoring.mdx
@@ -26,10 +26,13 @@ import CheckOutputMixed from "/snippets/v2/monitor/check/output/mixed.mdx";
 import DiffMarkdown from "/snippets/v2/monitor/diff/markdown.mdx";
 import DiffJson from "/snippets/v2/monitor/diff/json.mdx";
 import DiffMixed from "/snippets/v2/monitor/diff/mixed.mdx";
+import GovLegalFeedbackCTA from "/snippets/gov-legal-feedback-cta.mdx";
 
 Firecrawl monitoring runs recurring checks and notifies you or your agent when something changes or appears. Use `/monitor` to [watch known pages](/features/monitoring-page), [crawl a website on a schedule](/features/monitoring-website), or [run an always-on web search](/features/monitoring-web-scale) for new results that match a goal.
 
 All monitor types share the same workflow: choose one or more targets, set a schedule, add an optional plain-language goal, and receive webhook, email, or Slack notifications when something matters. This page covers shared configuration. For target-specific setup and examples, go to the [Page](/features/monitoring-page), [Website](/features/monitoring-website), or [Entire web-scale](/features/monitoring-web-scale) monitoring page.
+
+<GovLegalFeedbackCTA src="docs-monitoring" />
 
 <CardGroup cols={3}>
   <Card title="Page monitoring" icon="file-lines" href="/features/monitoring-page">

--- a/features/search.mdx
+++ b/features/search.mdx
@@ -37,8 +37,6 @@ For the full parameter list, see the [Search Endpoint API Reference](https://doc
 
 <PlaygroundCTA />
 
-<GovLegalFeedbackCTA src="docs-search" />
-
 ## Performing a Search with Firecrawl
 
 ### /search endpoint
@@ -52,6 +50,8 @@ Used to perform web searches and optionally retrieve content from the results.
   <InstallationNode />
   <InstallationCLI />
 </CodeGroup>
+
+<GovLegalFeedbackCTA src="docs-search" />
 
 ### Basic Usage
 

--- a/features/search.mdx
+++ b/features/search.mdx
@@ -27,6 +27,7 @@ import SearchTimeCURL from "/snippets/v2/search/time/curl.mdx";
 import SearchTimeCLI from "/snippets/v2/search/time/cli.mdx";
 import SearchResponse from "/snippets/v2/search/base/output.mdx";
 import PlaygroundCTA from "/snippets/shared/playground-cta-search.mdx";
+import GovLegalFeedbackCTA from "/snippets/gov-legal-feedback-cta.mdx";
 
 Search the web and get clean, structured content from every result in a single API call. Pass a query to `/search` and Firecrawl returns titles, descriptions, and URLs. Add `scrapeOptions` to also retrieve full-page markdown, HTML, links, or screenshots for each result.
 
@@ -35,6 +36,8 @@ Search results include query-relevant [Highlights](/features/search-highlights) 
 For the full parameter list, see the [Search Endpoint API Reference](https://docs.firecrawl.dev/api-reference/endpoint/search).
 
 <PlaygroundCTA />
+
+<GovLegalFeedbackCTA src="docs-search" />
 
 ## Performing a Search with Firecrawl
 

--- a/snippets/gov-legal-feedback-cta.mdx
+++ b/snippets/gov-legal-feedback-cta.mdx
@@ -1,0 +1,24 @@
+<div className="firecrawl-cta-box">
+  <div style={{ display: "flex", alignItems: "flex-start", gap: "8px", marginBottom: "8px" }}>
+    <Icon icon="sack-dollar" color="#ff4d00" size={22} />
+    <div className="firecrawl-cta-title" style={{ margin: 0 }}>
+      <span style={{ color: "#ff4d00" }}>Bounty: 5,000 credit reward</span>
+      <span style={{ fontWeight: 400 }}> for feedback on government and legal sources</span>
+    </div>
+  </div>
+  <p className="firecrawl-cta-description">
+    To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with our Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human/agent-friendly (just paste the link into your agentic harness!). Most useful if you search or scrape government, court, regulatory, or public-record sites and have hit their quirks firsthand.
+  </p>
+  <a
+    href={"https://www.firecrawl.dev/survey/u90t8?src=" + (props.src || "docs-gov-legal")}
+    className="firecrawl-cta-btn-primary firecrawl-cta-btn-inline"
+  >
+    Start the interview
+  </a>
+  <p
+    className="firecrawl-cta-description"
+    style={{ fontSize: "12px", fontStyle: "italic", margin: "12px 0 0 0" }}
+  >
+    Include your email to be eligible. Interviews are reviewed for quality at the end of each week.
+  </p>
+</div>


### PR DESCRIPTION
Adds the interview bounty CTA for survey `u90t8` to two pages:

- `features/search.mdx` with `src="docs-search"`
- `features/monitoring.mdx` with `src="docs-monitoring"`

Both render the shared snippet `snippets/gov-legal-feedback-cta.mdx`, so when the study closes, one edit expires it everywhere.

## What the study is for

Whether government, legal and regulatory sources justify a dedicated vertical index, and if so which sources to start with. It asks only about current behaviour: what people use today, what breaks, and what they have already built, bought, or abandoned. It never describes or promises an unshipped capability.

## Copy changes from the precedent

Structurally identical to `snippets/interact-feedback-cta.mdx`. Three lines differ:

1. **Title tail** is "for feedback on government and legal sources" rather than "for solid feedback on /X", because this study has no endpoint to name.
2. **Qualify sentence** targets rather than broadens. The interact CTA closes with "Never used /interact? Your take still counts"; this one closes with "Most useful if you search or scrape government, court, regulatory, or public-record sites and have hit their quirks firsthand", because a respondent with no such need produces a low-signal transcript.
3. **Survey slug** `u90t8`.

Fixed elements are untouched: `sack-dollar` icon, `#ff4d00` accent, two-span title, button text, italic footer.

## Placement

Above the first `##` on both pages. On search it sits below the existing `<PlaygroundCTA />` so the product CTA still leads. On monitoring it sits between the intro and the `CardGroup`.

Monitoring carries it because regulatory tracking is monitor-shaped work, so those readers are likelier than average to have the need being sized.

## Notes

- No localized copies touched; those import their own snippets and sync via locadex.
- Survey `u90t8` is published and live.
- On close this flips to the dimmed expired card before removal, so link-followers are not left mid-promise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-docs/pr/1223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788670672&installation_model_id=11126&pr_number=1223&repository=firecrawl%2Ffirecrawl-docs&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-docs%2Fpull%2F1223&signature=64d3a73eb226b1a5bdc1691bd9ad4b478ef77f58f0c60d39670aec423e51e800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->