### PR TITLE
docs(mcp): remove deprecated extract tool from docs

### DIFF
--- a/developer-guides/llm-sdks-and-frameworks/google-adk.mdx
+++ b/developer-guides/llm-sdks-and-frameworks/google-adk.mdx
@@ -91,7 +91,6 @@ root_agent = Agent(
 | Search Tool | `firecrawl_search` | Search the web and optionally extract content from search results |
 | Crawl Tool | `firecrawl_crawl` | Start an asynchronous crawl with advanced options |
 | Check Crawl Status | `firecrawl_check_crawl_status` | Check the status of a crawl job |
-| Extract Tool | `firecrawl_extract` | Extract structured information from web pages using LLM capabilities |
 
 ## Configuration
 

--- a/mcp-server/tools.mdx
+++ b/mcp-server/tools.mdx
@@ -27,7 +27,6 @@ Start with [Firecrawl MCP setup](/mcp-server) to choose OAuth, API-key, or keyle
 | Search the web | `firecrawl_search` | You have a query rather than a known URL. |
 | Parse a file | `firecrawl_parse` | You need content from a PDF, document, spreadsheet, or HTML file. |
 | Extract many pages | `firecrawl_crawl` and `firecrawl_check_crawl_status` | You need to traverse a site or section. The crawl tool polls the job to a terminal state before returning. |
-| Extract structured data | `firecrawl_extract` | You have URLs and want data matching a prompt or JSON schema. |
 | Run autonomous research | `firecrawl_agent` and `firecrawl_agent_status` | The task spans multiple sources and the exact pages are not known. |
 | Operate a live page | `firecrawl_interact` and `firecrawl_interact_stop` | You need clicks, form fills, navigation, or dynamic-page extraction. |
 | Research papers and repositories | `firecrawl_research_*` | You need paper discovery, paper reading, related work, or public repository search. |

--- a/quickstarts/codex-cli.mdx
+++ b/quickstarts/codex-cli.mdx
@@ -39,7 +39,7 @@ Codex discovers the Firecrawl tools on launch. Confirm they are loaded:
 /mcp
 ```
 
-You should see `firecrawl` listed with tools like `firecrawl_search`, `firecrawl_scrape`, `firecrawl_crawl`, and `firecrawl_extract`.
+You should see `firecrawl` listed with tools like `firecrawl_search`, `firecrawl_scrape`, `firecrawl_crawl`, and `firecrawl_agent`.
 
 ## Quick Demo
 


### PR DESCRIPTION
## Why
`firecrawl_extract` is no longer part of the MCP tool surface. Docs that still list it steer users to a tool that is not available.

## Summary
- Remove `firecrawl_extract` from the MCP tools chooser
- Update Codex CLI and Google ADK MCP tool lists to match
- Leave localized copies to Mintlify

## Test Plan
- [ ] Confirm https://docs.firecrawl.dev/mcp-server/tools no longer lists `firecrawl_extract`
- [ ] Confirm scrape still covers structured fields on that page
- [ ] Spot-check Codex CLI and Google ADK pages for the updated tool lists

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/firecrawl/codesmith/firecrawl-docs/pr/1231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788730308&installation_model_id=11126&pr_number=1231&repository=firecrawl%2Ffirecrawl-docs&return_to=https%3A%2F%2Fgithub.com%2Ffirecrawl%2Ffirecrawl-docs%2Fpull%2F1231&signature=bc6cfee9282883fc64e5ceda6a36680b91c3943d274dd624a040b027565b1c84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->