### PR TITLE
docs(nav): keep live v2 pages indexed under the hidden v1 nav

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -725,6 +725,8 @@
                     ]
                   }
                 ],
+                "hidden": true,
+                "searchable": true,
                 "tab": "Documentation"
               },
               {
@@ -754,6 +756,8 @@
                     "pages": []
                   }
                 ],
+                "hidden": true,
+                "searchable": true,
                 "tab": "SDKs"
               },
               {


### PR DESCRIPTION
## The issue

`sitemap.xml` carries **996 URLs** (166 per locale × 6) against **225 pages declared per locale**.

The v1 version is `hidden: true`, and Mintlify applies `noindex` to every page reachable under a hidden nav node — which also drops it from the sitemap. The v1 nav doesn't use v1-specific copies for most of its tree; it **re-lists the same page paths the live v2 nav uses**. Mintlify resolves indexing per page path, so the hidden v1 listing wins over the visible v2 one.

Result: **36 pages that are live and linked from the visible v2 sidebar are served `noindex`**. Verified against production — all 204 v2 nav pages return 200, exactly 38 carry `noindex`, and those 38 are precisely the ones absent from the sitemap:

```
GET /billing → 200
<meta name="robots" content="noindex"/>
<link rel="canonical" href="https://docs.firecrawl.dev/billing"/>
grep -c 'firecrawl.dev/billing' sitemap.xml → 0
```

`billing.mdx` frontmatter is clean — no `noindex`, no `hidden`. The cause is purely the duplicate listing:

```
"billing" in the en nav:
  docs.json:139   v2 > Documentation > Get Started > Plans and Billing   hidden ancestors: NONE
  docs.json:674   v1 > Documentation > Get Started > Plans and Billing   hidden ancestors: ['v1']
```

Affected: `introduction`, `mcp-server`, `advanced-scraping-guide`, `dashboard`, `enterprise`, `billing`, `rate-limits`, `partner-credits`, all 14 `features/*` (incl. `scrape`, `crawl`, `map`, `search`, `batch-scrape`, `llm-extract`), all 10 `sdks/*`, all 4 `webhooks/*`.

## Fix

Mark the v1 `Documentation` and `SDKs` tabs `hidden` + `searchable`. Per the `docs.json` schema, `searchable` on a hidden tab keeps descendant pages:

> "indexed for search, sitemap, AI assistant, and llms.txt despite being hidden from the rendered navigation. **Has no effect when `hidden` is false.**"

That last sentence is why both flags are added — `hidden` currently sits on the v1 *version* node, and `searchable` isn't valid on a version. The tabs are already hidden in practice via the version, so the added `hidden` changes nothing that renders.

**Purely additive: 4 insertions, 0 deletions.** No page entry is removed, added, or reordered in either version.

```diff
                 ],
+                "hidden": true,
+                "searchable": true,
                 "tab": "Documentation"
               },
...
                 ],
+                "hidden": true,
+                "searchable": true,
                 "tab": "SDKs"
```

### Scoped to `en` only

Per `CLAUDE.md`, localized content is not modified here. The `es` / `fr` / `ja` / `pt-BR` / `zh` navigation blocks are **byte-identical** to `main` — verified mechanically.

The same duplication exists in all six language blocks, so the localized URLs stay `noindex` until this propagates. `gt.config.json` lists `./docs.json` under its translated files, so the locale blocks are generated output and should pick these flags up on the next locadex/GT run. Worth confirming that regeneration carries structural keys like `searchable` through — if it doesn't, the locale blocks will need a follow-up.

## Scope

| | Count |
|---|---|
| Approved pages restored to the sitemap (`en`) | 36 |
| Also restored (see below) | 1 — `migrate-to-v2` |
| Left `noindex` on purpose | 22 |

**`migrate-to-v2` is included.** `searchable` works at container level, and this page sits in the v1 `Get Started` group alongside the approved ones, so it can't be excluded without restructuring the nav. It's live at 200 with the title "Migrating from v1 to v2" — a page people search for — so indexing it is a win, but flagging it since it wasn't on the approved list.

**Deliberately still `noindex`:** the 20 v1-only pages under the v1 `API Reference` tab (`api-reference/v1-endpoint/*`, `v1/api-reference/introduction`), plus `api-reference/endpoint/extract` and `extract-get`, which carry `hidden: true` inside v2 itself.

Nothing becomes newly *reachable* — all 37 already return HTTP 200. `hidden` controls the `noindex` tag, sidebar visibility, and sitemap membership, not whether a URL resolves. The 131 off-nav files (stale `v0/*`, `v1/*`, `v1-welcome`, `features/agent`…) stay out of the sitemap, since this doesn't touch `seo.indexing`.

## Verification

Checked mechanically against `origin/main:docs.json`:

- ✅ Everything outside `navigation` identical
- ✅ **v2 and v1 page lists byte-identical in all 6 locales** — nothing removed, added, or reordered
- ✅ **All 5 localized blocks completely untouched**
- ✅ `hidden` 12 → 14; `searchable` 0 → 2 (both additions in the `en` v1 block)
- ✅ v1 `API Reference` tab untouched — its 20 pages stay `noindex`
- ✅ Flagged tabs match the schema's `{tab, groups, hidden, searchable}` variant
- ✅ JSON round-trips byte-identically at the repo's existing formatting

**Please confirm on the preview deploy** that the 36 no longer serve `noindex`. This is the one thing I couldn't verify locally: whether a tab-level `searchable` is honored when the *version* above it is hidden. If Mintlify ignores it, the fallback is removing the 36 duplicate entries from the v1 nav instead — a change we'd rather avoid, hence trying this first.

Worth raising with Mintlify regardless: default `seo.indexing` is `"navigable"` — "indexes pages that are set in navigation" — and these pages *are* in the visible v2 navigation. A page listed in a visible version arguably shouldn't inherit `noindex` from also being listed in a hidden one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)