### PR TITLE
docs: add /agent feedback bounty CTA

### DIFF
--- a/features/agent.mdx
+++ b/features/agent.mdx
@@ -43,8 +43,10 @@ Whether you need one data point or entire datasets at scale, Firecrawl `/agent` 
 **Think of `/agent` as deep research for data, wherever it is!**
 
 <Info>
-**Research Preview**: Agent is in early access. Expect rough edges. It will get significantly better over time. [Share feedback →](mailto:product@firecrawl.com)
+**Research Preview**: Agent is in early access. Expect rough edges. It will get significantly better over time.
 </Info>
+
+<AgentFeedbackCTA src="docs-agent" />
 
 Agent builds on everything great about `/extract` and takes it further:
 
@@ -54,8 +56,6 @@ Agent builds on everything great about `/extract` and takes it further:
 - **Faster**: Processes multiple sources in parallel for quicker results
 
 <PlaygroundCTA />
-
-<AgentFeedbackCTA src="docs-agent" />
 
 ## Using `/agent`
 

--- a/features/agent.mdx
+++ b/features/agent.mdx
@@ -30,6 +30,7 @@ import AgentWithModelJS from "/snippets/v2/agent/with-model/js.mdx";
 import AgentWithModelCURL from "/snippets/v2/agent/with-model/curl.mdx";
 import PlaygroundCTA from "/snippets/shared/playground-cta-agent.mdx";
 import ChooseDataExtractor from "/snippets/shared/choose-data-extractor/from-agent.mdx";
+import AgentFeedbackCTA from "/snippets/agent-feedback-cta.mdx";
 
 
 **Picking the right tool.** Agent is right when you **don't know the URLs** or need autonomous navigation across the web.
@@ -53,6 +54,8 @@ Agent builds on everything great about `/extract` and takes it further:
 - **Faster**: Processes multiple sources in parallel for quicker results
 
 <PlaygroundCTA />
+
+<AgentFeedbackCTA src="docs-agent" />
 
 ## Using `/agent`
 

--- a/snippets/agent-feedback-cta.mdx
+++ b/snippets/agent-feedback-cta.mdx
@@ -1,0 +1,24 @@
+<div className="firecrawl-cta-box">
+  <div style={{ display: "flex", alignItems: "flex-start", gap: "8px", marginBottom: "8px" }}>
+    <Icon icon="sack-dollar" color="#ff4d00" size={22} />
+    <div className="firecrawl-cta-title" style={{ margin: 0 }}>
+      <span style={{ color: "#ff4d00" }}>Bounty: 5,000 credit reward</span>
+      <span style={{ fontWeight: 400 }}> for solid feedback on /agent</span>
+    </div>
+  </div>
+  <p className="firecrawl-cta-description">
+    To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with our Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human/agent-friendly (just paste the link into your agentic harness!). Never used /agent? Your take still counts.
+  </p>
+  <a
+    href={"https://www.firecrawl.dev/survey/7pjb4?src=" + (props.src || "docs-agent")}
+    className="firecrawl-cta-btn-primary firecrawl-cta-btn-inline"
+  >
+    Start the interview
+  </a>
+  <p
+    className="firecrawl-cta-description"
+    style={{ fontSize: "12px", fontStyle: "italic", margin: "12px 0 0 0" }}
+  >
+    Include your email to be eligible. Interviews are reviewed for quality at the end of each week.
+  </p>
+</div>


### PR DESCRIPTION
Adds the Firecrawl Feedback Assistant bounty CTA to the `/agent` feature page, matching the existing `/interact` and gov-legal placements.

## What
- New snippet `snippets/agent-feedback-cta.mdx` (copied from `interact-feedback-cta.mdx`, retargeted to `/agent`)
- Imported and rendered in `features/agent.mdx` right after the playground CTA

## Link
Points at the `/agent` discovery survey via the standard participant surface: `firecrawl.dev/survey/7pjb4?src=docs-agent`.

## Notes
- `features/agent.mdx` is `noindex`, so this reaches users who navigate to the agent page directly. A marketing-site placement (firecrawl.dev/prometheus) is being added separately.
- English base file only; translations are managed separately per repo CLAUDE.md.
- The survey (slug `7pjb4`) is still a **draft** — the bounty link goes live once the survey is published; merge/deploy after publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)