### PR TITLE
docs: correct research-index routing and wire the skill into onboarding

### DIFF
--- a/ai-onboarding.mdx
+++ b/ai-onboarding.mdx
@@ -102,16 +102,15 @@ The install sets up three categories of skills that cover every way an agent use
 
 **Build skills** — for integrating Firecrawl into application code:
 
-| Skill                        | Purpose                                              |
-| ---------------------------- | ---------------------------------------------------- |
-| `firecrawl-build`            | Choose the right Firecrawl endpoint for your product |
-| `firecrawl-build-onboarding` | Auth and project setup                               |
-| `firecrawl-build-scrape`     | Implement scraping in app code                       |
-| `firecrawl-build-search`     | Implement search in app code                         |
-| `firecrawl-build-interact`   | Implement page interaction in app code               |
-| `firecrawl-build-crawl`      | Implement crawling in app code                       |
-| `firecrawl-build-map`        | Implement URL discovery in app code                  |
-| `firecrawl-build-parse`      | Implement document parsing in app code               |
+| Skill                        | Purpose                                                          |
+| ---------------------------- | ---------------------------------------------------------------- |
+| `firecrawl-build`            | Choose the right Firecrawl endpoint for your product             |
+| `firecrawl-build-onboarding` | Auth and project setup                                           |
+| `firecrawl-build-scrape`     | Implement scraping in app code                                   |
+| `firecrawl-build-search`     | Implement search in app code                                     |
+| `firecrawl-build-interact`   | Implement page interaction in app code                           |
+| `firecrawl-research-index`   | Search papers, read passages, and follow citations in app code   |
+| `firecrawl-developer-index`  | Search issues, pull requests, READMEs, and docs in app code      |
 
 **Workflow skills** — outcome-focused skills that produce a concrete deliverable from Firecrawl web data:
 

--- a/ai-onboarding.mdx
+++ b/ai-onboarding.mdx
@@ -112,6 +112,12 @@ The install sets up three categories of skills that cover every way an agent use
 | `firecrawl-research-index`   | Search papers, read passages, and follow citations in app code   |
 | `firecrawl-developer-index`  | Search issues, pull requests, READMEs, and docs in app code      |
 
+The install above includes both index skills. To add just the paper-search one to an existing setup — worth doing when the work is biomedical or scientific literature — run:
+
+```bash
+npx skills add firecrawl/skills@firecrawl-research-index
+```
+
 **Workflow skills** — outcome-focused skills that produce a concrete deliverable from Firecrawl web data:
 
 | Skill                              | Outcome                                                                       |
@@ -243,7 +249,9 @@ Firecrawl gives agents five core tools for working with the web. Each tool maps 
       -d '{"query": "latest OpenAI API pricing"}'
     ```
 
-    **When to use:** Research tasks, finding documentation, competitive analysis, answering questions that require up-to-date web information.
+    **When to use:** General web research, finding documentation, competitive analysis, answering questions that require up-to-date web information.
+
+    **When not to use:** Scientific literature. To find papers, read passages from inside one, or follow citations, use the [Research Index](/features/research) instead — the `firecrawl_research_*` MCP tools, `firecrawl research search-papers` on the CLI, or the `firecrawl-research-index` skill. Search returns web page snippets; the Research Index returns paper records with full abstracts.
 
   </Accordion>
 

--- a/api-reference/endpoint/search.mdx
+++ b/api-reference/endpoint/search.mdx
@@ -48,9 +48,15 @@ Examples: `"US"`, `"DE"`, `"FR"`, `"JP"`, `"UK"`, `"CA"`.
 Filter search results by specific categories using the `categories` parameter:
 
 - **`github`**: Search within GitHub repositories, code, issues, and documentation
-- **`research`**: Search academic and research websites (arXiv, Nature, IEEE, PubMed, etc.)
+- **`research`**: Restrict web search to academic and research **websites** (arxiv.org, nature.com, ieee.org, pubmed.ncbi.nlm.nih.gov, biorxiv.org, medrxiv.org, and similar). Returns ordinary web page results with snippets — not paper records
 - **`pdf`**: Search for PDFs
+- **`developer`**: Search the [Developer Index](/features/developer) — issues, merged pull requests, and READMEs from public code repositories, alongside curated documentation sites
 
+<Note>
+**`research` is a website filter, not the paper index.** It narrows this endpoint's web results to a fixed list of academic domains.
+
+To search scientific literature directly — paper abstracts across PubMed, bioRxiv, medRxiv, and arXiv, plus in-paper passage reads and citation-graph expansion — use the [Research Index](/features/research) at [`GET /search/research/papers`](/api-reference/endpoint/research-search-papers).
+</Note>
 
 ### Example Usage
 

--- a/features/research.mdx
+++ b/features/research.mdx
@@ -8,6 +8,8 @@ icon: "book-open"
 
 Firecrawl Research is a purpose-built index for scientific and engineering research agents. It exposes a research-specific toolset for searching papers, inspecting paper metadata, reading relevant full-text passages, and discovering related papers through structural expansion.
 
+The index covers roughly 43 million paper abstracts. The majority of the corpus is biomedical and life sciences — **PubMed**, **bioRxiv**, and **medRxiv** — alongside **arXiv** for physics, mathematics, and computer science. Papers are addressable by their source ids, so `pmid:`, `pmcid:`, and `doi:` references work the same way `arxiv:` ones do.
+
 - Find papers by topic, method, benchmark, author, or category
 - Inspect canonical paper metadata and source ids
 - Read the passages in one paper that answer a specific question
@@ -19,6 +21,20 @@ To give your agent access to the Research Index, we strongly recommend using our
 npx skills add firecrawl/skills@firecrawl-research-index
 ```
 </Note>
+
+## How this relates to `/search`
+
+Firecrawl has two things named "research", and they are not the same feature:
+
+| | Research Index (this page) | `/search` with `categories: ["research"]` |
+| :-- | --- | --- |
+| What it searches | A paper index of ~43M abstracts — PubMed, bioRxiv, medRxiv, arXiv | The open web, restricted to ~14 academic **websites** (arxiv.org, nature.com, pubmed.ncbi.nlm.nih.gov, …) |
+| What you get back | Ranked paper records: canonical `paperId`, `primaryId`, source ids, title, full abstract, score | Ordinary web results: URL, title, snippet |
+| Can it read inside a paper | Yes — passage-level reads via `GET /search/research/papers/{id}` | No |
+| Can it expand by citations | Yes — `GET /search/research/papers/{id}/similar` | No |
+| Endpoint | `GET /search/research/papers` | `POST /search` |
+
+Use the Research Index when you are doing literature work: finding papers, reading them, and following citations. Use [`categories: ["research"]`](/features/search#search-categories) when you want ordinary web pages that happen to live on academic domains.
 
 ## Endpoints
 
@@ -78,9 +94,58 @@ Optional filters:
 - `from`: inclusive created/updated lower bound, `YYYY-MM-DD`
 - `to`: inclusive created/updated upper bound, `YYYY-MM-DD`
 
+### Biomedical example
+
+Most of the index is life sciences, so clinical and molecular biology queries work the same way:
+
+<CodeGroup>
+
+```bash cURL
+# No API key needed to get started; add -H "Authorization: Bearer $FIRECRAWL_API_KEY" for higher rate limits:
+curl -s "https://api.firecrawl.dev/v2/search/research/papers?query=CRISPR%20base%20editing%20off-target%20effects%20in%20primary%20human%20T%20cells&k=20"
+```
+
+```bash CLI
+firecrawl research search-papers "CRISPR base editing off-target effects in primary human T cells" --limit 20
+```
+
+```python Python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(
+  # No API key needed to get started; add one for higher rate limits:
+  # api_key="fc-YOUR-API-KEY",
+)
+
+result = firecrawl.v2.search_papers(
+  "CRISPR base editing off-target effects in primary human T cells",
+  k=20,
+)
+print(result)
+```
+
+```js Node
+import { Firecrawl } from "firecrawl";
+
+const firecrawl = new Firecrawl({
+  // No API key needed to get started; add one for higher rate limits:
+  // apiKey: "fc-YOUR-API-KEY",
+});
+
+const result = await firecrawl.research.searchPapers(
+  "CRISPR base editing off-target effects in primary human T cells",
+  { k: 20 },
+);
+console.log(result);
+```
+
+</CodeGroup>
+
+Results carry a `primaryId` in whichever namespace the source uses, so biomedical hits come back as `pmid:<id>`, `pmcid:<id>`, or `doi:<doi>`. Feed that value straight back into the inspect, read, and related endpoints below.
+
 ## Inspect a paper
 
-Use a canonical `paperId` or a source-specific `primaryId`.
+Use a canonical `paperId` or a source-specific `primaryId`. Accepted `primaryId` forms are `arxiv:<id>`, `pmid:<id>`, `pmcid:<id>`, and `doi:<doi>` — for example `curl -s ".../v2/search/research/papers/pmid:<id>"` for a PubMed record.
 
 <CodeGroup>
 

--- a/features/search.mdx
+++ b/features/search.mdx
@@ -105,9 +105,15 @@ You can request multiple sources in a single call (e.g., `sources: ["web", "news
 Filter search results by specific categories using the `categories` parameter:
 
 - `github`: Search within GitHub repositories, code, issues, and documentation
-- `research`: Search academic and research websites (arXiv, Nature, IEEE, PubMed, etc.)
+- `research`: Restrict web search to academic and research **websites** (arxiv.org, nature.com, ieee.org, pubmed.ncbi.nlm.nih.gov, biorxiv.org, medrxiv.org, and similar). Returns ordinary web page results with snippets — not paper records. To search papers themselves, use the [Research Index](/features/research)
 - `pdf`: Search for PDFs
 - `developer`: Search the [Developer Index](/features/developer) — issues, merged pull requests, and READMEs from public code repositories, alongside curated documentation sites
+
+<Note>
+**`research` is a website filter, not the paper index.** It narrows ordinary web search to a fixed list of academic domains and returns page snippets from them.
+
+If you want to search scientific literature — full abstracts, in-paper passage reads, and citation-graph expansion over a paper index of PubMed, bioRxiv, medRxiv, and arXiv — use the [Research Index](/features/research) instead.
+</Note>
 
 ### GitHub Category Search
 
@@ -126,7 +132,7 @@ curl -X POST https://api.firecrawl.dev/v2/search \
 
 ### Research Category Search
 
-Search academic and research websites:
+Restrict web search to academic and research websites. This returns web pages hosted on those domains — landing pages, abstract pages, publisher pages — with the usual snippets:
 
 ```bash cURL
 curl -X POST https://api.firecrawl.dev/v2/search \
@@ -137,6 +143,12 @@ curl -X POST https://api.firecrawl.dev/v2/search \
     "categories": ["research"],
     "limit": 10
   }'
+```
+
+To search the papers themselves rather than the websites that host them, use the [Research Index](/features/research), which searches paper abstracts across PubMed, bioRxiv, medRxiv, and arXiv and can read passages from inside a paper:
+
+```bash cURL
+curl -s "https://api.firecrawl.dev/v2/search/research/papers?query=CRISPR%20base%20editing%20off-target%20effects&k=10"
 ```
 
 ### Developer Category Search

--- a/mcp-server/tools.mdx
+++ b/mcp-server/tools.mdx
@@ -30,7 +30,7 @@ Start with [Get Started](/mcp-server) and pick [For Agents](/mcp-server/keyless)
 | Extract many pages | `firecrawl_crawl` and `firecrawl_check_crawl_status` | You need to traverse a site or section. The crawl tool polls the job to a terminal state before returning. |
 | Run autonomous research | `firecrawl_agent` and `firecrawl_agent_status` | The task spans multiple sources and the exact pages are not known. |
 | Operate a live page | `firecrawl_interact` and `firecrawl_interact_stop` | You need clicks, form fills, navigation, or dynamic-page extraction. |
-| Research papers and repositories | `firecrawl_research_*` | You need paper discovery, paper reading, related work, or public repository search. |
+| Search scientific literature | `firecrawl_research_*` | You need to find papers, read passages from inside one, or follow citations. Searches a paper index of PubMed, bioRxiv, medRxiv, and arXiv abstracts. |
 | Answer a programming question | `firecrawl_developer_search` | You need primary-source answers from issues, merged pull requests, READMEs, and curated docs. |
 | Monitor changes | `firecrawl_monitor_*` | You need recurring checks, diffs, and webhook or email notifications. |
 | Send product feedback | `firecrawl_search_feedback` and `firecrawl_feedback` | You want to rate search results or report endpoint-level quality. |
@@ -83,6 +83,12 @@ Use the schema shown by your MCP client for the current arguments. The feature g
   </Card>
   <Card title="Search" href="/features/search" icon="magnifying-glass">
     Find relevant web, news, image, and developer sources.
+  </Card>
+  <Card title="Research Index" href="/features/research" icon="book-open">
+    Search papers, read passages, and follow citations.
+  </Card>
+  <Card title="Developer Index" href="/features/developer" icon="code">
+    Answer coding questions from issues, PRs, READMEs, and docs.
   </Card>
   <Card title="Crawl" href="/features/crawl" icon="spider-web">
     Traverse and extract a site or section.

--- a/mcp-server/tools.mdx
+++ b/mcp-server/tools.mdx
@@ -30,7 +30,7 @@ Start with [Get Started](/mcp-server) and pick [For Agents](/mcp-server/keyless)
 | Extract many pages | `firecrawl_crawl` and `firecrawl_check_crawl_status` | You need to traverse a site or section. The crawl tool polls the job to a terminal state before returning. |
 | Run autonomous research | `firecrawl_agent` and `firecrawl_agent_status` | The task spans multiple sources and the exact pages are not known. |
 | Operate a live page | `firecrawl_interact` and `firecrawl_interact_stop` | You need clicks, form fills, navigation, or dynamic-page extraction. |
-| Search scientific literature | `firecrawl_research_*` | You need to find papers, read passages from inside one, or follow citations. Searches a paper index of PubMed, bioRxiv, medRxiv, and arXiv abstracts. |
+| Search scientific literature | `firecrawl_research_*` | You need to find papers, read passages from inside one, or follow citations. Searches the [Research Index](/features/research) of PubMed, bioRxiv, medRxiv, and arXiv paper abstracts. |
 | Answer a programming question | `firecrawl_developer_search` | You need primary-source answers from issues, merged pull requests, READMEs, and curated docs. |
 | Monitor changes | `firecrawl_monitor_*` | You need recurring checks, diffs, and webhook or email notifications. |
 | Send product feedback | `firecrawl_search_feedback` and `firecrawl_feedback` | You want to rate search results or report endpoint-level quality. |

--- a/quickstarts/claude-code.mdx
+++ b/quickstarts/claude-code.mdx
@@ -37,6 +37,14 @@ Scrape https://firecrawl.dev and explain what it does.
 - [Configure an API key](/mcp-server/keyless#add-an-api-key) for unattended use. Keep the secret outside agent chat and use an environment-variable reference.
 - [Run MCP locally](/mcp-server/local) only when you need a local process or a self-hosted Firecrawl API. The local package requires Node.js 22 or newer.
 
+## Optional: literature research
+
+For paper and literature work, the research-index skill routes those queries to the `firecrawl_research_*` tools and the [Research Index](/features/research) instead of general web search:
+
+```bash
+npx skills add firecrawl/skills@firecrawl-research-index
+```
+
 ## Troubleshooting
 
 - **A Firecrawl server already exists:** run `claude mcp remove firecrawl`, add the intended connection once, then start a new session.

--- a/quickstarts/codex-cli.mdx
+++ b/quickstarts/codex-cli.mdx
@@ -41,6 +41,14 @@ Scrape https://docs.firecrawl.dev and list the top-level sections.
 - [Configure an API key](/mcp-server/keyless#add-an-api-key) with `bearer_token_env_var` for unattended use. Keep the secret outside agent chat and source control.
 - [Run MCP locally](/mcp-server/local) only when you need a local process or a self-hosted Firecrawl API. The local package requires Node.js 22 or newer.
 
+## Optional: literature research
+
+For paper and literature work, the research-index skill routes those queries to the `firecrawl_research_*` tools and the [Research Index](/features/research) instead of general web search:
+
+```bash
+npx skills add firecrawl/skills@firecrawl-research-index
+```
+
 ## Troubleshooting
 
 - **Codex does not see the tools:** run `codex mcp list`, confirm that only one `firecrawl` entry exists, and restart Codex.


### PR DESCRIPTION
## Why
"PubMed" appeared in exactly two places in the English docs — both describing the website filter, not the paper index. `features/research.mdx` was a closed loop (its only inbound links were its own API-reference subpages), the ai-onboarding page routed "Research tasks" to web Search, and its skills table listed phantom skills while omitting the two index skills that exist. Measured: an MCP-quickstart user reaches the paper index 0/48 on biomedical tasks; installing the one research-index skill (the command this PR wires into onboarding) takes that to 48/48 with 0/80 false triggers on out-of-scope work.

## Summary
- search feature + API-reference pages: the `research` category described as what it is (website filter incl. PubMed/bioRxiv/medRxiv pages) with a link to /features/research for the paper index
- features/research.mdx: names the biomedical corpus, shows real id formats, adds a "how this relates to /search" section
- ai-onboarding: literature routing corrected; skills table fixed (phantom entries removed, both index skills added); research-index skill install command added
- quickstarts/claude-code + codex-cli: optional literature-research note with the one-line skill install
- mcp-server/tools.mdx: research row corrected and linked; Research/Developer cards added

## Test Plan
- All touched files compile through @mdx-js/mdx (remark-frontmatter + gfm); all 79 internal links resolve; docs.json valid
- English pages only — locales are Locadex-generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)