### PR TITLE
docs(nav): stop noindexing 36 live pages via the hidden v1 nav

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -664,97 +664,11 @@
                   {
                     "group": "Get Started",
                     "pages": [
-                      "introduction",
-                      "mcp-server",
-                      "migrate-to-v2",
-                      "advanced-scraping-guide",
-                      {
-                        "group": "Plans and Billing",
-                        "pages": [
-                          "billing",
-                          "rate-limits",
-                          "partner-credits"
-                        ]
-                      },
-                      {
-                        "group": "Enterprise",
-                        "pages": [
-                          "enterprise",
-                          "features/ip-restrictions",
-                          "features/key-restrictions",
-                          "features/threat-protection",
-                          "features/siem"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Standard Features",
-                    "pages": [
-                      {
-                        "group": "Scrape",
-                        "icon": "markdown",
-                        "pages": [
-                          "features/scrape",
-                          "features/fast-scraping",
-                          "features/batch-scrape",
-                          "features/llm-extract",
-                          "features/change-tracking",
-                          "features/enhanced-mode",
-                          "features/proxies"
-                        ]
-                      },
-                      "features/crawl",
-                      "features/map",
-                      "features/search"
-                    ]
-                  },
-                  {
-                    "group": "Webhooks",
-                    "pages": [
-                      "webhooks/overview",
-                      "webhooks/events",
-                      "webhooks/security",
-                      "webhooks/testing"
-                    ]
-                  },
-                  {
-                    "group": "Dashboard",
-                    "pages": [
-                      "dashboard"
+                      "migrate-to-v2"
                     ]
                   }
                 ],
                 "tab": "Documentation"
-              },
-              {
-                "groups": [
-                  {
-                    "group": "Overall",
-                    "pages": [
-                      "sdks/overview"
-                    ]
-                  },
-                  {
-                    "group": "Official",
-                    "pages": [
-                      "sdks/python",
-                      "sdks/node",
-                      "sdks/go",
-                      "sdks/java",
-                      "sdks/ruby",
-                      "sdks/rust",
-                      "sdks/dotnet",
-                      "sdks/php",
-                      "sdks/elixir"
-                    ]
-                  },
-                  {
-                    "group": "Community",
-                    "pages": []
-                  }
-                ],
-                "tab": "SDKs"
               },
               {
                 "href": "https://www.firecrawl.dev/app",
@@ -1403,97 +1317,11 @@
                   {
                     "group": "Primeros pasos",
                     "pages": [
-                      "es/introduction",
-                      "es/mcp-server",
-                      "es/migrate-to-v2",
-                      "es/advanced-scraping-guide",
-                      {
-                        "group": "Planes y facturación",
-                        "pages": [
-                          "es/billing",
-                          "es/rate-limits",
-                          "es/partner-credits"
-                        ]
-                      },
-                      {
-                        "group": "Enterprise",
-                        "pages": [
-                          "es/enterprise",
-                          "es/features/ip-restrictions",
-                          "es/features/key-restrictions",
-                          "es/features/threat-protection",
-                          "es/features/siem"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Funciones de Standard",
-                    "pages": [
-                      {
-                        "group": "scraping",
-                        "icon": "markdown",
-                        "pages": [
-                          "es/features/scrape",
-                          "es/features/fast-scraping",
-                          "es/features/batch-scrape",
-                          "es/features/llm-extract",
-                          "es/features/change-tracking",
-                          "es/features/enhanced-mode",
-                          "es/features/proxies"
-                        ]
-                      },
-                      "es/features/crawl",
-                      "es/features/map",
-                      "es/features/search"
-                    ]
-                  },
-                  {
-                    "group": "Webhooks",
-                    "pages": [
-                      "es/webhooks/overview",
-                      "es/webhooks/events",
-                      "es/webhooks/security",
-                      "es/webhooks/testing"
-                    ]
-                  },
-                  {
-                    "group": "Dashboard",
-                    "pages": [
-                      "es/dashboard"
+                      "es/migrate-to-v2"
                     ]
                   }
                 ],
                 "tab": "Documentación"
-              },
-              {
-                "groups": [
-                  {
-                    "group": "General",
-                    "pages": [
-                      "es/sdks/overview"
-                    ]
-                  },
-                  {
-                    "group": "Oficial",
-                    "pages": [
-                      "es/sdks/python",
-                      "es/sdks/node",
-                      "es/sdks/go",
-                      "es/sdks/java",
-                      "es/sdks/ruby",
-                      "es/sdks/rust",
-                      "es/sdks/dotnet",
-                      "es/sdks/php",
-                      "es/sdks/elixir"
-                    ]
-                  },
-                  {
-                    "group": "Comunidad",
-                    "pages": []
-                  }
-                ],
-                "tab": "SDKs"
               },
               {
                 "href": "https://www.firecrawl.dev/app",
@@ -2142,97 +1970,11 @@
                   {
                     "group": "Démarrage rapide",
                     "pages": [
-                      "fr/introduction",
-                      "fr/mcp-server",
-                      "fr/migrate-to-v2",
-                      "fr/advanced-scraping-guide",
-                      {
-                        "group": "Offres et facturation",
-                        "pages": [
-                          "fr/billing",
-                          "fr/rate-limits",
-                          "fr/partner-credits"
-                        ]
-                      },
-                      {
-                        "group": "Entreprise",
-                        "pages": [
-                          "fr/enterprise",
-                          "fr/features/ip-restrictions",
-                          "fr/features/key-restrictions",
-                          "fr/features/threat-protection",
-                          "fr/features/siem"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Fonctionnalités Standard",
-                    "pages": [
-                      {
-                        "group": "Scrape",
-                        "icon": "markdown",
-                        "pages": [
-                          "fr/features/scrape",
-                          "fr/features/fast-scraping",
-                          "fr/features/batch-scrape",
-                          "fr/features/llm-extract",
-                          "fr/features/change-tracking",
-                          "fr/features/enhanced-mode",
-                          "fr/features/proxies"
-                        ]
-                      },
-                      "fr/features/crawl",
-                      "fr/features/map",
-                      "fr/features/search"
-                    ]
-                  },
-                  {
-                    "group": "Webhooks",
-                    "pages": [
-                      "fr/webhooks/overview",
-                      "fr/webhooks/events",
-                      "fr/webhooks/security",
-                      "fr/webhooks/testing"
-                    ]
-                  },
-                  {
-                    "group": "Tableau de bord",
-                    "pages": [
-                      "fr/dashboard"
+                      "fr/migrate-to-v2"
                     ]
                   }
                 ],
                 "tab": "Documentation"
-              },
-              {
-                "groups": [
-                  {
-                    "group": "Global",
-                    "pages": [
-                      "fr/sdks/overview"
-                    ]
-                  },
-                  {
-                    "group": "Officiel",
-                    "pages": [
-                      "fr/sdks/python",
-                      "fr/sdks/node",
-                      "fr/sdks/go",
-                      "fr/sdks/java",
-                      "fr/sdks/ruby",
-                      "fr/sdks/rust",
-                      "fr/sdks/dotnet",
-                      "fr/sdks/php",
-                      "fr/sdks/elixir"
-                    ]
-                  },
-                  {
-                    "group": "Communauté",
-                    "pages": []
-                  }
-                ],
-                "tab": "SDKs"
               },
               {
                 "href": "https://www.firecrawl.dev/app",
@@ -2881,97 +2623,11 @@
                   {
                     "group": "はじめに",
                     "pages": [
-                      "ja/introduction",
-                      "ja/mcp-server",
-                      "ja/migrate-to-v2",
-                      "ja/advanced-scraping-guide",
-                      {
-                        "group": "プランと課金",
-                        "pages": [
-                          "ja/billing",
-                          "ja/rate-limits",
-                          "ja/partner-credits"
-                        ]
-                      },
-                      {
-                        "group": "エンタープライズ",
-                        "pages": [
-                          "ja/enterprise",
-                          "ja/features/ip-restrictions",
-                          "ja/features/key-restrictions",
-                          "ja/features/threat-protection",
-                          "ja/features/siem"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Standardの機能",
-                    "pages": [
-                      {
-                        "group": "スクレイピング",
-                        "icon": "markdown",
-                        "pages": [
-                          "ja/features/scrape",
-                          "ja/features/fast-scraping",
-                          "ja/features/batch-scrape",
-                          "ja/features/llm-extract",
-                          "ja/features/change-tracking",
-                          "ja/features/enhanced-mode",
-                          "ja/features/proxies"
-                        ]
-                      },
-                      "ja/features/crawl",
-                      "ja/features/map",
-                      "ja/features/search"
-                    ]
-                  },
-                  {
-                    "group": "webhook",
-                    "pages": [
-                      "ja/webhooks/overview",
-                      "ja/webhooks/events",
-                      "ja/webhooks/security",
-                      "ja/webhooks/testing"
-                    ]
-                  },
-                  {
-                    "group": "ダッシュボード",
-                    "pages": [
-                      "ja/dashboard"
+                      "ja/migrate-to-v2"
                     ]
                   }
                 ],
                 "tab": "ドキュメント"
-              },
-              {
-                "groups": [
-                  {
-                    "group": "概要",
-                    "pages": [
-                      "ja/sdks/overview"
-                    ]
-                  },
-                  {
-                    "group": "公式",
-                    "pages": [
-                      "ja/sdks/python",
-                      "ja/sdks/node",
-                      "ja/sdks/go",
-                      "ja/sdks/java",
-                      "ja/sdks/ruby",
-                      "ja/sdks/rust",
-                      "ja/sdks/dotnet",
-                      "ja/sdks/php",
-                      "ja/sdks/elixir"
-                    ]
-                  },
-                  {
-                    "group": "コミュニティ",
-                    "pages": []
-                  }
-                ],
-                "tab": "SDK"
               },
               {
                 "href": "https://www.firecrawl.dev/app",
@@ -3620,97 +3276,11 @@
                   {
                     "group": "Primeiros passos",
                     "pages": [
-                      "pt-BR/introduction",
-                      "pt-BR/mcp-server",
-                      "pt-BR/migrate-to-v2",
-                      "pt-BR/advanced-scraping-guide",
-                      {
-                        "group": "Planos e cobrança",
-                        "pages": [
-                          "pt-BR/billing",
-                          "pt-BR/rate-limits",
-                          "pt-BR/partner-credits"
-                        ]
-                      },
-                      {
-                        "group": "Enterprise",
-                        "pages": [
-                          "pt-BR/enterprise",
-                          "pt-BR/features/ip-restrictions",
-                          "pt-BR/features/key-restrictions",
-                          "pt-BR/features/threat-protection",
-                          "pt-BR/features/siem"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Recursos do Standard",
-                    "pages": [
-                      {
-                        "group": "Scrape",
-                        "icon": "markdown",
-                        "pages": [
-                          "pt-BR/features/scrape",
-                          "pt-BR/features/fast-scraping",
-                          "pt-BR/features/batch-scrape",
-                          "pt-BR/features/llm-extract",
-                          "pt-BR/features/change-tracking",
-                          "pt-BR/features/enhanced-mode",
-                          "pt-BR/features/proxies"
-                        ]
-                      },
-                      "pt-BR/features/crawl",
-                      "pt-BR/features/map",
-                      "pt-BR/features/search"
-                    ]
-                  },
-                  {
-                    "group": "Webhooks",
-                    "pages": [
-                      "pt-BR/webhooks/overview",
-                      "pt-BR/webhooks/events",
-                      "pt-BR/webhooks/security",
-                      "pt-BR/webhooks/testing"
-                    ]
-                  },
-                  {
-                    "group": "Painel",
-                    "pages": [
-                      "pt-BR/dashboard"
+                      "pt-BR/migrate-to-v2"
                     ]
                   }
                 ],
                 "tab": "Documentação"
-              },
-              {
-                "groups": [
-                  {
-                    "group": "Geral",
-                    "pages": [
-                      "pt-BR/sdks/overview"
-                    ]
-                  },
-                  {
-                    "group": "Oficial",
-                    "pages": [
-                      "pt-BR/sdks/python",
-                      "pt-BR/sdks/node",
-                      "pt-BR/sdks/go",
-                      "pt-BR/sdks/java",
-                      "pt-BR/sdks/ruby",
-                      "pt-BR/sdks/rust",
-                      "pt-BR/sdks/dotnet",
-                      "pt-BR/sdks/php",
-                      "pt-BR/sdks/elixir"
-                    ]
-                  },
-                  {
-                    "group": "Comunidade",
-                    "pages": []
-                  }
-                ],
-                "tab": "SDKs"
               },
               {
                 "href": "https://www.firecrawl.dev/app",
@@ -4359,97 +3929,11 @@
                   {
                     "group": "快速开始",
                     "pages": [
-                      "zh/introduction",
-                      "zh/mcp-server",
-                      "zh/migrate-to-v2",
-                      "zh/advanced-scraping-guide",
-                      {
-                        "group": "套餐与计费",
-                        "pages": [
-                          "zh/billing",
-                          "zh/rate-limits",
-                          "zh/partner-credits"
-                        ]
-                      },
-                      {
-                        "group": "企业版",
-                        "pages": [
-                          "zh/enterprise",
-                          "zh/features/ip-restrictions",
-                          "zh/features/key-restrictions",
-                          "zh/features/threat-protection",
-                          "zh/features/siem"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "group": "Standard 功能",
-                    "pages": [
-                      {
-                        "group": "抓取",
-                        "icon": "markdown",
-                        "pages": [
-                          "zh/features/scrape",
-                          "zh/features/fast-scraping",
-                          "zh/features/batch-scrape",
-                          "zh/features/llm-extract",
-                          "zh/features/change-tracking",
-                          "zh/features/enhanced-mode",
-                          "zh/features/proxies"
-                        ]
-                      },
-                      "zh/features/crawl",
-                      "zh/features/map",
-                      "zh/features/search"
-                    ]
-                  },
-                  {
-                    "group": "Webhooks",
-                    "pages": [
-                      "zh/webhooks/overview",
-                      "zh/webhooks/events",
-                      "zh/webhooks/security",
-                      "zh/webhooks/testing"
-                    ]
-                  },
-                  {
-                    "group": "Dashboard",
-                    "pages": [
-                      "zh/dashboard"
+                      "zh/migrate-to-v2"
                     ]
                   }
                 ],
                 "tab": "文档"
-              },
-              {
-                "groups": [
-                  {
-                    "group": "概览",
-                    "pages": [
-                      "zh/sdks/overview"
-                    ]
-                  },
-                  {
-                    "group": "官方",
-                    "pages": [
-                      "zh/sdks/python",
-                      "zh/sdks/node",
-                      "zh/sdks/go",
-                      "zh/sdks/java",
-                      "zh/sdks/ruby",
-                      "zh/sdks/rust",
-                      "zh/sdks/dotnet",
-                      "zh/sdks/php",
-                      "zh/sdks/elixir"
-                    ]
-                  },
-                  {
-                    "group": "社区",
-                    "pages": []
-                  }
-                ],
-                "tab": "SDK"
               },
               {
                 "href": "https://www.firecrawl.dev/app",


### PR DESCRIPTION
## Problem

`sitemap.xml` carries **996 URLs** (166 per locale × 6) against **225 pages declared per locale** — 59 missing per locale.

The v1 version is `hidden: true`. Mintlify stamps `<meta name="robots" content="noindex">` on every page reachable under a hidden nav node, and noindexed pages are excluded from the sitemap. The v1 nav didn't use v1-specific copies for most of its tree — it **re-listed the same page paths the live v2 nav uses**. The hidden listing wins, so 36 current pages were served `noindex` despite being linked from the visible v2 sidebar:

```
200  introduction     robots=[noindex]
200  features/scrape  robots=[noindex]
200  sdks/python      robots=[noindex]
200  billing          robots=[noindex]
200  quickstart       robots=[]        ← v2-only, correctly indexed
```

Affected: `introduction`, `mcp-server`, `advanced-scraping-guide`, `dashboard`, `enterprise`, `billing`, `rate-limits`, `partner-credits`, all 14 `features/*` (incl. `scrape`, `crawl`, `map`, `search`, `batch-scrape`, `llm-extract`), all 10 `sdks/*`, all 4 `webhooks/*`.

## Fix

Drop the 36 duplicated page entries from the v1 nav in all six language blocks, and prune the groups/tabs left empty (`Standard Features`, `Webhooks`, `Dashboard`, the `SDKs` tab, `Plans and Billing`, `Enterprise`). These were pure duplicates — a v1 reader clicking `features/scrape` was served v2 content anyway.

**Deliberately unchanged**, since the hiding there is intended:
- `hidden: true` on the v1 version and on the v2 `Extract Endpoints` group
- the 21 genuinely-v1 pages (`api-reference/v1-endpoint/*`, `v1/api-reference/introduction`, `migrate-to-v2`), which stay out of the sitemap

## Expected result

| | Before | After |
|---|---|---|
| Pages per locale in sitemap | 166 | 202 |
| Total sitemap URLs | 996 | 1212 |
| Intentionally excluded per locale | 59 | 23 |

## Verification

Checked mechanically against `HEAD:docs.json`:

- ✅ Everything outside `navigation` byte-identical
- ✅ Visible **v2 nav unchanged** in all 6 locales — no entry added, removed, or reordered
- ✅ No page becomes unreachable from the nav entirely
- ✅ `hidden: true` count preserved (12 → 12)
- ✅ JSON round-trips byte-identically at the repo's existing formatting, so the diff is only the removals

## Follow-up (not in this PR)

`migrate-to-v2` is listed **only** in the hidden v1 nav, so it stays `noindex` and out of the sitemap. It's a page people actively search for ("firecrawl v1 to v2 migration"). Adding it to the v2 nav would fix that, but it's a visible-sidebar change — happy to do it here or separately if you want it indexed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)